### PR TITLE
fix: eregi_replace is deprecated in PHP5.3, removed in PHP7

### DIFF
--- a/library/exten-boot_log.php
+++ b/library/exten-boot_log.php
@@ -50,7 +50,7 @@ if (is_readable($logfile) == false) {
                                 if (preg_match("/$bootFilter/i", $line)) {
                                         if ($counter == 0)
                                                 break;
-                                        $ret = eregi_replace("\n", "<br>", $line);
+                                        $ret = preg_replace("/\n/i", "<br>", $line);
                                         echo $ret;
                                         $counter--;
                                 }

--- a/library/exten-daloradius_log.php
+++ b/library/exten-daloradius_log.php
@@ -49,7 +49,7 @@ if (isset($configValues['CONFIG_LOG_FILE'])) {
 					if (preg_match("/$daloradiusFilter/i", $line)) {
 						if ($counter == 0)
 							break;
-						$ret = eregi_replace("\n", "<br>", $line);
+						$ret = preg_replace("/\n/i", "<br>", $line);
 						echo $ret;
 						$counter--;
 					}

--- a/library/exten-radius_log.php
+++ b/library/exten-radius_log.php
@@ -59,7 +59,7 @@ if (is_readable($logfile) == false) {
                                 if (preg_match("/$radiusFilter/i", $line)) {
                                         if ($counter == 0)
                                                 break;
-                                        $ret = eregi_replace("\n", "<br>", $line);
+                                        $ret = preg_replace("/\n/i", "<br>", $line);
                                         echo $ret;
                                         $counter--;
                                 }

--- a/library/exten-syslog_log.php
+++ b/library/exten-syslog_log.php
@@ -50,7 +50,7 @@ if (is_readable($logfile) == false) {
                                 if (preg_match("/$systemFilter/i", $line)) {
                                         if ($counter == 0)
                                                 break;
-                                        $ret = eregi_replace("\n", "<br>", $line);
+                                        $ret = preg_replace("/\n/i", "<br>", $line);
                                         echo $ret;
                                         $counter--;
                                 }


### PR DESCRIPTION
- This function was deprecated in PHP 5.3.0, and removed in PHP 7.0.0.
- http://php.net/manual/en/function.eregi-replace.php
- Replace instances of `eregi_replace` with `preg_replace`

There is another instance where git thinks the entire file changed, I wonder if line endings are changing for some reason.