### PR TITLE
fix: Maps Error When Using HTTPS

### DIFF
--- a/gis-main.php
+++ b/gis-main.php
@@ -14,7 +14,7 @@
     function writeGoogleMapsCode($googleMapsCode) {
 		$myfile = "library/googlemaps.php";
 		if ($fh = fopen($myfile, 'w') ) {
-			$strCode = "<script src='http://maps.google.com/maps?file=api&amp;v=2&amp;key=" . $googleMapsCode . 
+			$strCode = "<script src='//maps.google.com/maps?file=api&amp;v=3&amp;key=" . $googleMapsCode . 
 						"' type='text/javascript'></script>";
 			fwrite($fh, $strCode);
 			fclose($fh);

--- a/gis-viewmap.php
+++ b/gis-viewmap.php
@@ -59,8 +59,8 @@ map.openInfoWindow(map.getCenter(),
 
 // Create our "tiny" marker icon
 var iconRed = new GIcon();
-iconRed.image = "http://labs.google.com/ridefinder/images/mm_20_red.png";
-iconRed.shadow = "http://labs.google.com/ridefinder/images/mm_20_shadow.png";
+iconRed.image = "//labs.google.com/ridefinder/images/mm_20_red.png";
+iconRed.shadow = "//labs.google.com/ridefinder/images/mm_20_shadow.png";
 iconRed.iconSize = new GSize(12, 20);
 iconRed.shadowSize = new GSize(22, 20);
 iconRed.iconAnchor = new GPoint(6, 20);
@@ -68,8 +68,8 @@ iconRed.infoWindowAnchor = new GPoint(5, 1);
 
 
 var iconBlue = new GIcon();
-iconBlue.image = "http://labs.google.com/ridefinder/images/mm_20_blue.png";
-iconBlue.shadow = "http://labs.google.com/ridefinder/images/mm_20_shadow.png";
+iconBlue.image = "//labs.google.com/ridefinder/images/mm_20_blue.png";
+iconBlue.shadow = "//labs.google.com/ridefinder/images/mm_20_shadow.png";
 iconBlue.iconSize = new GSize(12, 20);
 iconBlue.shadowSize = new GSize(22, 20);
 iconBlue.iconAnchor = new GPoint(6, 20);

--- a/library/googlemaps.php
+++ b/library/googlemaps.php
@@ -1,2 +1,2 @@
-<script src='http://maps.google.com/maps?file=api&amp;v=2&amp;key=ABQIAAAAvDA1LFHpWKREw2gtHBYMbRSA7TeyclIs2Du2iixdj2Lkq9VI1xRmDifIqWHjs4ZLwlTSuYn5lYba7A'
+<script src='//maps.google.com/maps?file=api&amp;v=3&amp;key=ABQIAAAAvDA1LFHpWKREw2gtHBYMbRSA7TeyclIs2Du2iixdj2Lkq9VI1xRmDifIqWHjs4ZLwlTSuYn5lYba7A'
 			type='text/javascript'></script>


### PR DESCRIPTION
GIS mapping has an error when trying to use the Google Maps API when DaloRADIUS is under HTTPS.
It also has issues with using version 2 of the API, changing this to version 3 seems to work.

- Change script to use a URL without a scheme
- Change images to use URLs without a scheme
- Change Google Maps API to v=3