### PR TITLE
fix: Replace PHP short tags

### DIFF
--- a/acct-active.php
+++ b/acct-active.php
@@ -50,7 +50,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['acctactive.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctactive.php']; ?>
 		<h144>+</h144></a></h2>
 				
                 <div id="helpPage" style="display:none;visibility:visible" >

--- a/acct-all.php
+++ b/acct-all.php
@@ -44,7 +44,7 @@
 
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['acctall.php']?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctall.php']?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/acct-custom-query.php
+++ b/acct-custom-query.php
@@ -58,7 +58,7 @@
 
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['acctcustomquery.php']?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctcustomquery.php']?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/acct-custom.php
+++ b/acct-custom.php
@@ -39,7 +39,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['acctcustom.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctcustom.php']; ?>
 		<h144>+</h144></a></h2>
 				
                 <div id="helpPage" style="display:none;visibility:visible" >

--- a/acct-date.php
+++ b/acct-date.php
@@ -58,7 +58,7 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['acctdate.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctdate.php']; ?>
 		<h144>+</h144></a></h2>
 		<div id="helpPage" style="display:none;visibility:visible" >
 			<?php echo $l['helpPage']['acctdate'] ?>

--- a/acct-hotspot-accounting.php
+++ b/acct-hotspot-accounting.php
@@ -49,7 +49,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['accthotspot.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['accthotspot.php']; ?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/acct-hotspot-compare.php
+++ b/acct-hotspot-compare.php
@@ -48,7 +48,7 @@
 
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['accthotspotcompare.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['accthotspotcompare.php']; ?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/acct-hotspot.php
+++ b/acct-hotspot.php
@@ -39,7 +39,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['accthotspot.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['accthotspot.php']; ?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/acct-ipaddress.php
+++ b/acct-ipaddress.php
@@ -51,7 +51,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?echo $l['Intro']['acctipaddress.php'];?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctipaddress.php'];?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/acct-main.php
+++ b/acct-main.php
@@ -38,7 +38,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['acctmain.php'];?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctmain.php'];?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/acct-maintenance-cleanup.php
+++ b/acct-maintenance-cleanup.php
@@ -103,7 +103,7 @@
 			<label for='enddate' class='form'><?php echo $l['all']['CleanupSessions']?></label>
 			<input name='enddate' type='text' id='enddate' value='<?php echo $enddate ?>' tabindex=100 />
 			<img src="library/js_date/calendar.gif" onclick=
-			"showChooser(this, 'enddate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d h:i:s', true);" >
+			"showChooser(this, 'enddate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d h:i:s', true);" >
 			<br />
 
 			<br/><br/>

--- a/acct-maintenance-delete.php
+++ b/acct-maintenance-delete.php
@@ -125,13 +125,13 @@
 			<label for='startdate' class='form'><?php echo $l['all']['StartingDate']?></label>
 			<input name='startdate' type='text' id='startdate' value='<?php echo $startdate ?>' tabindex=100 />
 			<img src="library/js_date/calendar.gif" onclick=
-			"showChooser(this, 'startdate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d h:i:s', true);" >
+			"showChooser(this, 'startdate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d h:i:s', true);" >
 			<br />
 
 			<label for='enddate' class='form'><?php echo $l['all']['EndingDate']?></label>
 			<input name='enddate' type='text' id='enddate' value='<?php echo $enddate ?>' tabindex=100 />
 			<img src="library/js_date/calendar.gif" onclick=
-			"showChooser(this, 'enddate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d h:i:s', true);" >
+			"showChooser(this, 'enddate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d h:i:s', true);" >
 			<br />
 
 			<br/><br/>

--- a/acct-maintenance.php
+++ b/acct-maintenance.php
@@ -39,7 +39,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['acctmaintenance.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctmaintenance.php']; ?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/acct-nasipaddress.php
+++ b/acct-nasipaddress.php
@@ -52,7 +52,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['acctnasipaddress.php']; ?></a></h2>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctnasipaddress.php']; ?></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
 			<?php echo $l['helpPage']['acctnasipaddress'] ?>

--- a/acct-plans-usage.php
+++ b/acct-plans-usage.php
@@ -64,7 +64,7 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['acctplans.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctplans.php']; ?>
 		<h144>+</h144></a></h2>
 		<div id="helpPage" style="display:none;visibility:visible" >
 			<?php echo $l['helpPage']['acctplans'] ?>

--- a/acct-plans.php
+++ b/acct-plans.php
@@ -38,7 +38,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['acctplans.php'];?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctplans.php'];?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/acct-username.php
+++ b/acct-username.php
@@ -51,7 +51,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['acctusername.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctusername.php']; ?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/bill-history-query.php
+++ b/bill-history-query.php
@@ -58,7 +58,7 @@
 
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['billhistoryquery.php']?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billhistoryquery.php']?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/bill-invoice-edit.php
+++ b/bill-invoice-edit.php
@@ -359,7 +359,7 @@ function removeTableRow(rowCounter) {
 
 		<label for='invoice_date' class='form'><?php echo $l['all']['Date']?></label>		
 		<input value='<?php echo $invoiceDetails['date']?>' id='invoice_date' name='invoice_date'  tabindex=108 />
-		<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'invoice_date', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d H:i:s', true);">
+		<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'invoice_date', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d H:i:s', true);">
 		<br/>
 
 
@@ -376,8 +376,8 @@ function removeTableRow(rowCounter) {
 		<br/>
 		<br/>
 		
-		<input class='button' type='button' value='Download Invoice' onClick="javascript:window.location.href='include/common/notificationsUserInvoice.php?invoice_id=<?= $invoice_id ?>&destination=download'"/>
-		<input class='button' type='button' value='Email Invoice to Customer' onClick="javascript:window.location.href='include/common/notificationsUserInvoice.php?invoice_id=<?= $invoice_id ?>&destination=email'"/>
+		<input class='button' type='button' value='Download Invoice' onClick="javascript:window.location.href='include/common/notificationsUserInvoice.php?invoice_id=<?php echo $invoice_id ?>&destination=download'"/>
+		<input class='button' type='button' value='Email Invoice to Customer' onClick="javascript:window.location.href='include/common/notificationsUserInvoice.php?invoice_id=<?php echo $invoice_id ?>&destination=email'"/>
 	  	              			
 		<br/><br/>
 		

--- a/bill-invoice-new.php
+++ b/bill-invoice-new.php
@@ -328,7 +328,7 @@ function removeTableRow(rowCounter) {
 
 		<label for='invoice_date' class='form'><?php echo $l['all']['Date']?></label>		
 		<input value='' id='invoice_date' name='invoice_date'  tabindex=108 />
-		<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'invoice_date', 'chooserSpan_invoicedate', 1950, <?= date('Y', time());?>, 'Y-m-d H:i:s', true);">
+		<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'invoice_date', 'chooserSpan_invoicedate', 1950, <?php echo date('Y', time());?>, 'Y-m-d H:i:s', true);">
 		<br/>
 
 		<label for='invoice_notes' class='form'><?php echo $l['ContactInfo']['Notes']?></label>

--- a/bill-merchant-transactions.php
+++ b/bill-merchant-transactions.php
@@ -67,7 +67,7 @@
 
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['billpaypaltransactions.php']?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billpaypaltransactions.php']?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/bill-payments-edit.php
+++ b/bill-payments-edit.php
@@ -206,7 +206,7 @@
 
                 <label for='payment_date' class='form'><?php echo $l['all']['PaymentDate']?></label>
                 <input value='<?php echo $payment_date ?>' id='payment_date' name='payment_date'  tabindex=108 />
-                <img src="library/js_date/calendar.gif" onclick="showChooser(this, 'payment_date', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d H:i:s', true);">
+                <img src="library/js_date/calendar.gif" onclick="showChooser(this, 'payment_date', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d H:i:s', true);">
                 <br/>
 
                 <li class='fieldset'>

--- a/bill-payments-new.php
+++ b/bill-payments-new.php
@@ -174,7 +174,7 @@
 
 		<label for='payment_date' class='form'><?php echo $l['all']['PaymentDate']?></label>
    		<input value='<?php echo $payment_date ?>' id='payment_date' name='payment_date'  tabindex=108 />
-   		<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'payment_date', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d H:i:s', true);">
+   		<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'payment_date', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d H:i:s', true);">
 		<br/>
 
    		<li class='fieldset'>

--- a/bill-paypal-transactions.php
+++ b/bill-paypal-transactions.php
@@ -67,7 +67,7 @@
 
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['billpaypaltransactions.php']?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billpaypaltransactions.php']?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/bill-rates-date.php
+++ b/bill-rates-date.php
@@ -63,7 +63,7 @@
 
 	<div id="contentnorightbar">
 
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['billratesdate.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billratesdate.php']; ?>
 		<h144>+</h144></a></h2>
 		<div id="helpPage" style="display:none;visibility:visible" >
 			<?php echo $l['helpPage']['billratesdate'] ?>

--- a/config-logging.php
+++ b/config-logging.php
@@ -125,7 +125,7 @@
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_debugpageslogging' class='form'><? echo $l['all']['LoggingDebugOnPages'] ?></label>
+                <label for='config_debugpageslogging' class='form'><?php echo $l['all']['LoggingDebugOnPages'] ?></label>
 		<select class='form' name="config_debugpageslogging">
 			<option value="<?php echo $configValues['CONFIG_DEBUG_SQL_ONPAGE'] ?>"> <?php echo $configValues['CONFIG_DEBUG_SQL_ONPAGE'] ?> </option>
 			<option value="">  </option>

--- a/daloradius-users/acct-date.php
+++ b/daloradius-users/acct-date.php
@@ -53,7 +53,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['acctdate.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctdate.php']; ?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/daloradius-users/acct-main.php
+++ b/daloradius-users/acct-main.php
@@ -34,7 +34,7 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['acctmain.php'];?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctmain.php'];?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/daloradius-users/bill-invoice-show.php
+++ b/daloradius-users/bill-invoice-show.php
@@ -182,7 +182,7 @@
 		<br/>
 		<br/>
 		
-		<input class='button' type='button' value='Download Invoice' onClick="javascript:window.location.href='include/common/notificationsUserInvoice.php?invoice_id=<?= $invoice_id ?>&destination=download'"/>
+		<input class='button' type='button' value='Download Invoice' onClick="javascript:window.location.href='include/common/notificationsUserInvoice.php?invoice_id=<?php echo $invoice_id ?>&destination=download'"/>
 	  	              			
 		<br/><br/>
 		</li>

--- a/daloradius-users/billing-main.php
+++ b/daloradius-users/billing-main.php
@@ -35,7 +35,7 @@
 
 	<div id="contentnorightbar">
 
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['billmain.php'];?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billmain.php'];?>
 		<h144>+</h144></a></h2>
 	
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/daloradius-users/graph-main.php
+++ b/daloradius-users/graph-main.php
@@ -35,7 +35,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['graphmain.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['graphmain.php']; ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/daloradius-users/graphs-overall_download.php
+++ b/daloradius-users/graphs-overall_download.php
@@ -52,7 +52,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['graphsoveralldownload.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['graphsoveralldownload.php']; ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/daloradius-users/graphs-overall_logins.php
+++ b/daloradius-users/graphs-overall_logins.php
@@ -53,7 +53,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['graphsoveralllogins.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['graphsoveralllogins.php']; ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/daloradius-users/graphs-overall_upload.php
+++ b/daloradius-users/graphs-overall_upload.php
@@ -53,7 +53,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['graphsoverallupload.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['graphsoverallupload.php']; ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/daloradius-users/include/menu/menu-items.php
+++ b/daloradius-users/include/menu/menu-items.php
@@ -8,7 +8,7 @@
 
                                 <h2>
                                 
-                                <? echo $l['all']['copyright1']; ?>
+                                <?php echo $l['all']['copyright1']; ?>
                                 
 				                                </h2>
 

--- a/daloradius-users/login.php
+++ b/daloradius-users/login.php
@@ -62,22 +62,22 @@ body {
 		
 		<h2>
 		
-		<?echo $l['all']['copyright1']; ?>	
+		<?php echo $l['all']['copyright1']; ?>	
 		</h2>
 		<br/>
 		
 		<ul id="subnav">
 		
-		<li><? echo $l['all']['daloRADIUS'] ?></li>
+		<li><?php echo $l['all']['daloRADIUS'] ?></li>
 		
 		</ul>
 	</div>
 	
 	<div id="sidebar">
 	
-	<h2><? echo $l['text']['LoginRequired'] ?></h2>
+	<h2><?php echo $l['text']['LoginRequired'] ?></h2>
 
-	<h3><? echo $l['text']['LoginPlease'] ?></h3>
+	<h3><?php echo $l['text']['LoginPlease'] ?></h3>
 
 		<form name="login" action="dologin.php" class="sidebar" method="post" >
 			<ul class="subnav">

--- a/daloradius-users/menu-billing.php
+++ b/daloradius-users/menu-billing.php
@@ -80,7 +80,7 @@
 			                                tooltipText='<?php echo $l['Tooltip']['Date']; ?> <br/>'
 					value="<?php if (isset($billinvoice_startdate)) echo $billinvoice_startdate;
 									else echo date("Y-m-01"); ?>">
-				<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'startdate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+				<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'startdate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
 				<div id="chooserSpan" class="dateChooser select-free" style="display: none; visibility: hidden; width: 160px;"></div>
 			
 				<input name="enddate" type="text" id="enddate" 
@@ -88,7 +88,7 @@
 			                                tooltipText='<?php echo $l['Tooltip']['Date']; ?> <br/>'
 					value="<?php if (isset($billinvoice_enddate)) echo $billinvoice_enddate;
 									else echo date("Y-m-t"); ?>">
-				<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'enddate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+				<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'enddate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
 				<div id="chooserSpan" class="dateChooser select-free" style="display: none; visibility: hidden; width: 160px;"></div>
 			
 				<br/>

--- a/daloradius-users/pref-main.php
+++ b/daloradius-users/pref-main.php
@@ -35,7 +35,7 @@
 
 	<div id="contentnorightbar">
 
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['prefmain.php'];?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['prefmain.php'];?>
 		<h144>+</h144></a></h2>
 	
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/gis-editmap.php
+++ b/gis-editmap.php
@@ -61,7 +61,7 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['giseditmap.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['giseditmap.php']; ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
@@ -106,14 +106,14 @@ function load() {
 		}
 
 
-		map.openInfoWindow(map.getCenter(), document.createTextNode("<?echo $l['messages']['gisedit1']; ?>"));
+		map.openInfoWindow(map.getCenter(), document.createTextNode("<?php echo $l['messages']['gisedit1']; ?>"));
 
 		GEvent.addListener(map, "click", function(marker, point) {
 		var geopoint = point;
 		if (marker) {
-			var remove_val=confirm("<? echo $l['messages']['gisedit2']; ?>")
+			var remove_val=confirm("<?php echo $l['messages']['gisedit2']; ?>")
 			if (remove_val==true) {
-			var hotspot_name=prompt("<? echo $l['messages']['gisedit3']; ?>","")
+			var hotspot_name=prompt("<?php echo $l['messages']['gisedit3']; ?>","")
 				if (hotspot_name!=null && hotspot_name!="") {
 					map.removeOverlay(marker);
 					document.editmaps.type.value = "del";
@@ -122,11 +122,11 @@ function load() {
 				}
 			}
 		  } else {
-			var add_val=confirm("<? echo $l['messages']['gisedit4']; ?>" + " Geocode: " + geopoint)
+			var add_val=confirm("<?php echo $l['messages']['gisedit4']; ?>" + " Geocode: " + geopoint)
 			if (add_val==true) {
-				var hotspot_name=prompt("<? echo $l['messages']['gisedit5']; ?>","")
+				var hotspot_name=prompt("<?php echo $l['messages']['gisedit5']; ?>","")
 				if (hotspot_name!=null && hotspot_name!="") {
-					var hotspot_mac=prompt("<? echo $l['messages']['gisedit6'] ; ?>","")
+					var hotspot_mac=prompt("<?php echo $l['messages']['gisedit6'] ; ?>","")
 					if (hotspot_mac!=null && hotspot_mac!="") {
 						map.addOverlay(new GMarker(point));
 						document.editmaps.type.value = "add";

--- a/gis-main.php
+++ b/gis-main.php
@@ -37,7 +37,7 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['gismain.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['gismain.php']; ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/gis-viewmap.php
+++ b/gis-viewmap.php
@@ -21,7 +21,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['gisviewmap.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['gisviewmap.php']; ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
@@ -53,7 +53,7 @@ map.enableContinuousZoom();
 map.setCenter(new GLatLng(0, 0), 1, G_HYBRID_MAP);
 
 map.openInfoWindow(map.getCenter(),
-	document.createTextNode("<? echo $l['messages']['gisviewwelcome']; ?>"));
+	document.createTextNode("<?php echo $l['messages']['gisviewwelcome']; ?>"));
 
 
 

--- a/graph-main.php
+++ b/graph-main.php
@@ -17,7 +17,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['graphmain.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['graphmain.php']; ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/graphs-alltime_logins.php
+++ b/graphs-alltime_logins.php
@@ -30,7 +30,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['graphsalltimelogins.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['graphsalltimelogins.php']; ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/graphs-alltime_traffic_compare.php
+++ b/graphs-alltime_traffic_compare.php
@@ -28,7 +28,7 @@
 
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['graphsalltimetrafficcompare.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['graphsalltimetrafficcompare.php']; ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/graphs-logged_users.php
+++ b/graphs-logged_users.php
@@ -32,7 +32,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['graphsloggedusers.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['graphsloggedusers.php']; ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/graphs-overall_download.php
+++ b/graphs-overall_download.php
@@ -37,7 +37,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['graphsoveralldownload.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['graphsoveralldownload.php']; ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/graphs-overall_logins.php
+++ b/graphs-overall_logins.php
@@ -38,7 +38,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['graphsoveralllogins.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['graphsoveralllogins.php']; ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/graphs-overall_upload.php
+++ b/graphs-overall_upload.php
@@ -38,7 +38,7 @@
 
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['graphsoverallupload.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['graphsoverallupload.php']; ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/include/menu/menu-items.php
+++ b/include/menu/menu-items.php
@@ -8,7 +8,7 @@
 
                                 <h2>
                                 
-                                <? echo $l['all']['copyright1']; ?>
+                                <?php echo $l['all']['copyright1']; ?>
                                 
 				                                </h2>
 

--- a/library/exten-radius_log.php
+++ b/library/exten-radius_log.php
@@ -42,7 +42,7 @@ if (empty($logfile)) {
 	echo "<br/><br/>
 		error reading log file: <br/><br/>
 		looked for log file in '".implode(", ", $logfile_loc)."' but couldn't find it.<br/>
-		if you know where your freeradius log file is located, set it's location in " . $_SERVER[SCRIPT_NAME];
+		if you know where your freeradius log file is located, set it's location in " . $_SERVER['SCRIPT_NAME'];
 	exit;
 }
 	

--- a/login.php
+++ b/login.php
@@ -28,13 +28,13 @@
 				
 				<h2>
 				
-				<?echo $l['all']['copyright1']; ?>	
+				<?php echo $l['all']['copyright1']; ?>	
 				</h2>
 				<br/>
 				
 				<ul id="subnav">
 				
-				<li><? echo $l['all']['daloRADIUS'] ?></li>
+				<li><?php echo $l['all']['daloRADIUS'] ?></li>
 				
 				</ul>
 		
@@ -42,9 +42,9 @@
 		
 		<div id="sidebar">
 		
-		<h2><? echo $l['text']['LoginRequired'] ?></h2>
+		<h2><?php echo $l['text']['LoginRequired'] ?></h2>
 				
-		<h3><? echo $l['text']['LoginPlease'] ?></h3>
+		<h3><?php echo $l['text']['LoginPlease'] ?></h3>
 
 				<form name="login" action="dologin.php" class="sidebar" method="post" >
 					<ul class="subnav">

--- a/menu-accounting-custom.php
+++ b/menu-accounting-custom.php
@@ -51,7 +51,7 @@
                                 tooltipText='<?php echo $l['Tooltip']['Date']; ?> <br/>'
 value="<?php if (isset($accounting_custom_startdate)) echo $accounting_custom_startdate;
 						else echo date("Y-m-01"); ?>">
-<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'startdate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'startdate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
 <div id="chooserSpan" class="dateChooser select-free" style="display: none; visibility: hidden; width: 160px;"></div>
 
                                                         <input name="enddate" type="text" id="enddate" 
@@ -59,7 +59,7 @@ value="<?php if (isset($accounting_custom_startdate)) echo $accounting_custom_st
                                 tooltipText='<?php echo $l['Tooltip']['Date']; ?> <br/>'
 value="<?php if (isset($accounting_custom_enddate)) echo $accounting_custom_enddate;
 						else echo date("Y-m-t"); ?>">
-<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'enddate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'enddate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
 <div id="chooserSpan" class="dateChooser select-free" style="display: none; visibility: hidden; width: 160px;"></div>
 
 

--- a/menu-accounting-plans.php
+++ b/menu-accounting-plans.php
@@ -56,7 +56,7 @@
 			else echo date("Y-m-01"); ?>">
 			
 			<img src="library/js_date/calendar.gif" 
-				onclick="showChooser(this, 'startdate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+				onclick="showChooser(this, 'startdate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
 			<div id="chooserSpan" class="dateChooser select-free" 
 				style="display: none; visibility: hidden; 	width: 160px;"></div>
 
@@ -66,7 +66,7 @@
 				value="<?php if (isset($accounting_plan_enddate)){ echo $accounting_plan_enddate;}
 				else { echo date("Y-m-t");} ?>">
 			<img src="library/js_date/calendar.gif" 
-				onclick="showChooser(this, 'enddate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+				onclick="showChooser(this, 'enddate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
 			<div id="chooserSpan" class="dateChooser select-free" 
 				style="display: none; visibility: hidden; width: 160px;"></div>
 

--- a/menu-accounting.php
+++ b/menu-accounting.php
@@ -79,7 +79,7 @@
 			else echo date("Y-m-01"); ?>">
 			
 			<img src="library/js_date/calendar.gif" 
-				onclick="showChooser(this, 'startdate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+				onclick="showChooser(this, 'startdate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
 			<div id="chooserSpan" class="dateChooser select-free" 
 				style="display: none; visibility: hidden; 	width: 160px;"></div>
 
@@ -89,7 +89,7 @@
 				value="<?php if (isset($accounting_date_enddate)){ echo $accounting_date_enddate;}
 				else { echo date("Y-m-t");} ?>">
 			<img src="library/js_date/calendar.gif" 
-				onclick="showChooser(this, 'enddate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+				onclick="showChooser(this, 'enddate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
 			<div id="chooserSpan" class="dateChooser select-free" 
 				style="display: none; visibility: hidden; width: 160px;"></div>
 

--- a/menu-bill-history.php
+++ b/menu-bill-history.php
@@ -47,7 +47,7 @@
                         else echo date("Y-m-01"); ?>">
 
                         <img src="library/js_date/calendar.gif"
-                                onclick="showChooser(this, 'startdate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+                                onclick="showChooser(this, 'startdate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
                         <div id="chooserSpan" class="dateChooser select-free"
                                 style="display: none; visibility: hidden;       width: 160px;"></div>
 
@@ -56,7 +56,7 @@
                                 else echo date("Y-m-t"); ?>">
 
                         <img src="library/js_date/calendar.gif"
-                                onclick="showChooser(this, 'enddate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+                                onclick="showChooser(this, 'enddate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
                         <div id="chooserSpan" class="dateChooser select-free"
                                 style="display: none; visibility: hidden; width: 160px;"></div>
 			<br/><br/>

--- a/menu-bill-invoice.php
+++ b/menu-bill-invoice.php
@@ -84,7 +84,7 @@
 			                                tooltipText='<?php echo $l['Tooltip']['Date']; ?> <br/>'
 					value="<?php if (isset($billinvoice_startdate)) echo $billinvoice_startdate;
 									else echo date("Y-m-01"); ?>">
-				<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'startdate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+				<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'startdate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
 				<div id="chooserSpan" class="dateChooser select-free" style="display: none; visibility: hidden; width: 160px;"></div>
 			
 				<input name="enddate" type="text" id="enddate" 
@@ -92,7 +92,7 @@
 			                                tooltipText='<?php echo $l['Tooltip']['Date']; ?> <br/>'
 					value="<?php if (isset($billinvoice_enddate)) echo $billinvoice_enddate;
 									else echo date("Y-m-t"); ?>">
-				<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'enddate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+				<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'enddate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
 				<div id="chooserSpan" class="dateChooser select-free" style="display: none; visibility: hidden; width: 160px;"></div>
 			
 				<br/>

--- a/menu-bill-merchant.php
+++ b/menu-bill-merchant.php
@@ -47,7 +47,7 @@
                         else echo date("Y-m-01"); ?>">
 
                         <img src="library/js_date/calendar.gif"
-                                onclick="showChooser(this, 'startdate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+                                onclick="showChooser(this, 'startdate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
                         <div id="chooserSpan" class="dateChooser select-free"
                                 style="display: none; visibility: hidden;       width: 160px;"></div>
 
@@ -56,7 +56,7 @@
                                 else echo date("Y-m-t"); ?>">
 
                         <img src="library/js_date/calendar.gif"
-                                onclick="showChooser(this, 'enddate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+                                onclick="showChooser(this, 'enddate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
                         <div id="chooserSpan" class="dateChooser select-free"
                                 style="display: none; visibility: hidden; width: 160px;"></div>
 			<br/><br/>

--- a/menu-bill-paypal.php
+++ b/menu-bill-paypal.php
@@ -47,7 +47,7 @@
                         else echo date("Y-m-01"); ?>">
 
                         <img src="library/js_date/calendar.gif"
-                                onclick="showChooser(this, 'startdate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+                                onclick="showChooser(this, 'startdate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
                         <div id="chooserSpan" class="dateChooser select-free"
                                 style="display: none; visibility: hidden;       width: 160px;"></div>
 
@@ -56,7 +56,7 @@
                                 else date("Y-m-t"); ?>">
 
                         <img src="library/js_date/calendar.gif"
-                                onclick="showChooser(this, 'enddate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+                                onclick="showChooser(this, 'enddate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
                         <div id="chooserSpan" class="dateChooser select-free"
                                 style="display: none; visibility: hidden; width: 160px;"></div>
 			<br/><br/>

--- a/menu-bill-rates.php
+++ b/menu-bill-rates.php
@@ -59,7 +59,7 @@
                         else echo date("Y-m-01"); ?>">
 
                         <img src="library/js_date/calendar.gif"
-                                onclick="showChooser(this, 'startdate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+                                onclick="showChooser(this, 'startdate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
                         <div id="chooserSpan" class="dateChooser select-free"
                                 style="display: none; visibility: hidden;       width: 160px;"></div>
 
@@ -70,7 +70,7 @@
                                 else echo date("Y-m-t"); ?>">
 
                         <img src="library/js_date/calendar.gif"
-                                onclick="showChooser(this, 'enddate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+                                onclick="showChooser(this, 'enddate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
                         <div id="chooserSpan" class="dateChooser select-free"
                                 style="display: none; visibility: hidden; width: 160px;"></div>
 

--- a/menu-billing.php
+++ b/menu-billing.php
@@ -62,11 +62,11 @@
 
 						<br/>Filter by date
 							<input name="startdate" type="text" id="startdate" value="2006-01-01">
-<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'startdate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'startdate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
 <div id="chooserSpan" class="dateChooser select-free" style="display: none; visibility: hidden; width: 160px;"></div>
 
 							<input name="enddate" type="text" id="enddate" value="2006-12-01">
-<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'enddate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'enddate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
 <div id="chooserSpan" class="dateChooser select-free" style="display: none; visibility: hidden; width: 160px;"></div>
 
 
@@ -100,10 +100,10 @@
 
 						<br/>Filter by date
 							<input name="ps-startdate" type="text" id="ps-startdate" value="2006-01-01">
-<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'ps-startdate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'ps-startdate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
 <div id="chooserSpan" class="dateChooser select-free" style="display: none; visibility: hidden; width: 160px;"></div>
 							<input name="ps-enddate" type="text" id="ps-enddate" value="2006-12-01">
-<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'ps-enddate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'ps-enddate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
 <div id="chooserSpan" class="dateChooser select-free" style="display: none; visibility: hidden; width: 160px;"></div>
 
 							</form></li>

--- a/menu-reports.php
+++ b/menu-reports.php
@@ -66,7 +66,7 @@ include_once ("lang/main.php");
 								</select>
 							<h4>Start Date</h4>
 							<img src="library/js_date/calendar.gif" 
-								onclick="showChooser(this, 'startdate_lastconnect', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+								onclick="showChooser(this, 'startdate_lastconnect', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
 							<input name="startdate" type="text" id="startdate_lastconnect" onClick='javascript:__displayTooltip();'
 								tooltipText='<?php echo $l['Tooltip']['Date']; ?>'
 							value="<?php if (isset($startdate)) echo $startdate;
@@ -77,7 +77,7 @@ include_once ("lang/main.php");
 							<h4>End Date</h4>
 
 							<img src="library/js_date/calendar.gif" 
-								onclick="showChooser(this, 'enddate_lastconnect', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+								onclick="showChooser(this, 'enddate_lastconnect', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
 							<input name="enddate" type="text" id="enddate_lastconnect" onClick='javascript:__displayTooltip();'
 								tooltipText='<?php echo $l['Tooltip']['Date']; ?>'
 								value="<?php if (isset($enddate)) echo $enddate;
@@ -98,7 +98,7 @@ include_once ("lang/main.php");
 						<form name="repnewusers" action="rep-newusers.php" method="get" class="sidebar">
 							<h4>Start Date</h4>
 							<img src="library/js_date/calendar.gif" 
-								onclick="showChooser(this, 'startdate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+								onclick="showChooser(this, 'startdate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
 							<input name="startdate" type="text" id="startdate" onClick='javascript:__displayTooltip();'
 								tooltipText='<?php echo $l['Tooltip']['Date']; ?>'
 							value="<?php if (isset($startdate)) echo $startdate;
@@ -108,7 +108,7 @@ include_once ("lang/main.php");
 							</div>
 							<h4>End Date</h4>
 							<img src="library/js_date/calendar.gif" 
-								onclick="showChooser(this, 'enddate', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+								onclick="showChooser(this, 'enddate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
 							<input name="enddate" type="text" id="enddate" onClick='javascript:__displayTooltip();'
 								tooltipText='<?php echo $l['Tooltip']['Date']; ?>'
 								value="<?php if (isset($enddate)) echo $enddate;
@@ -139,7 +139,7 @@ include_once ("lang/main.php");
 			value="<?php if (isset($username)) echo $username; else echo "%"; ?>">
 			<h4>Start Date</h4>
 			<img src="library/js_date/calendar.gif" 
-				onclick="showChooser(this, 'startdate_topuser', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+				onclick="showChooser(this, 'startdate_topuser', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
 			<input name="startdate" type="text" id="startdate_topuser" onClick='javascript:__displayTooltip();'
                      tooltipText='<?php echo $l['Tooltip']['Date']; ?>'
 			value="<?php if (isset($startdate)) echo $startdate;
@@ -150,7 +150,7 @@ include_once ("lang/main.php");
 			
 			<h4>End Date</h4>
 			<img src="library/js_date/calendar.gif" 
-				onclick="showChooser(this, 'enddate_topuser', 'chooserSpan', 1950, <?= date('Y', time());?>, 'Y-m-d', false);">
+				onclick="showChooser(this, 'enddate_topuser', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
 			<input name="enddate" type="text" id="enddate_topuser" onClick='javascript:__displayTooltip();'
                      tooltipText='<?php echo $l['Tooltip']['Date']; ?>'
 			value="<?php if (isset($enddate)) echo $enddate;

--- a/mng-batch-list.php
+++ b/mng-batch-list.php
@@ -70,7 +70,7 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['mngbatchlist.php']; ?>
+		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngbatchlist.php']; ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/mng-edit.php
+++ b/mng-edit.php
@@ -813,7 +813,7 @@ function enableUser() {
 		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
 
 		<div style="float: right; text-align: right;">
-				<a href="<?= $_SESSION['PREV_LIST_PAGE']; ?>">Back to Listing Page</a>
+				<a href="<?php echo $_SESSION['PREV_LIST_PAGE']; ?>">Back to Listing Page</a>
 		</div>
 
 		</li>

--- a/mng-new-quick.php
+++ b/mng-new-quick.php
@@ -418,7 +418,7 @@
 
 		<label for='expiration' class='form'><?php echo $l['all']['Expiration']?></label>		
 		<input value='' id='expiration' name='expiration'  tabindex=108 />
-		<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'expiration', 'chooserSpan', 1950, <?= date('Y', time());?>, 'd M Y', false);">
+		<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'expiration', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'd M Y', false);">
 		<br/>
 
 		<label for='sessiontimeout' class='form'><?php echo $l['all']['SessionTimeout']?></label>

--- a/rep-batch-details.php
+++ b/rep-batch-details.php
@@ -51,7 +51,7 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['repbatchdetails.php']; ?>
+		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['repbatchdetails.php']; ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/rep-batch-list.php
+++ b/rep-batch-list.php
@@ -47,7 +47,7 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['repbatchlist.php']; ?>
+		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['repbatchlist.php']; ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/rep-batch.php
+++ b/rep-batch.php
@@ -37,7 +37,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['repbatch.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['repbatch.php']; ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/rep-hb-dashboard.php
+++ b/rep-hb-dashboard.php
@@ -50,7 +50,7 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['rephbdashboard.php']; ?>
+		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['rephbdashboard.php']; ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/rep-hb.php
+++ b/rep-hb.php
@@ -37,7 +37,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['rephb.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['rephb.php']; ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/rep-history.php
+++ b/rep-history.php
@@ -48,7 +48,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['rephistory.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['rephistory.php']; ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/rep-lastconnect.php
+++ b/rep-lastconnect.php
@@ -48,7 +48,7 @@
 ?>		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['replastconnect.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['replastconnect.php']; ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/rep-logs-boot.php
+++ b/rep-logs-boot.php
@@ -43,7 +43,7 @@
 ?>	
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['replogsboot.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['replogsboot.php']; ?>
                 :: <?php if (isset($bootLineCount)) { echo $bootLineCount . " Lines Count "; } ?>
                    <?php if (isset($bootFilter)) { echo " with filter set to " . $bootFilter; } ?>
 		<h144>+</h144></a></h2>

--- a/rep-logs-daloradius.php
+++ b/rep-logs-daloradius.php
@@ -44,7 +44,7 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['replogsdaloradius.php']; ?>
+		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['replogsdaloradius.php']; ?>
 		:: <?php if (isset($daloradiusLineCount)) { echo $daloradiusLineCount . " Lines Count "; } ?>
 		   <?php if (isset($daloradiusFilter)) { echo " with filter set to " . $daloradiusFilter; } ?>
 		<h144>+</h144></a></h2>

--- a/rep-logs-radius.php
+++ b/rep-logs-radius.php
@@ -46,7 +46,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['replogsradius.php']; ?>
+		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['replogsradius.php']; ?>
                 :: <?php if (isset($radiusLineCount)) { echo $radiusLineCount . " Lines Count "; } ?>
                    <?php if (isset($radiusFilter)) { echo " with radiusFilter set to " . $radiusFilter; } ?>
 		<h144>+</h144></a></h2>

--- a/rep-logs-system.php
+++ b/rep-logs-system.php
@@ -42,7 +42,7 @@
 ?>	
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['replogssystem.php']; ?>
+		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['replogssystem.php']; ?>
                 :: <?php if (isset($systemLineCount)) { echo $systemLineCount . " Lines Count "; } ?>
                    <?php if (isset($systemFilter)) { echo " with filter set to " . $systemFilter; } ?>
 		<h144>+</h144></a></h2>

--- a/rep-logs.php
+++ b/rep-logs.php
@@ -37,7 +37,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['replogs.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['replogs.php']; ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/rep-main.php
+++ b/rep-main.php
@@ -37,7 +37,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['repmain.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['repmain.php']; ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/rep-newusers.php
+++ b/rep-newusers.php
@@ -67,7 +67,7 @@
 
                 <div id="contentnorightbar">
                 
-                                <h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['repnewusers.php']; ?>
+                                <h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['repnewusers.php']; ?>
                                 <h144>+</h144></a></h2>
                                 
                 <div id="helpPage" style="display:none;visibility:visible" >

--- a/rep-online.php
+++ b/rep-online.php
@@ -68,7 +68,7 @@
 
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['reponline.php']; ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['reponline.php']; ?>
 				<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/rep-stat-raid.php
+++ b/rep-stat-raid.php
@@ -79,7 +79,7 @@
 		foreach($mdstat as $mddevice):
 	?>
 
-			<div class="tabbertab" title="<?= $mddevice ?>">
+			<div class="tabbertab" title="<?php echo $mddevice ?>">
 
 				<?php
 					$output = "";

--- a/rep-stat-server.php
+++ b/rep-stat-server.php
@@ -43,7 +43,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['repstatserver.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['repstatserver.php']; ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/rep-stat-services.php
+++ b/rep-stat-services.php
@@ -45,7 +45,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['repstatradius.php']; ?>
+		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['repstatradius.php']; ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >

--- a/rep-status.php
+++ b/rep-status.php
@@ -37,7 +37,7 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><? echo $l['Intro']['repstatus.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['repstatus.php']; ?>
 		<h144>+</h144></a></h2>
 			
 		<div id="helpPage" style="display:none;visibility:visible" >


### PR DESCRIPTION
By default, PHP is configured with short tags disabled. This PR changes all of the short tags used into full PHP tags.
Example `<?` is now `<?php` and `<?=` is now `<?php echo`

- Replace all PHP short tags with full versions
- Fix for "PHP Notice: Use of undefined constant SCRIPT_NAME - assumed 'SCRIPT_NAME' in library/exten-radius_log.php on line 45"