### PR TITLE
A clearSessionsUsers BUG in mng-del.php

### DIFF
--- a/mng-del.php
+++ b/mng-del.php
@@ -154,7 +154,7 @@
 
 				if (trim($value) != "") {
 
-					list($userSessions,$acctStartTime) = preg_split('\|\|', $value);
+					list($userSessions,$acctStartTime) = preg_split('/\\|\\|/', $value);
 
 					$allUsernames .= $userSessions . ", ";
 


### PR DESCRIPTION
Line 157
which is
list($userSessions,$acctStartTime) = preg_split('\|\|', $value);
should be
list($userSessions,$acctStartTime) = preg_split('/\\|\\|/', $value);