### PR TITLE
Change method of language translation

### DIFF
--- a/acct-active.php
+++ b/acct-active.php
@@ -50,11 +50,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctactive.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','acctactive.php'); ?>
 		<h144>+</h144></a></h2>
 				
                 <div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['acctactive'] ?>
+					<?php echo t('helpPage','acctactive') ?>
 					<br/>
 				</div>
 				<br/>
@@ -113,22 +113,22 @@
 	echo "<thread> <tr>
 		<th scope='col'>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=username&orderType=$orderTypeNextPage\">
-		".$l['all']['Username']."</a>
+		".t('all','Username')."</a>
 		</th>
 		<th scope='col'>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=attribute&orderType=$orderTypeNextPage\">
-		".$l['all']['Attribute']."</a>
+		".t('all','Attribute')."</a>
 		</th>
 		<th scope='col'>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=maxtimeexpiration&orderType=$orderTypeNextPage\">
-		".$l['all']['MaxTimeExpiration']."</a>
+		".t('all','MaxTimeExpiration')."</a>
 		</th>
 		<th scope='col'>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=usedtime&orderType=$orderTypeNextPage\">
-		".$l['all']['UsedTime']."</a>
+		".t('all','UsedTime')."</a>
 		</th>
-		<th scope='col'> ".$l['all']['Status']." </th>
-		<th scope='col'> ".$l['all']['Usage']." </th>
+		<th scope='col'> ".t('all','Status')." </th>
+		<th scope='col'> ".t('all','Usage')." </th>
 		</tr> </thread>";
 	
 	while($row = $res->fetchRow()) {
@@ -153,7 +153,7 @@
                                         javascript:__displayTooltip();'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-edit.php?username=$row[0]\">
-                                                {$l['Tooltip']['UserEdit']}</a>
+                                                {t('Tooltip','UserEdit')}</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerUserInfo\">

--- a/acct-all.php
+++ b/acct-all.php
@@ -44,11 +44,11 @@
 
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctall.php']?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','acctall.php')?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['acctall'] ?>
+			<?php echo t('helpPage','acctall') ?>
 			<br/>
 		</div>
 		<br/>
@@ -111,57 +111,57 @@
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=radacctid&orderType=$orderTypeNextPage\">
-		".$l['all']['ID']."</a>
+		".t('all','ID')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=hotspot&orderType=$orderTypeNextPage\">
-		".$l['all']['HotSpot']."</a>
+		".t('all','HotSpot')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=username&orderType=$orderTypeNextPage\">
-		".$l['all']['Username']."</a>
+		".t('all','Username')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=framedipaddress&orderType=$orderTypeNextPage\">
-		".$l['all']['IPAddress']."</a>
+		".t('all','IPAddress')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=acctstarttime&orderType=$orderTypeNextPage\">
-		".$l['all']['StartTime']."</a>
+		".t('all','StartTime')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=acctstoptime&orderType=$orderTypeNextPage\">
-		".$l['all']['StopTime']."</a>
+		".t('all','StopTime')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=acctsessiontime&orderType=$orderTypeNextPage\">
-		".$l['all']['TotalTime']."</a>
+		".t('all','TotalTime')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=acctinputoctets&orderType=$orderTypeNextPage\">
-		".$l['all']['Upload']." (".$l['all']['Bytes'].")</a>
+		".t('all','Upload')." (".t('all','Bytes').")</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=acctoutputoctets&orderType=$orderTypeNextPage\">
-		".$l['all']['Download']." (".$l['all']['Bytes'].")</a>
+		".t('all','Download')." (".t('all','Bytes').")</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=acctterminatecause&orderType=$orderTypeNextPage\">
-		".$l['all']['Termination']."</a>
+		".t('all','Termination')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=nasipaddress&orderType=$orderTypeNextPage\">
-		".$l['all']['NASIPAddress']."</a>
+		".t('all','NASIPAddress')."</a>
 		</th>
 		</tr> </thread>";
 	
@@ -175,10 +175,10 @@
                                         javascript:__displayTooltip();'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-hs-edit.php?name=$row[1]\">
-						{$l['Tooltip']['HotspotEdit']}</a>
+						{t('Tooltip','HotspotEdit')}</a>
 					&nbsp;
                                         <a class=\"toolTip\" href=\"acct-hotspot-compare.php?\">
-	                                        {$l['all']['Compare']}</a>
+	                                        {t('all','Compare')}</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerHotspotInfo\">
@@ -194,7 +194,7 @@
                                         javascript:__displayTooltip();'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-edit.php?username=$row[2]\">
-	                                        {$l['Tooltip']['UserEdit']}</a>
+	                                        {t('Tooltip','UserEdit')}</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerUserInfo\">

--- a/acct-custom-query.php
+++ b/acct-custom-query.php
@@ -58,11 +58,11 @@
 
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctcustomquery.php']?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','acctcustomquery.php')?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['acctcustomquery'] ?>
+			<?php echo t('helpPage','acctcustomquery') ?>
 			<br/>
 		</div>
 		<br/>
@@ -135,7 +135,7 @@
 	echo "
 					<thead>
 							<tr>
-							<th colspan='25'>".$l['all']['Records']."</th>
+							<th colspan='25'>".t('all','Records')."</th>
 							</tr>
 
                                                         <tr>

--- a/acct-custom.php
+++ b/acct-custom.php
@@ -39,11 +39,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctcustom.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','acctcustom.php'); ?>
 		<h144>+</h144></a></h2>
 				
                 <div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['acctcustom'] ?>
+			<?php echo t('helpPage','acctcustom') ?>
 			<br/>
 		</div>
 		<br/>

--- a/acct-date.php
+++ b/acct-date.php
@@ -58,10 +58,10 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctdate.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','acctdate.php'); ?>
 		<h144>+</h144></a></h2>
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['acctdate'] ?>
+			<?php echo t('helpPage','acctdate') ?>
 			<br/>
 		</div>
 		<br/>
@@ -146,57 +146,57 @@
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&startdate=$startdate&enddate=$enddate&orderBy=radacctid&orderType=$orderTypeNextPage\">
-		".$l['all']['ID']."</a>
+		".t('all','ID')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&startdate=$startdate&enddate=$enddate&orderBy=hotspot&orderType=$orderTypeNextPage\">
-		".$l['all']['HotSpot']."</a>
+		".t('all','HotSpot')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&startdate=$startdate&enddate=$enddate&orderBy=username&orderType=$orderTypeNextPage\">
-		".$l['all']['Username']."</a>
+		".t('all','Username')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&startdate=$startdate&enddate=$enddate&orderBy=framedipaddress&orderType=$orderTypeNextPage\">
-		".$l['all']['IPAddress']."</a>
+		".t('all','IPAddress')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&startdate=$startdate&enddate=$enddate&orderBy=acctstarttime&orderType=$orderTypeNextPage\">
-		".$l['all']['StartTime']."</a>
+		".t('all','StartTime')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&startdate=$startdate&enddate=$enddate&orderBy=acctstoptime&orderType=$orderTypeNextPage\">
-		".$l['all']['StopTime']."</a>
+		".t('all','StopTime')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&startdate=$startdate&enddate=$enddate&orderBy=acctsessiontime&orderType=$orderTypeNextPage\">
-		".$l['all']['TotalTime']."</a>
+		".t('all','TotalTime')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&startdate=$startdate&enddate=$enddate&orderBy=acctinputoctets&orderType=$orderTypeNextPage\">
-		".$l['all']['Upload']." (".$l['all']['Bytes'].")</a>
+		".t('all','Upload')." (".t('all','Bytes').")</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&startdate=$startdate&enddate=$enddate&orderBy=acctoutputoctets&orderType=$orderTypeNextPage\">
-		".$l['all']['Download']." (".$l['all']['Bytes'].")</a>
+		".t('all','Download')." (".t('all','Bytes').")</a>
 		</th>
 		<th scope='col'>
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&startdate=$startdate&enddate=$enddate&orderBy=acctterminatecause&orderType=$orderTypeNextPage\">
-		 ".$l['all']['Termination']."</a>
+		 ".t('all','Termination')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&startdate=$startdate&enddate=$enddate&orderBy=nasipaddress&orderType=$orderTypeNextPage\">
-		".$l['all']['NASIPAddress']."</a>
+		".t('all','NASIPAddress')."</a>
 		</th>
                 </tr> </thread>";
 
@@ -209,10 +209,10 @@
                                         javascript:__displayTooltip();'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-hs-edit.php?name=$row[1]\">
-                                                {$l['Tooltip']['HotspotEdit']}</a>
+                                                {t('Tooltip','HotspotEdit')}</a>
                                         &nbsp;
                                         <a class=\"toolTip\" href=\"acct-hotspot-compare.php?\">
-                                                {$l['all']['Compare']}</a>
+                                                {t('all','Compare')}</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerHotspotInfo\">
@@ -227,7 +227,7 @@
                                         javascript:__displayTooltip();'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-edit.php?username=$row[2]\">
-	                                        {$l['Tooltip']['UserEdit']}</a>
+	                                        {t('Tooltip','UserEdit')}</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerUserInfo\">

--- a/acct-hotspot-accounting.php
+++ b/acct-hotspot-accounting.php
@@ -49,11 +49,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['accthotspot.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','accthotspot.php'); ?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['accthotspotaccounting'] ?>
+			<?php echo t('helpPage','accthotspotaccounting') ?>
 			<br/>
 		</div>
 		<br/>
@@ -124,57 +124,57 @@
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?hotspot=$hotspot&orderBy=radacctid&orderType=$orderTypeNextPage\">
-		".$l['all']['ID']."</a>
+		".t('all','ID')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?hotspot=$hotspot&orderBy=hotspot&orderType=$orderTypeNextPage\">
-		".$l['all']['HotSpot']."</a>
+		".t('all','HotSpot')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?hotspot=$hotspot&orderBy=username&orderType=$orderTypeNextPage\">
-		".$l['all']['Username']."</a>
+		".t('all','Username')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?hotspot=$hotspot&orderBy=framedipaddress&orderType=$orderTypeNextPage\">
-		".$l['all']['IPAddress']."</a>
+		".t('all','IPAddress')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?hotspot=$hotspot&orderBy=acctstarttime&orderType=$orderTypeNextPage\">
-		".$l['all']['StartTime']."</a>
+		".t('all','StartTime')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?hotspot=$hotspot&orderBy=acctstoptime&orderType=$orderTypeNextPage\">
-		".$l['all']['StopTime']."</a>
+		".t('all','StopTime')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?hotspot=$hotspot&orderBy=acctsessiontime&orderType=$orderTypeNextPage\">
-		".$l['all']['TotalTime']."</a>
+		".t('all','TotalTime')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?hotspot=$hotspot&orderBy=acctinputoctets&orderType=$orderTypeNextPage\">
-		".$l['all']['Upload']." (".$l['all']['Bytes'].")</a>
+		".t('all','Upload')." (".t('all','Bytes').")</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?hotspot=$hotspot&orderBy=acctoutputoctets&orderType=$orderTypeNextPage\">
-		".$l['all']['Download']." (".$l['all']['Bytes'].")</a>
+		".t('all','Download')." (".t('all','Bytes').")</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?hotspot=$hotspot&orderBy=acctterminatecause&orderType=$orderTypeNextPage\">
-		".$l['all']['Termination']."</a>
+		".t('all','Termination')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?hotspot=$hotspot&orderBy=nasipaddress&orderType=$orderTypeNextPage\">
-		".$l['all']['NASIPAddress']."</a>
+		".t('all','NASIPAddress')."</a>
 		</th>
 		</tr> </thread>";
 	while($row = $res->fetchRow()) {
@@ -187,7 +187,7 @@
                                         javascript:__displayTooltip();'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-edit.php?username=$row[2]\">
-                                                {$l['Tooltip']['UserEdit']}</a>
+                                                {t('Tooltip','UserEdit')}</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerUserInfo\">

--- a/acct-hotspot-compare.php
+++ b/acct-hotspot-compare.php
@@ -48,11 +48,11 @@
 
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['accthotspotcompare.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','accthotspotcompare.php'); ?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['accthotspotcompare'] ?>
+			<?php echo t('helpPage','accthotspotcompare') ?>
 			<br/>
 		</div>
 		<br/>
@@ -88,7 +88,7 @@
         echo "
                         <thead>
                                 <tr>
-                                <th colspan='10'>".$l['all']['Records']."</th>
+                                <th colspan='10'>".t('all','Records')."</th>
                                 </tr>
                         </thead>
                 ";
@@ -103,27 +103,27 @@
                 <th scope='col'> 
 			<br/>
 			<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=hotspot&orderType=$orderType\">
-			".$l['all']['HotSpot']."</a>
+			".t('all','HotSpot')."</a>
 			</th>
 			<th scope='col'> 
 			<br/>
 			<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=uniqueusers&orderType=$orderType\">
-			".$l['all']['UniqueUsers']."</a>
+			".t('all','UniqueUsers')."</a>
 			</th>
 			<th scope='col'> 
 			<br/>
 			<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=totalhits&orderType=$orderType\">
-			".$l['all']['TotalHits']."</a>
+			".t('all','TotalHits')."</a>
 			</th>
 			<th scope='col'> 
 			<br/>
 			<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=avgsessiontime&orderType=$orderType\">
-			".$l['all']['AverageTime']."</a>
+			".t('all','AverageTime')."</a>
 			</th>
 			<th scope='col'> 
 			<br/>
 			<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=totaltime&orderType=$orderType\">
-			".$l['all']['TotalTime']."</a>
+			".t('all','TotalTime')."</a>
 			</th>
 			<th scope='col'> 
 			<br/>

--- a/acct-hotspot.php
+++ b/acct-hotspot.php
@@ -39,11 +39,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['accthotspot.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','accthotspot.php'); ?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['accthotspot'] ?>
+			<?php echo t('helpPage','accthotspot') ?>
 			<br/>
 		</div>
 		<br/>

--- a/acct-ipaddress.php
+++ b/acct-ipaddress.php
@@ -51,11 +51,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctipaddress.php'];?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','acctipaddress.php');?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['acctipaddress'] ?>
+			<?php echo t('helpPage','acctipaddress') ?>
 			<br/>
 		</div>
 		<br/>
@@ -122,57 +122,57 @@
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?ipaddress=$ipaddress&orderBy=radacctid&orderType=$orderTypeNextPage\">
-		".$l['all']['ID']."</a>
+		".t('all','ID')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?ipaddress=$ipaddress&orderBy=hotspot&orderType=$orderTypeNextPage\">
-		".$l['all']['HotSpot']."</a>
+		".t('all','HotSpot')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?ipaddress=$ipaddress&orderBy=username&orderType=$orderTypeNextPage\">
-		".$l['all']['Username']."</a>
+		".t('all','Username')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?ipaddress=$ipaddress&orderBy=framedipaddress&orderType=$orderTypeNextPage\">
-		".$l['all']['IPAddress']."</a>
+		".t('all','IPAddress')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?ipaddress=$ipaddress&orderBy=acctstarttime&orderType=$orderTypeNextPage\">
-		".$l['all']['StartTime']."</a>
+		".t('all','StartTime')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?ipaddress=$ipaddress&orderBy=acctstoptime&orderType=$orderTypeNextPage\">
-		".$l['all']['StopTime']."</a>
+		".t('all','StopTime')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?ipaddress=$ipaddress&orderBy=acctsessiontime&orderType=$orderTypeNextPage\">
-		".$l['all']['TotalTime']."</a>
+		".t('all','TotalTime')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?ipaddress=$ipaddress&orderBy=acctinputoctets&orderType=$orderTypeNextPage\">
-		".$l['all']['Upload']." (".$l['all']['Bytes'].")</a>
+		".t('all','Upload')." (".t('all','Bytes').")</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?ipaddress=$ipaddress&orderBy=acctoutputoctets&orderType=$orderTypeNextPage\">
-		".$l['all']['Download']." (".$l['all']['Bytes'].")</a>
+		".t('all','Download')." (".t('all','Bytes').")</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?ipaddress=$ipaddress&orderBy=acctterminatecause&orderType=$orderTypeNextPage\">
-		".$l['all']['Termination']."</a>
+		".t('all','Termination')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?ipaddress=$ipaddress&orderBy=nasipaddress&orderType=$orderTypeNextPage\">
-		".$l['all']['NASIPAddress']."</a>
+		".t('all','NASIPAddress')."</a>
 		</th>
                 </tr> </thread>";
 	while($row = $res->fetchRow()) {
@@ -184,10 +184,10 @@
                                         javascript:__displayTooltip();'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-hs-edit.php?name=$row[1]\">
-                                                {$l['Tooltip']['HotspotEdit']}</a>
+                                                {t('Tooltip','HotspotEdit')}</a>
                                         &nbsp;
                                         <a class=\"toolTip\" href=\"acct-hotspot-compare.php?\">
-                                                {$l['all']['Compare']}</a>
+                                                {t('all','Compare')}</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerHotspotInfo\">
@@ -202,7 +202,7 @@
                                         javascript:__displayTooltip();'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-edit.php?username=$row[2]\">
-	                                        {$l['Tooltip']['UserEdit']}</a>
+	                                        {t('Tooltip','UserEdit')}</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerUserInfo\">

--- a/acct-main.php
+++ b/acct-main.php
@@ -38,11 +38,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctmain.php'];?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','acctmain.php');?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['acctmain'] ?>
+			<?php echo t('helpPage','acctmain') ?>
 			<br/>
 		</div>
 		<br/>

--- a/acct-maintenance-cleanup.php
+++ b/acct-maintenance-cleanup.php
@@ -84,11 +84,11 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctmaintenancecleanup.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','acctmaintenancecleanup.php') ?>
 		<h144>+</h144></a></h2>
 		
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['acctmaintenancecleanup'] ?>
+			<?php echo t('helpPage','acctmaintenancecleanup') ?>
 			<br/>
 		</div>
 		<?php
@@ -97,10 +97,10 @@
 		
 		<form action="<?php echo $_SERVER['PHP_SELF']; ?>" method="post">
         <fieldset>
-			<h302> <?php echo $l['title']['CleanupRecords'] ?> </h302>
+			<h302> <?php echo t('title','CleanupRecords') ?> </h302>
 			<br/>
 			
-			<label for='enddate' class='form'><?php echo $l['all']['CleanupSessions']?></label>
+			<label for='enddate' class='form'><?php echo t('all','CleanupSessions')?></label>
 			<input name='enddate' type='text' id='enddate' value='<?php echo $enddate ?>' tabindex=100 />
 			<img src="library/js_date/calendar.gif" onclick=
 			"showChooser(this, 'enddate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d H:i:s', true);" >
@@ -108,7 +108,7 @@
 
 			<br/><br/>
 			<hr><br/>
-			<input type="submit" name="submit" value="<?php echo $l['buttons']['apply'] ?>" tabindex=1000 class='button' />
+			<input type="submit" name="submit" value="<?php echo t('buttons','apply') ?>" tabindex=1000 class='button' />
 	</fieldset>
 
 	<div id="chooserSpan" class="dateChooser select-free" 

--- a/acct-maintenance-delete.php
+++ b/acct-maintenance-delete.php
@@ -101,11 +101,11 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctmaintenancedelete.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','acctmaintenancedelete.php') ?>
 		<h144>+</h144></a></h2>
 		
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['acctmaintenancedelete'] ?>
+			<?php echo t('helpPage','acctmaintenancedelete') ?>
 			<br/>
 		</div>
 		<?php
@@ -115,20 +115,20 @@
 		<form action="<?php echo $_SERVER['PHP_SELF']; ?>" method="post">
         <fieldset>
 
-			<h302> <?php echo $l['title']['DeleteRecords'] ?> </h302>
+			<h302> <?php echo t('title','DeleteRecords') ?> </h302>
 			<br/>
 
-			<label for='username' class='form'><?php echo $l['all']['Username']?></label>
+			<label for='username' class='form'><?php echo t('all','Username')?></label>
 			<input name='username' type='text' id='username' value='<?php echo $username ?>' tabindex=100 />
 			<br />
 
-			<label for='startdate' class='form'><?php echo $l['all']['StartingDate']?></label>
+			<label for='startdate' class='form'><?php echo t('all','StartingDate')?></label>
 			<input name='startdate' type='text' id='startdate' value='<?php echo $startdate ?>' tabindex=100 />
 			<img src="library/js_date/calendar.gif" onclick=
 			"showChooser(this, 'startdate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d H:i:s', true);" >
 			<br />
 
-			<label for='enddate' class='form'><?php echo $l['all']['EndingDate']?></label>
+			<label for='enddate' class='form'><?php echo t('all','EndingDate')?></label>
 			<input name='enddate' type='text' id='enddate' value='<?php echo $enddate ?>' tabindex=100 />
 			<img src="library/js_date/calendar.gif" onclick=
 			"showChooser(this, 'enddate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d H:i:s', true);" >
@@ -136,7 +136,7 @@
 
 			<br/><br/>
 			<hr><br/>
-			<input type="submit" name="submit" value="<?php echo $l['buttons']['apply'] ?>" tabindex=1000 class='button' />
+			<input type="submit" name="submit" value="<?php echo t('buttons','apply') ?>" tabindex=1000 class='button' />
 
 	</fieldset>
 

--- a/acct-maintenance.php
+++ b/acct-maintenance.php
@@ -39,11 +39,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctmaintenance.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','acctmaintenance.php'); ?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['acctmaintenance'] ?>
+			<?php echo t('helpPage','acctmaintenance') ?>
 			<br/>
 		</div>
 		<br/>

--- a/acct-nasipaddress.php
+++ b/acct-nasipaddress.php
@@ -52,10 +52,10 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctnasipaddress.php']; ?></a></h2>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','acctnasipaddress.php'); ?></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['acctnasipaddress'] ?>
+			<?php echo t('helpPage','acctnasipaddress') ?>
 			<br/>
 		</div>
 		<br/>
@@ -126,57 +126,57 @@
 		<th scope='col'>
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?nasipaddress=$nasipaddress&orderBy=radacctid&orderType=$orderTypeNextPage\">
-		".$l['all']['ID']."</a>
+		".t('all','ID')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?nasipaddress=$nasipaddress&orderBy=hotspot&orderType=$orderTypeNextPage\">
-		".$l['all']['HotSpot']."</a>
+		".t('all','HotSpot')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?nasipaddress=$nasipaddress&orderBy=username&orderType=$orderTypeNextPage\">
-		".$l['all']['Username']."</a>
+		".t('all','Username')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?nasipaddress=$nasipaddress&orderBy=framedipaddress&orderType=$orderTypeNextPage\">
-		".$l['all']['IPAddress']."</a>
+		".t('all','IPAddress')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?nasipaddress=$nasipaddress&orderBy=acctstarttime&orderType=$orderTypeNextPage\">
-		".$l['all']['StartTime']."</a>
+		".t('all','StartTime')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?nasipaddress=$nasipaddress&orderBy=acctstoptime&orderType=$orderTypeNextPage\">
-		".$l['all']['StopTime']."</a>
+		".t('all','StopTime')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?nasipaddress=$nasipaddress&orderBy=acctsessiontime&orderType=$orderTypeNextPage\">
-		".$l['all']['TotalTime']."</a>
+		".t('all','TotalTime')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?nasipaddress=$nasipaddress&orderBy=acctinputoctets&orderType=$orderTypeNextPage\">
-		".$l['all']['Upload']." (".$l['all']['Bytes'].")</a>
+		".t('all','Upload')." (".t('all','Bytes').")</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?nasipaddress=$nasipaddress&orderBy=acctoutputoctets&orderType=$orderTypeNextPage\">
-		".$l['all']['Download']." (".$l['all']['Bytes'].")</a>
+		".t('all','Download')." (".t('all','Bytes').")</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?nasipaddress=$nasipaddress&orderBy=acctterminatecause&orderType=$orderTypeNextPage\">
-		".$l['all']['Termination']."</a>
+		".t('all','Termination')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?nasipaddress=$nasipaddress&orderBy=nasipaddress&orderType=$orderTypeNextPage\">
-		".$l['all']['NASIPAddress']."</a>
+		".t('all','NASIPAddress')."</a>
 		</th>
                 </tr> </thread>";
 	while($row = $res->fetchRow()) {
@@ -188,10 +188,10 @@
                                         javascript:__displayTooltip();'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-hs-edit.php?name=$row[1]\">
-                                                {$l['Tooltip']['HotspotEdit']}</a>
+                                                {t('Tooltip','HotspotEdit')}</a>
                                         &nbsp;
                                         <a class=\"toolTip\" href=\"acct-hotspot-compare.php?\">
-                                                {$l['all']['Compare']}</a>
+                                                {t('all','Compare')}</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerHotspotInfo\">
@@ -206,7 +206,7 @@
                                         javascript:__displayTooltip();'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-edit.php?username=$row[2]\">
-	                                        {$l['Tooltip']['UserEdit']}</a>
+	                                        {t('Tooltip','UserEdit')}</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerUserInfo\">

--- a/acct-plans-usage.php
+++ b/acct-plans-usage.php
@@ -64,10 +64,10 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctplans.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','acctplans.php'); ?>
 		<h144>+</h144></a></h2>
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['acctplans'] ?>
+			<?php echo t('helpPage','acctplans') ?>
 			<br/>
 		</div>
 		<br/>
@@ -207,26 +207,26 @@
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&startdate=$startdate&enddate=$enddate&planname=$planname&orderBy=username&orderType=$orderTypeNextPage\">
-		".$l['all']['Username']."</a>
+		".t('all','Username')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&startdate=$startdate&enddate=$enddate&planname=$planname&orderBy=planname&orderType=$orderTypeNextPage\">
-		".$l['all']['PlanName']."</a>
+		".t('all','PlanName')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&startdate=$startdate&enddate=$enddate&planname=$planname&orderBy=sessiontime&orderType=$orderTypeNextPage\">
-		".$l['all']['UsedTime']."</a>
+		".t('all','UsedTime')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&startdate=$startdate&enddate=$enddate&planname=$planname&orderBy=plantimebank&orderType=$orderTypeNextPage\">
-		".$l['all']['TotalTime']."</a>
+		".t('all','TotalTime')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
-		".$l['all']['TotalTraffic']." (".$l['all']['Bytes'].")</a>
+		".t('all','TotalTraffic')." (".t('all','Bytes').")</a>
 		</th>
                 </tr> </thread>";
 
@@ -244,7 +244,7 @@
                                         javascript:__displayTooltip();'
                                 tooltipText='
 								<a class=\"toolTip\" href=\"bill-pos-edit.php?username={$row['username']}\">
-	                                        {$l['Tooltip']['UserEdit']}</a>
+	                                        {t('Tooltip','UserEdit')}</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerUserInfo\">

--- a/acct-plans.php
+++ b/acct-plans.php
@@ -38,11 +38,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctplans.php'];?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','acctplans.php');?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['acctplans'] ?>
+			<?php echo t('helpPage','acctplans') ?>
 			<br/>
 		</div>
 		<br/>

--- a/acct-username.php
+++ b/acct-username.php
@@ -51,11 +51,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctusername.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','acctusername.php'); ?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['acctusername'] ?>
+			<?php echo t('helpPage','acctusername') ?>
 			<br/>
 		</div>
 		<br/>
@@ -156,57 +156,57 @@
 			<th scope='col'> 
 			<br/>
 			<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=radacctid&orderType=$orderTypeNextPage\">
-			".$l['all']['ID']."</a>
+			".t('all','ID')."</a>
 			</th>
 			<th scope='col'> 
 			<br/>
 			<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=hotspot&orderType=$orderTypeNextPage\">
-			".$l['all']['HotSpot']."</a>
+			".t('all','HotSpot')."</a>
 			</th>
 			<th scope='col'> 
 			<br/>
 			<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=username&orderType=$orderTypeNextPage\">
-			".$l['all']['Username']."</a>
+			".t('all','Username')."</a>
 			</th>
 			<th scope='col'> 
 			<br/>
 			<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=framedipaddress&orderType=$orderTypeNextPage\">
-			".$l['all']['IPAddress']."</a>
+			".t('all','IPAddress')."</a>
 			</th>
 			<th scope='col'> 
 			<br/>
 			<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=acctstarttime&orderType=$orderTypeNextPage\">
-			".$l['all']['StartTime']."</a>
+			".t('all','StartTime')."</a>
 			</th>
 			<th scope='col'> 
 			<br/>
 			<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=acctstoptime&orderType=$orderTypeNextPage\">
-			".$l['all']['StopTime']."</a>
+			".t('all','StopTime')."</a>
 			</th>
 			<th scope='col'> 
 			<br/>
 			<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=acctsessiontime&orderType=$orderTypeNextPage\">
-			".$l['all']['TotalTime']."</a>
+			".t('all','TotalTime')."</a>
 			</th>
 			<th scope='col'> 
 			<br/>
 			<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=acctinputoctets&orderType=$orderTypeNextPage\">
-			".$l['all']['Upload']." (".$l['all']['Bytes'].")</a>
+			".t('all','Upload')." (".t('all','Bytes').")</a>
 			</th>
 			<th scope='col'> 
 			<br/>
 			<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=acctoutputoctets&orderType=$orderTypeNextPage\">
-			".$l['all']['Download']." (".$l['all']['Bytes'].")</a>
+			".t('all','Download')." (".t('all','Bytes').")</a>
 			</th>
 			<th scope='col'> 
 			<br/>
 			<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=acctterminatecause&orderType=$orderTypeNextPage\">
-			".$l['all']['Termination']."</a>
+			".t('all','Termination')."</a>
 			</th>
 			<th scope='col'> 
 			<br/>
 			<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=nasipaddress&orderType=$orderTypeNextPage\">
-			".$l['all']['NASIPAddress']."</a>
+			".t('all','NASIPAddress')."</a>
 			</th>
 			</tr> </thread>";
 			
@@ -219,10 +219,10 @@
 										javascript:__displayTooltip();'
 								tooltipText='
 										<a class=\"toolTip\" href=\"mng-hs-edit.php?name=$row[1]\">
-												{$l['Tooltip']['HotspotEdit']}</a>
+												{t('Tooltip','HotspotEdit')}</a>
 										&nbsp;
 										<a class=\"toolTip\" href=\"acct-hotspot-compare.php?\">
-												{$l['all']['Compare']}</a>
+												{t('all','Compare')}</a>
 										<br/><br/>
 
 										<div id=\"divContainerHotspotInfo\">
@@ -237,7 +237,7 @@
 										javascript:__displayTooltip();'
 								tooltipText='
 										<a class=\"toolTip\" href=\"mng-edit.php?username=$row[2]\">
-											{$l['Tooltip']['UserEdit']}</a>
+											{t('Tooltip','UserEdit')}</a>
 										<br/><br/>
 
 										<div id=\"divContainerUserInfo\">

--- a/bill-history-query.php
+++ b/bill-history-query.php
@@ -58,11 +58,11 @@
 
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billhistoryquery.php']?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','billhistoryquery.php')?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['billhistoryquery'] ?>
+			<?php echo t('helpPage','billhistoryquery') ?>
 			<br/>
 		</div>
 		<br/>
@@ -138,7 +138,7 @@
 	echo "
 					<thead>
 							<tr>
-							<th colspan='25'>".$l['all']['Records']."</th>
+							<th colspan='25'>".t('all','Records')."</th>
 							</tr>
 
                                                         <tr>
@@ -161,67 +161,67 @@
 		switch($value) {
 
 		case "id":
-			$title = $l['all']['ID'];
+			$title = t('all','ID');
 			break;
 		case "username":
-			$title = $l['all']['Username'];
+			$title = t('all','Username');
 			break;
 		case "planId":
-			$title = $l['all']['PlanId'];
+			$title = t('all','PlanId');
 			break;
 		case "billAmount":
-			$title = $l['all']['BillAmount'];
+			$title = t('all','BillAmount');
 			break;
 		case "billAction":
-			$title = $l['all']['BillAction'];
+			$title = t('all','BillAction');
 			break;
 		case "billPerformer":
-			$title = $l['all']['BillPerformer'];
+			$title = t('all','BillPerformer');
 			break;
 		case "billReason":
-			$title = $l['all']['BillReason'];
+			$title = t('all','BillReason');
 			break;
 		case "paymentmethod":
-			$title = $l['ContactInfo']['PaymentMethod'];
+			$title = t('ContactInfo','PaymentMethod');
 			break;
 		case "cash":
-			$title = $l['ContactInfo']['Cash'];
+			$title = t('ContactInfo','Cash');
 			break;
 		case "creditcardname":
-			$title = $l['ContactInfo']['CreditCardName'];
+			$title = t('ContactInfo','CreditCardName');
 			break;
 		case "creditcardnumber":
-			$title = $l['ContactInfo']['CreditCardNumber'];
+			$title = t('ContactInfo','CreditCardNumber');
 			break;
 		case "creditcardverification":
-			$title = $l['ContactInfo']['CreditCardVerificationNumber'];
+			$title = t('ContactInfo','CreditCardVerificationNumber');
 			break;
 		case "creditcardtype":
-			$title = $l['ContactInfo']['CreditCardType'];
+			$title = t('ContactInfo','CreditCardType');
 			break;
 		case "creditcardexp":
-			$title = $l['ContactInfo']['CreditCardExpiration'];
+			$title = t('ContactInfo','CreditCardExpiration');
 			break;
 		case "coupon":
-			$title = $l['all']['Coupon'];
+			$title = t('all','Coupon');
 			break;
 		case "discount":
-			$title = $l['all']['Discount'];
+			$title = t('all','Discount');
 			break;
 		case "notes":
-			$title = $l['ContactInfo']['Notes'];
+			$title = t('ContactInfo','Notes');
 			break;
 		case "creationdate":
-			$title = $l['all']['CreationDate'];
+			$title = t('all','CreationDate');
 			break;
 		case "creationby":
-			$title = $l['all']['CreationBy'];
+			$title = t('all','CreationBy');
 			break;
 		case "updatedate":
-			$title = $l['all']['UpdateDate'];
+			$title = t('all','UpdateDate');
 			break;
 		case "updateby":
-			$title = $l['all']['UpdateBy'];
+			$title = t('all','UpdateBy');
 			break;
 		default:
 			$title = $value;

--- a/bill-history.php
+++ b/bill-history.php
@@ -22,7 +22,7 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#"><?php echo $l['Intro']['billhistorymain.php'] ?></a></h2>
+				<h2 id="Intro"><a href="#"><?php echo t('Intro','billhistorymain.php') ?></a></h2>
 
 
 <?php

--- a/bill-invoice-del.php
+++ b/bill-invoice-del.php
@@ -96,11 +96,11 @@
 
 <div id="contentnorightbar">
 
-	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billinvoicedel.php'] ?>
+	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','billinvoicedel.php') ?>
 	:: <?php if (isset($invoice_id)) { echo $invoice_id; } ?><h144>+</h144></a></h2>
 
 	<div id="helpPage" style="display:none;visibility:visible" >
-		<?php echo $l['helpPage']['billinvoicedel'] ?>
+		<?php echo t('helpPage','billinvoicedel') ?>
 		<br/>
 	</div>
 	<?php
@@ -112,17 +112,17 @@
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['InvoiceRemoval'] ?> </h302>
+		<h302> <?php echo t('title','InvoiceRemoval') ?> </h302>
 		<br/>
 
-		<label for='invoice_id' class='form'><?php echo $l['all']['InvoiceID'] ?></label>
+		<label for='invoice_id' class='form'><?php echo t('all','InvoiceID') ?></label>
 		<input name='invoice_id[]' type='text' id='invoice_id' value='<?php echo $invoice_id ?>' tabindex=100 autocomplete="off" />
 		<br/>
 
 		<br/><br/>
 		<hr><br/>
 
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=1000 
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=1000 
 			class='button' />
 
 	</fieldset>

--- a/bill-invoice-edit.php
+++ b/bill-invoice-edit.php
@@ -258,11 +258,11 @@ function removeTableRow(rowCounter) {
 
 <div id="contentnorightbar">
 
-	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billinvoiceedit.php'] ?>
+	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','billinvoiceedit.php') ?>
 	<h144>+</h144></a></h2>
 	
 	<div id="helpPage" style="display:none;visibility:visible" >
-		<?php echo $l['helpPage']['billinvoiceedit'] ?>
+		<?php echo t('helpPage','billinvoiceedit') ?>
 		<br/>
 	</div>
 	<?php
@@ -273,10 +273,10 @@ function removeTableRow(rowCounter) {
 
 <div class="tabber">
 
-	<div class="tabbertab" title="<?php echo $l['title']['Invoice']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','Invoice'); ?>">
 	<fieldset>
 
-		<h302> <?php echo $l['title']['Invoice']; ?> </h302>
+		<h302> <?php echo t('title','Invoice'); ?> </h302>
 
 		<ul>
 
@@ -303,67 +303,67 @@ function removeTableRow(rowCounter) {
 
 
 		<li class='fieldset'>
-		<label for='' class='form'><?php echo $l['all']['TotalBilled']?></label>
+		<label for='' class='form'><?php echo t('all','TotalBilled')?></label>
 		<input class="money" name='' type='text' disabled id='' value='<?php echo $invoiceDetails['totalbilled']?>' tabindex=101 />
 		</li>
 		
 		<li class='fieldset'>
-		<label for='' class='form'><?php echo $l['all']['TotalPayed']?></label>
+		<label for='' class='form'><?php echo t('all','TotalPayed')?></label>
 		<input class="money" name='' type='text' disabled id='' value='<?php echo $invoiceDetails['totalpayed']?>' tabindex=101 />
 		</li>
 		
 		<li class='fieldset'>
-		<label for='' class='form'><?php echo $l['all']['Balance']?></label>
+		<label for='' class='form'><?php echo t('all','Balance')?></label>
 		<input class="money" name='' type='text' disabled id='' value='<?php echo (float) ($invoiceDetails['totalpayed'] - $invoiceDetails['totalbilled'])?>' tabindex=101 />
 		</li>
 
 		<br/>
 
 		<li class='fieldset'>
-		<label for='invoice_status_id' class='form'><?php echo $l['all']['InvoiceStatus']?></label>
+		<label for='invoice_status_id' class='form'><?php echo t('all','InvoiceStatus')?></label>
 		<?php
 		        populate_invoice_status_id($invoiceDetails['status'], "invoice_status_id", "form", "", $invoiceDetails['status_id']);
 		?>
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('invoice_status_id')" />
 		<div id='invoiceStatusTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['invoiceStatusTooltip'] ?>
+			<?php echo t('Tooltip','invoiceStatusTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='invoice_type_id' class='form'><?php echo $l['all']['InvoiceType']?></label>
+		<label for='invoice_type_id' class='form'><?php echo t('all','InvoiceType')?></label>
 		<?php
 		        populate_invoice_type_id($invoiceDetails['type'], "invoice_type_id", "form", "", $invoiceDetails['type_id']);
 		?>
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('invoice_type_id')" />
 		<div id='invoiceTypeTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['invoiceTypeTooltip'] ?>
+			<?php echo t('Tooltip','invoiceTypeTooltip') ?>
 		</div>
 		</li>
 
 
 		<li class='fieldset'>
-		<label for='user_id' class='form'><?php echo $l['all']['UserId'] ?></label>
+		<label for='user_id' class='form'><?php echo t('all','UserId') ?></label>
 		<input name='user_id' type='text' id='user_id' value='<?php echo $invoiceDetails['user_id']?>' tabindex=101 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('user_idTooltip')" /> 
 		
 		<div id='user_idTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['user_idTooltip'] ?>
+			<?php echo t('Tooltip','user_idTooltip') ?>
 		</div>
 		</li>
 
 
 
-		<label for='invoice_date' class='form'><?php echo $l['all']['Date']?></label>		
+		<label for='invoice_date' class='form'><?php echo t('all','Date')?></label>		
 		<input value='<?php echo $invoiceDetails['date']?>' id='invoice_date' name='invoice_date'  tabindex=108 />
 		<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'invoice_date', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d H:i:s', true);">
 		<br/>
 
 
-		<label for='invoice_notes' class='form'><?php echo $l['ContactInfo']['Notes']?></label>
+		<label for='invoice_notes' class='form'><?php echo t('ContactInfo','Notes')?></label>
 		<textarea class='form' name='invoice_notes' ><?php echo $invoiceDetails['notes']?></textarea>
 
 
@@ -383,7 +383,7 @@ function removeTableRow(rowCounter) {
 		<br/><br/>
 		
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' />
 		</li>
 		
 		</ul>
@@ -397,10 +397,10 @@ function removeTableRow(rowCounter) {
 
 
 
-	<div class="tabbertab" title="<?php echo $l['title']['Items']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','Items'); ?>">
 	<fieldset>
 
-		<h302> <?php echo $l['title']['Items']; ?> </h302>
+		<h302> <?php echo t('title','Items'); ?> </h302>
 		<input type='button' name='addItem' value='Add Item'
 			onclick="javascript:addTableRow();" class='button'>
 		<br/>

--- a/bill-invoice-list.php
+++ b/bill-invoice-list.php
@@ -64,11 +64,11 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billinvoicelist.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','billinvoicelist.php') ?>
 				<h144>+</h144></a></h2>
 				
 				<div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['billinvoicelist'] ?>
+					<?php echo t('helpPage','billinvoicelist') ?>
 					<br/>
 				</div>
 				<br/>
@@ -173,36 +173,36 @@
 	echo "<thread> <tr>
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=id&orderType=$orderTypeNextPage\">
-		".$l['all']['Invoice']."</a>
+		".t('all','Invoice')."</a>
 		</th>
 
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=contactperson&orderType=$orderTypeNextPage\">
-		".$l['all']['ClientName']."</a>
+		".t('all','ClientName')."</a>
 		</th>
 
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=date&orderType=$orderTypeNextPage\">
-		".$l['all']['Date']."</a>
+		".t('all','Date')."</a>
 		</th>
 		
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=totalbilled&orderType=$orderTypeNextPage\">
-		".$l['all']['TotalBilled']."</a>
+		".t('all','TotalBilled')."</a>
 		</th>
 		
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=totalpayed&orderType=$orderTypeNextPage\">
-		".$l['all']['TotalPayed']."</a>
+		".t('all','TotalPayed')."</a>
 		</th>
 		
 		<th scope='col'> 
-		".$l['all']['Balance']."
+		".t('all','Balance')."
 		</th>
 		
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=status_id&orderType=$orderTypeNextPage\">
-		".$l['all']['Status']."</a>
+		".t('all','Status')."</a>
 		</th>
 		
 	</tr> </thread>";
@@ -211,7 +211,7 @@
 		
 		echo '<tr>';
 		
-		$content =  '<a class="toolTip" href="bill-invoice-edit.php?invoice_id='.$row['id'].'">'.$l['Tooltip']['InvoiceEdit'].'</a>';
+		$content =  '<a class="toolTip" href="bill-invoice-edit.php?invoice_id='.$row['id'].'">'.t('Tooltip','InvoiceEdit').'</a>';
 		$invoice_id = addToolTipBalloon(array(
 									'content' => $content,
 									'onClick' => '',
@@ -220,7 +220,7 @@
 		
 							));
 
-		$content =  '<a class="toolTip" href="bill-pos-edit.php?username='.urlencode($row['username']).'">'.$l['Tooltip']['UserEdit'].'</a>';
+		$content =  '<a class="toolTip" href="bill-pos-edit.php?username='.urlencode($row['username']).'">'.t('Tooltip','UserEdit').'</a>';
 		$contactperson = addToolTipBalloon(array(
 									'content' => $content,
 									'onClick' => '',

--- a/bill-invoice-new.php
+++ b/bill-invoice-new.php
@@ -255,11 +255,11 @@ function removeTableRow(rowCounter) {
 
 <div id="contentnorightbar">
 
-	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billinvoicenew.php'] ?>
+	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','billinvoicenew.php') ?>
 	<h144>+</h144></a></h2>
 	
 	<div id="helpPage" style="display:none;visibility:visible" >
-		<?php echo $l['helpPage']['billinvoicesnew'] ?>
+		<?php echo t('helpPage','billinvoicesnew') ?>
 		<br/>
 	</div>
 	<?php
@@ -270,11 +270,11 @@ function removeTableRow(rowCounter) {
 
 <div class="tabber">
 
-	<div class="tabbertab" title="<?php echo $l['title']['Invoice']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','Invoice'); ?>">
 		
 	<fieldset>
 
-		<h302> <?php echo $l['title']['Invoice']; ?> </h302>
+		<h302> <?php echo t('title','Invoice'); ?> </h302>
 
 		<ul>
 		
@@ -287,7 +287,7 @@ function removeTableRow(rowCounter) {
 		<br/>
 
 		<li class='fieldset'>
-		<label for='invoice_status_id' class='form'><?php echo $l['all']['InvoiceStatus']?></label>
+		<label for='invoice_status_id' class='form'><?php echo t('all','InvoiceStatus')?></label>
 		<?php
 		        include_once('include/management/populate_selectbox.php');
 		        populate_invoice_status_id("Select Status", "invoice_status_id", 'form', '', 1);
@@ -295,12 +295,12 @@ function removeTableRow(rowCounter) {
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('invoice_status_id')" />
 		<div id='invoiceStatusTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['invoiceStatusTooltip'] ?>
+			<?php echo t('Tooltip','invoiceStatusTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='invoice_type_id' class='form'><?php echo $l['all']['InvoiceType']?></label>
+		<label for='invoice_type_id' class='form'><?php echo t('all','InvoiceType')?></label>
 		<?php
 		        include_once('include/management/populate_selectbox.php');
 		        populate_invoice_type_id("Select Type", "invoice_type_id");
@@ -308,37 +308,37 @@ function removeTableRow(rowCounter) {
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('invoice_type_id')" />
 		<div id='invoiceTypeTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['invoiceTypeTooltip'] ?>
+			<?php echo t('Tooltip','invoiceTypeTooltip') ?>
 		</div>
 		</li>
 
 
 		<li class='fieldset'>
-		<label for='user_id' class='form'><?php echo $l['all']['UserId'] ?></label>
+		<label for='user_id' class='form'><?php echo t('all','UserId') ?></label>
 		<input name='user_id' type='text' id='user_id' value='<?php echo $user_id ?>' tabindex=101 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('user_idTooltip')" /> 
 		
 		<div id='user_idTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['user_idTooltip'] ?>
+			<?php echo t('Tooltip','user_idTooltip') ?>
 		</div>
 		</li>
 
 
 
-		<label for='invoice_date' class='form'><?php echo $l['all']['Date']?></label>		
+		<label for='invoice_date' class='form'><?php echo t('all','Date')?></label>		
 		<input value='' id='invoice_date' name='invoice_date'  tabindex=108 />
 		<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'invoice_date', 'chooserSpan_invoicedate', 1950, <?php echo date('Y', time());?>, 'Y-m-d H:i:s', true);">
 		<br/>
 
-		<label for='invoice_notes' class='form'><?php echo $l['ContactInfo']['Notes']?></label>
+		<label for='invoice_notes' class='form'><?php echo t('ContactInfo','Notes')?></label>
 		<textarea class='form' name='invoice_notes' ></textarea>
 
 
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' />
 		</li>
 		
 		</ul>
@@ -347,10 +347,10 @@ function removeTableRow(rowCounter) {
 	<div id="chooserSpan_invoicedate" class="dateChooser select-free" style="display: none; visibility: hidden; width: 160px;"></div>
 	</div>
 
-	<div class="tabbertab" title="<?php echo $l['title']['Items']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','Items'); ?>">
 	<fieldset>
 
-		<h302> <?php echo $l['title']['Items']; ?> </h302>
+		<h302> <?php echo t('title','Items'); ?> </h302>
 		<input type='button' name='addItem' value='Add Item'
 			onclick="javascript:addTableRow();" class='button'>
 		<br/>

--- a/bill-invoice-report.php
+++ b/bill-invoice-report.php
@@ -68,11 +68,11 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billinvoicereport.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','billinvoicereport.php') ?>
 				<h144>+</h144></a></h2>
 				
 				<div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['billinvoicelist'] ?>
+					<?php echo t('helpPage','billinvoicelist') ?>
 					<br/>
 				</div>
 				<br/>
@@ -173,36 +173,36 @@
 	echo "<thread> <tr>
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=id&orderType=$orderTypeNextPage\">
-		".$l['all']['Invoice']."</a>
+		".t('all','Invoice')."</a>
 		</th>
 
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=contactperson&orderType=$orderTypeNextPage\">
-		".$l['all']['ClientName']."</a>
+		".t('all','ClientName')."</a>
 		</th>
 
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=date&orderType=$orderTypeNextPage\">
-		".$l['all']['Date']."</a>
+		".t('all','Date')."</a>
 		</th>
 		
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=totalbilled&orderType=$orderTypeNextPage\">
-		".$l['all']['TotalBilled']."</a>
+		".t('all','TotalBilled')."</a>
 		</th>
 		
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=totalpayed&orderType=$orderTypeNextPage\">
-		".$l['all']['TotalPayed']."</a>
+		".t('all','TotalPayed')."</a>
 		</th>
 		
 		<th scope='col'> 
-		".$l['all']['Balance']."
+		".t('all','Balance')."
 		</th>
 		
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=status_id&orderType=$orderTypeNextPage\">
-		".$l['all']['Status']."</a>
+		".t('all','Status')."</a>
 		</th>
 		
 	</tr> </thread>";
@@ -211,7 +211,7 @@
 		
 		echo '<tr>';
 		
-		$content =  '<a class="toolTip" href="bill-invoice-edit.php?invoice_id='.$row['id'].'">'.$l['Tooltip']['InvoiceEdit'].'</a>';
+		$content =  '<a class="toolTip" href="bill-invoice-edit.php?invoice_id='.$row['id'].'">'.t('Tooltip','InvoiceEdit').'</a>';
 		$invoice_id = addToolTipBalloon(array(
 									'content' => $content,
 									'onClick' => '',
@@ -220,7 +220,7 @@
 		
 							));
 
-		$content =  '<a class="toolTip" href="bill-pos-edit.php?username='.urlencode($row['username']).'">'.$l['Tooltip']['UserEdit'].'</a>';
+		$content =  '<a class="toolTip" href="bill-pos-edit.php?username='.urlencode($row['username']).'">'.t('Tooltip','UserEdit').'</a>';
 		$contactperson = addToolTipBalloon(array(
 									'content' => $content,
 									'onClick' => '',

--- a/bill-invoice.php
+++ b/bill-invoice.php
@@ -24,7 +24,7 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#"><?php echo $l['Intro']['billinvoice.php'] ?></a></h2>
+				<h2 id="Intro"><a href="#"><?php echo t('Intro','billinvoice.php') ?></a></h2>
 
 
 <?php

--- a/bill-main.php
+++ b/bill-main.php
@@ -22,7 +22,7 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#"><?php echo $l['Intro']['billmain.php'] ?></a></h2>
+				<h2 id="Intro"><a href="#"><?php echo t('Intro','billmain.php') ?></a></h2>
 				
 <?php
 	include('include/config/logging.php');

--- a/bill-merchant-transactions.php
+++ b/bill-merchant-transactions.php
@@ -67,11 +67,11 @@
 
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billpaypaltransactions.php']?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','billpaypaltransactions.php')?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['billpaypaltransactions'] ?>
+			<?php echo t('helpPage','billpaypaltransactions') ?>
 			<br/>
 		</div>
 		<br/>
@@ -161,7 +161,7 @@
 	echo "
 					<thead>
 							<tr>
-							<th colspan='25'>".$l['all']['Records']."</th>
+							<th colspan='25'>".t('all','Records')."</th>
 							</tr>
 
                                                         <tr>
@@ -184,88 +184,88 @@
 		switch($value) {
 
 		case "id":
-			$title = $l['all']['ID'];
+			$title = t('all','ID');
 			break;
 		case "username":
-			$title = $l['all']['Username'];
+			$title = t('all','Username');
 			break;
 		case "password":
-			$title = $l['all']['Password'];
+			$title = t('all','Password');
 			break;
 		case "txnId":
-			$title = $l['all']['TxnId'];
+			$title = t('all','TxnId');
 			break;
 		case "planId":
-			$title = $l['all']['PlanId'];
+			$title = t('all','PlanId');
 			break;
 		case "quantity":
-			$title = $l['all']['Quantity'];
+			$title = t('all','Quantity');
 			break;
 		case "business_email":
-			$title = $l['all']['ReceiverEmail'];
+			$title = t('all','ReceiverEmail');
 			break;
 		case "business_id":
-			$title = $l['all']['Business'];
+			$title = t('all','Business');
 			break;
 		case "payment_tax":
-			$title = $l['all']['Tax'];
+			$title = t('all','Tax');
 			break;
 		case "payment_cost":
-			$title = $l['all']['Cost'];
+			$title = t('all','Cost');
 			break;
 		case "payment_fee":
-			$title = $l['all']['TransactionFee'];
+			$title = t('all','TransactionFee');
 			break;
 		case "payment_total":
-			$title = $l['all']['TotalCost'];
+			$title = t('all','TotalCost');
 			break;
 		case "payment_currency":
-			$title = $l['all']['PaymentCurrency'];
+			$title = t('all','PaymentCurrency');
 			break;
 		case "first_name":
-			$title = $l['all']['FirstName'];
+			$title = t('all','FirstName');
 			break;
 		case "last_name":
-			$title = $l['all']['LastName'];
+			$title = t('all','LastName');
 			break;
 		case "payer_email":
-			$title = $l['all']['PayerEmail'];
+			$title = t('all','PayerEmail');
 			break;
 		case "payer_address_name":
-			$title = $l['all']['AddressRecipient'];
+			$title = t('all','AddressRecipient');
 			break;
 		case "payer_address_street":
-			$title = $l['all']['Street'];
+			$title = t('all','Street');
 			break;
 		case "payer_address_country":
-			$title = $l['all']['Country'];
+			$title = t('all','Country');
 			break;
 		case "payer_address_country_code":
-			$title = $l['all']['CountryCode'];
+			$title = t('all','CountryCode');
 			break;
 		case "payer_address_city":
-			$title = $l['all']['City'];
+			$title = t('all','City');
 			break;
 		case "payer_address_state":
-			$title = $l['all']['State'];
+			$title = t('all','State');
 			break;
 		case "payer_address_zip":
-			$title = $l['all']['Zip'];
+			$title = t('all','Zip');
 			break;
 		case "payment_date":
-			$title = $l['all']['PaymentDate'];
+			$title = t('all','PaymentDate');
 			break;
 		case "payment_status":
-			$title = $l['all']['PaymentStatus'];
+			$title = t('all','PaymentStatus');
 			break;
 		case "payer_status":
-			$title = $l['all']['PayerStatus'];
+			$title = t('all','PayerStatus');
 			break;
 		case "vendor_type":
-			$title = $l['all']['VendorType'];
+			$title = t('all','VendorType');
 			break;
 		case "payment_address_status":
-			$title = $l['all']['PaymentAddressStatus'];
+			$title = t('all','PaymentAddressStatus');
 			break;
 		default:
 			$title = $value;

--- a/bill-merchant.php
+++ b/bill-merchant.php
@@ -24,7 +24,7 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#"><?php echo $l['Intro']['paypalmain.php'] ?></a></h2>
+				<h2 id="Intro"><a href="#"><?php echo t('Intro','paypalmain.php') ?></a></h2>
 
 
 <?php

--- a/bill-payment-types-del.php
+++ b/bill-payment-types-del.php
@@ -92,10 +92,10 @@
 
 <div id="contentnorightbar">
 
-	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['paymenttypesdel.php'] ?>
+	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','paymenttypesdel.php') ?>
 	:: <?php if (isset($paymentname)) { echo $paymentname; } ?><h144>+</h144></a></h2>
 
-	<div id="helpPage" style="display:none;visibility:visible" >		<?php echo $l['helpPage']['paymenttypesdel'] ?>
+	<div id="helpPage" style="display:none;visibility:visible" >		<?php echo t('helpPage','paymenttypesdel') ?>
 		<br/>
 	</div>
 	<?php
@@ -107,17 +107,17 @@
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['PayTypeInfo'] ?> </h302>
+		<h302> <?php echo t('title','PayTypeInfo') ?> </h302>
 		<br/>
 
-		<label for='paymentname' class='form'><?php echo $l['all']['PayTypeName'] ?></label>
+		<label for='paymentname' class='form'><?php echo t('all','PayTypeName') ?></label>
 		<input name='paymentname[]' type='text' id='paymentname' value='<?php echo $paymentname ?>' tabindex=100 />
 		<br/>
 
 		<br/><br/>
 		<hr><br/>
 
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=1000 
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=1000 
 			class='button' />
 
 	</fieldset>

--- a/bill-payment-types-edit.php
+++ b/bill-payment-types-edit.php
@@ -112,11 +112,11 @@
 ?>		
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['paymenttypesedit.php'] ?>
+		<h2 id="Intro" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','paymenttypesedit.php') ?>
 		:: <?php if (isset($paymentname)) { echo $paymentname; } ?><h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['paymenttypesedit'] ?>
+			<?php echo t('helpPage','paymenttypesedit') ?>
 			<br/>
 		</div>
 		<?php
@@ -127,23 +127,23 @@
 
 <div class="tabber">
 
-	<div class="tabbertab" title="<?php echo $l['title']['PayTypeInfo']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','PayTypeInfo'); ?>">
 
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['PayTypeInfo']; ?> </h302>
+		<h302> <?php echo t('title','PayTypeInfo'); ?> </h302>
 		<br/>
 
 		<ul>
 
 			<li class='fieldset'>
-			<label for='paymentname' class='form'><?php echo $l['all']['PayTypeName'] ?></label>
+			<label for='paymentname' class='form'><?php echo t('all','PayTypeName') ?></label>
 			<input disabled name='paymentname' type='text' id='paymentname' value='<?php echo $paymentname ?>' tabindex=100 />
 			</li>
 
 			<li class='fieldset'>
-			<label for='paymentnotes' class='form'><?php echo $l['all']['PayTypeNotes'] ?></label>
+			<label for='paymentnotes' class='form'><?php echo t('all','PayTypeNotes') ?></label>
 
 	                <input class='text' name='paymentnotes' type='text' id='paymentnotes' value='<?php echo $paymentnotes ?>' tabindex=101 />
 
@@ -152,7 +152,7 @@
 			<li class='fieldset'>
 			<br/>
 			<hr><br/>
-			<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000
+			<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000
 				class='button' />
 			</li>
 
@@ -164,7 +164,7 @@
 
 </div>
 
-<div class="tabbertab" title="<?php echo $l['title']['Optional']; ?>">
+<div class="tabbertab" title="<?php echo t('title','Optional'); ?>">
 
 <fieldset>
 
@@ -176,19 +176,19 @@
         <br/>
 
         <br/>
-        <label for='creationdate' class='form'><?php echo $l['all']['CreationDate'] ?></label>
+        <label for='creationdate' class='form'><?php echo t('all','CreationDate') ?></label>
         <input disabled value='<?php if (isset($creationdate)) echo $creationdate ?>' tabindex=313 />
         <br/>
 
-        <label for='creationby' class='form'><?php echo $l['all']['CreationBy'] ?></label>
+        <label for='creationby' class='form'><?php echo t('all','CreationBy') ?></label>
         <input disabled value='<?php if (isset($creationby)) echo $creationby ?>' tabindex=314 />
         <br/>
 
-        <label for='updatedate' class='form'><?php echo $l['all']['UpdateDate'] ?></label>
+        <label for='updatedate' class='form'><?php echo t('all','UpdateDate') ?></label>
         <input disabled value='<?php if (isset($updatedate)) echo $updatedate ?>' tabindex=315 />
         <br/>
 
-        <label for='updateby' class='form'><?php echo $l['all']['UpdateBy'] ?></label>
+        <label for='updateby' class='form'><?php echo t('all','UpdateBy') ?></label>
         <input disabled value='<?php if (isset($updateby)) echo $updateby ?>' tabindex=316 />
         <br/>
 
@@ -196,7 +196,7 @@
         <br/><br/>
         <hr><br/>
 
-        <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000
+        <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000
                 class='button' />
 
 </fieldset>

--- a/bill-payment-types-list.php
+++ b/bill-payment-types-list.php
@@ -59,11 +59,11 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['paymenttypeslist.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','paymenttypeslist.php') ?>
 				<h144>+</h144></a></h2>
 				
 				<div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['paymenttypeslist'] ?>
+					<?php echo t('helpPage','paymenttypeslist') ?>
 					<br/>
 				</div>
 				<br/>
@@ -125,16 +125,16 @@
 	echo "<thread> <tr>
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=id&orderType=$orderTypeNextPage\">
-		".$l['all']['ID']."</a>
+		".t('all','ID')."</a>
 		</th>
 
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=paymentname&orderType=$orderTypeNextPage\">
-		".$l['all']['PayTypeName']."</a>
+		".t('all','PayTypeName')."</a>
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['PayTypeNotes']."
+		".t('all','PayTypeNotes')."
 		</th>
 
 
@@ -146,9 +146,9 @@
                         <td> <a class='tablenovisit' href='javascript:return;'
                                 onclick=\"javascript:__displayTooltip();\"
                                 tooltipText=\"
-                                        <a class='toolTip' href='bill-payment-types-edit.php?paymentname=$row[1]'>".$l['Tooltip']['EditPayType']."</a>
+                                        <a class='toolTip' href='bill-payment-types-edit.php?paymentname=$row[1]'>".t('Tooltip','EditPayType')."</a>
 					<br/>
-                                        <a class='toolTip' href='bill-payment-types-del.php?paymentname=$row[1]'>".$l['Tooltip']['RemovePayType']."</a>
+                                        <a class='toolTip' href='bill-payment-types-del.php?paymentname=$row[1]'>".t('Tooltip','RemovePayType')."</a>
                                         <br/><br/>\"
                               >$row[1]</a>
                         </td>

--- a/bill-payment-types-new.php
+++ b/bill-payment-types-new.php
@@ -101,11 +101,11 @@
 
 <div id="contentnorightbar">
 
-	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['paymenttypesnew.php'] ?>
+	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','paymenttypesnew.php') ?>
 	<h144>+</h144></a></h2>
 	
 	<div id="helpPage" style="display:none;visibility:visible" >
-		<?php echo $l['helpPage']['paymenttypesnew'] ?>
+		<?php echo t('helpPage','paymenttypesnew') ?>
 		<br/>
 	</div>
 	<?php
@@ -116,41 +116,41 @@
 
 <div class="tabber">
 
-	<div class="tabbertab" title="<?php echo $l['title']['PayTypeInfo']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','PayTypeInfo'); ?>">
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['PayTypeInfo']; ?> </h302>
+		<h302> <?php echo t('title','PayTypeInfo'); ?> </h302>
 		<br/>
 
 		<ul>
 
 		<li class='fieldset'>
-		<label for='name' class='form'><?php echo $l['all']['PayTypeName'] ?></label>
+		<label for='name' class='form'><?php echo t('all','PayTypeName') ?></label>
 		<input name='paymentname' type='text' id='paymentname' value='' tabindex=100 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('paymentTypeTooltip')" /> 
 		
 		<div id='paymentTypeTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['paymentTypeTooltip'] ?>
+			<?php echo t('Tooltip','paymentTypeTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='paymentnotes' class='form'><?php echo $l['all']['PayTypeNotes'] ?></label>
+		<label for='paymentnotes' class='form'><?php echo t('all','PayTypeNotes') ?></label>
 		<input name='paymentnotes' type='text' id='paymentnotes' value='' tabindex=101 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('paymentTypeNotesTooltip')" /> 
 		
 		<div id='paymentTypeNotesTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['paymentTypeNotesTooltip'] ?>
+			<?php echo t('Tooltip','paymentTypeNotesTooltip') ?>
 		</div>
 		</li>
 	
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' />
 		</li>
 
 		</ul>
@@ -159,7 +159,7 @@
 	</div>
 
 
-	<div class="tabbertab" title="<?php echo $l['title']['Optional']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','Optional'); ?>">
 
 <fieldset>
 
@@ -171,19 +171,19 @@
         <br/>
 
         <br/>
-        <label for='creationdate' class='form'><?php echo $l['all']['CreationDate'] ?></label>
+        <label for='creationdate' class='form'><?php echo t('all','CreationDate') ?></label>
         <input disabled value='<?php if (isset($creationdate)) echo $creationdate ?>' tabindex=313 />
         <br/>
 
-        <label for='creationby' class='form'><?php echo $l['all']['CreationBy'] ?></label>
+        <label for='creationby' class='form'><?php echo t('all','CreationBy') ?></label>
         <input disabled value='<?php if (isset($creationby)) echo $creationby ?>' tabindex=314 />
         <br/>
 
-        <label for='updatedate' class='form'><?php echo $l['all']['UpdateDate'] ?></label>
+        <label for='updatedate' class='form'><?php echo t('all','UpdateDate') ?></label>
         <input disabled value='<?php if (isset($updatedate)) echo $updatedate ?>' tabindex=315 />
         <br/>
 
-        <label for='updateby' class='form'><?php echo $l['all']['UpdateBy'] ?></label>
+        <label for='updateby' class='form'><?php echo t('all','UpdateBy') ?></label>
         <input disabled value='<?php if (isset($updateby)) echo $updateby ?>' tabindex=316 />
         <br/>
 
@@ -191,7 +191,7 @@
         <br/><br/>
         <hr><br/>
 
-        <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000
+        <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000
                 class='button' />
 
 </fieldset>

--- a/bill-payments-del.php
+++ b/bill-payments-del.php
@@ -92,10 +92,10 @@
 
 <div id="contentnorightbar">
 
-	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['paymentsdel.php'] ?>
+	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','paymentsdel.php') ?>
 	:: <?php if (isset($payment_id)) { echo $payment_id; } ?><h144>+</h144></a></h2>
 
-	<div id="helpPage" style="display:none;visibility:visible" >		<?php echo $l['helpPage']['paymentsdel'] ?>
+	<div id="helpPage" style="display:none;visibility:visible" >		<?php echo t('helpPage','paymentsdel') ?>
 		<br/>
 	</div>
 	<?php
@@ -107,17 +107,17 @@
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['PaymentInfo'] ?> </h302>
+		<h302> <?php echo t('title','PaymentInfo') ?> </h302>
 		<br/>
 
-		<label for='payment_id' class='form'><?php echo $l['all']['PaymentId'] ?></label>
+		<label for='payment_id' class='form'><?php echo t('all','PaymentId') ?></label>
 		<input name='payment_id[]' type='text' id='payment_id' value='<?php echo $payment_id ?>' tabindex=100 />
 		<br/>
 
 		<br/><br/>
 		<hr><br/>
 
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=1000 
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=1000 
 			class='button' />
 
 	</fieldset>

--- a/bill-payments-edit.php
+++ b/bill-payments-edit.php
@@ -150,11 +150,11 @@
 ?>		
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['paymentsedit.php'] ?>
+		<h2 id="Intro" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','paymentsedit.php') ?>
 		:: <?php if (isset($payment_id)) { echo $payment_id; } ?><h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['paymentsedit'] ?>
+			<?php echo t('helpPage','paymentsedit') ?>
 			<br/>
 		</div>
 		<?php
@@ -165,34 +165,34 @@
 
 <div class="tabber">
 
-	<div class="tabbertab" title="<?php echo $l['title']['PaymentInfo']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','PaymentInfo'); ?>">
 
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['PaymentInfo']; ?> </h302>
+		<h302> <?php echo t('title','PaymentInfo'); ?> </h302>
 		<br/>
 
 		<ul>
 
 			<li class='fieldset'>
-			<label for='payment_id' class='form'><?php echo $l['all']['PaymentId'] ?></label>
+			<label for='payment_id' class='form'><?php echo t('all','PaymentId') ?></label>
 			<input disabled name='payment_id' type='text' id='payment_id' value='<?php echo $payment_id ?>' tabindex=100 />
 			</li>
 
                 <li class='fieldset'>
-                <label for='name' class='form'><?php echo $l['all']['PaymentInvoiceID'] ?></label>
+                <label for='name' class='form'><?php echo t('all','PaymentInvoiceID') ?></label>
                 <input name='payment_invoice_id' type='text' id='payment_invoice_id' value='<?php echo $payment_invoice_id ?>' tabindex=102 />
                 <img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('paymentInvoiceTooltip')" />
 
                 <div id='paymentInvoiceTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['paymentInvoiceTooltip'] ?>
+                        <?php echo t('Tooltip','paymentInvoiceTooltip') ?>
                 </div>
                 </li>
 
                 <li class='fieldset'>
-                <label for='payment_amount' class='form'><?php echo $l['all']['PaymentAmount'] ?></label>
+                <label for='payment_amount' class='form'><?php echo t('all','PaymentAmount') ?></label>
                 <input class='integer5len' name='payment_amount' type='text' id='payment_amount' value='<?php echo $payment_amount ?>' tabindex=103 />
                    <img src="images/icons/bullet_arrow_up.png" alt="+" onclick="javascript:changeInteger('payment_amount','increment')" />
                    <img src="images/icons/bullet_arrow_down.png" alt="-" onclick="javascript:changeInteger('payment_amount','decrement')"/>
@@ -200,17 +200,17 @@
 
                 <div id='amountTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['amountTooltip'] ?>
+                        <?php echo t('Tooltip','amountTooltip') ?>
                 </div>
                 </li>
 
-                <label for='payment_date' class='form'><?php echo $l['all']['PaymentDate']?></label>
+                <label for='payment_date' class='form'><?php echo t('all','PaymentDate')?></label>
                 <input value='<?php echo $payment_date ?>' id='payment_date' name='payment_date'  tabindex=108 />
                 <img src="library/js_date/calendar.gif" onclick="showChooser(this, 'payment_date', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d H:i:s', true);">
                 <br/>
 
                 <li class='fieldset'>
-                <label for='payment_type_id' class='form'><?php echo $l['all']['PaymentType']?></label>
+                <label for='payment_type_id' class='form'><?php echo t('all','PaymentType')?></label>
                 <?php
                         include_once('include/management/populate_selectbox.php');
                         populate_payment_type_id("$payment_type_value", "payment_type_id", "form", "", "$payment_type_id");
@@ -218,18 +218,18 @@
                 <img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('paymentTypeIdTooltip')" />
                 <div id='paymentTypeIdTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['paymentTypeIdTooltip'] ?>
+                        <?php echo t('Tooltip','paymentTypeIdTooltip') ?>
                 </div>
                 </li>
 
                 <li class='fieldset'>
-                <label for='payment_notes' class='form'><?php echo $l['all']['PaymentNotes'] ?></label>
+                <label for='payment_notes' class='form'><?php echo t('all','PaymentNotes') ?></label>
                 <textarea name='payment_notes' id='payment_notes'><?php echo $payment_notes ?></textarea>
                 <img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('paymentNotesTooltip')" />
 
                 <div id='paymentNotesTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['paymentNotesTooltip'] ?>
+                        <?php echo t('Tooltip','paymentNotesTooltip') ?>
                 </div>
                 </li>
 
@@ -237,7 +237,7 @@
 			<li class='fieldset'>
 			<br/>
 			<hr><br/>
-			<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000
+			<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000
 				class='button' />
 			</li>
 
@@ -249,7 +249,7 @@
 
 </div>
 
-<div class="tabbertab" title="<?php echo $l['title']['Optional']; ?>">
+<div class="tabbertab" title="<?php echo t('title','Optional'); ?>">
 
 <fieldset>
 
@@ -261,19 +261,19 @@
         <br/>
 
         <br/>
-        <label for='creationdate' class='form'><?php echo $l['all']['CreationDate'] ?></label>
+        <label for='creationdate' class='form'><?php echo t('all','CreationDate') ?></label>
         <input disabled value='<?php if (isset($creationdate)) echo $creationdate ?>' tabindex=313 />
         <br/>
 
-        <label for='creationby' class='form'><?php echo $l['all']['CreationBy'] ?></label>
+        <label for='creationby' class='form'><?php echo t('all','CreationBy') ?></label>
         <input disabled value='<?php if (isset($creationby)) echo $creationby ?>' tabindex=314 />
         <br/>
 
-        <label for='updatedate' class='form'><?php echo $l['all']['UpdateDate'] ?></label>
+        <label for='updatedate' class='form'><?php echo t('all','UpdateDate') ?></label>
         <input disabled value='<?php if (isset($updatedate)) echo $updatedate ?>' tabindex=315 />
         <br/>
 
-        <label for='updateby' class='form'><?php echo $l['all']['UpdateBy'] ?></label>
+        <label for='updateby' class='form'><?php echo t('all','UpdateBy') ?></label>
         <input disabled value='<?php if (isset($updateby)) echo $updateby ?>' tabindex=316 />
         <br/>
 
@@ -281,7 +281,7 @@
         <br/><br/>
         <hr><br/>
 
-        <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000
+        <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000
                 class='button' />
 
 </fieldset>

--- a/bill-payments-list.php
+++ b/bill-payments-list.php
@@ -64,11 +64,11 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['paymentslist.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','paymentslist.php') ?>
 				<h144>+</h144></a></h2>
 				
 				<div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['paymentslist'] ?>
+					<?php echo t('helpPage','paymentslist') ?>
 					<br/>
 				</div>
 				<br/>
@@ -182,28 +182,28 @@
 	echo "<thread> <tr>
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=id&orderType=$orderTypeNextPage\">
-		".$l['all']['ID']."</a>
+		".t('all','ID')."</a>
 		</th>
 
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=invoice_id&orderType=$orderTypeNextPage\">
-		".$l['all']['PaymentInvoiceID']."</a>
+		".t('all','PaymentInvoiceID')."</a>
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['PaymentAmount']."
+		".t('all','PaymentAmount')."
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['PaymentDate']."
+		".t('all','PaymentDate')."
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['PaymentType']."
+		".t('all','PaymentType')."
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['PaymentNotes']."
+		".t('all','PaymentNotes')."
 		</th>
 
 
@@ -215,9 +215,9 @@
                         	<a class='tablenovisit' href='javascript:return;'
                                 onclick=\"javascript:__displayTooltip();\"
                                 tooltipText=\"
-                                        <a class='toolTip' href='bill-payments-edit.php?payment_id=$row[0]'>".$l['Tooltip']['EditPayment']."</a>
+                                        <a class='toolTip' href='bill-payments-edit.php?payment_id=$row[0]'>".t('Tooltip','EditPayment')."</a>
 					<br/><br/>
-                                        <a class='toolTip' href='bill-payments-del.php?payment_id=$row[0]'>".$l['Tooltip']['RemovePayment']."</a>
+                                        <a class='toolTip' href='bill-payments-del.php?payment_id=$row[0]'>".t('Tooltip','RemovePayment')."</a>
                                         <br/><br/>\"
                               >#$row[0]</a>
                         </td>
@@ -226,7 +226,7 @@
                         <td> <a class='tablenovisit' href='javascript:return;'
                                 onclick=\"javascript:__displayTooltip();\"
                                 tooltipText=\"
-                                        <a class='toolTip' href='bill-invoice-edit.php?invoice_id=$row[1]'>".$l['Tooltip']['InvoiceEdit']."</a>
+                                        <a class='toolTip' href='bill-invoice-edit.php?invoice_id=$row[1]'>".t('Tooltip','InvoiceEdit')."</a>
                                         <br/><br/>\"
                               >#$row[1]</a>
                         </td>

--- a/bill-payments-new.php
+++ b/bill-payments-new.php
@@ -124,11 +124,11 @@
 
 <div id="contentnorightbar">
 
-	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['paymentsnew.php'] ?>
+	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','paymentsnew.php') ?>
 	<h144>+</h144></a></h2>
 	
 	<div id="helpPage" style="display:none;visibility:visible" >
-		<?php echo $l['helpPage']['paymentsnew'] ?>
+		<?php echo t('helpPage','paymentsnew') ?>
 		<br/>
 	</div>
 	<?php
@@ -139,28 +139,28 @@
 
 <div class="tabber">
 
-	<div class="tabbertab" title="<?php echo $l['title']['PaymentInfo']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','PaymentInfo'); ?>">
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['PaymentInfo']; ?> </h302>
+		<h302> <?php echo t('title','PaymentInfo'); ?> </h302>
 		<br/>
 
 		<ul>
 
 		<li class='fieldset'>
-		<label for='name' class='form'><?php echo $l['all']['PaymentInvoiceID'] ?></label>
+		<label for='name' class='form'><?php echo t('all','PaymentInvoiceID') ?></label>
 		<input name='payment_invoice_id' type='text' id='payment_invoice_id' value='<?php echo $invoice_id ?>' tabindex=100 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('paymentInvoiceTooltip')" /> 
 		
 		<div id='paymentInvoiceTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['paymentInvoiceTooltip'] ?>
+			<?php echo t('Tooltip','paymentInvoiceTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-   		<label for='payment_amount' class='form'><?php echo $l['all']['PaymentAmount'] ?></label>
+   		<label for='payment_amount' class='form'><?php echo t('all','PaymentAmount') ?></label>
    		<input class='integer5len' name='payment_amount' type='text' id='payment_amount' value='000.00' tabindex=103 />
                    <img src="images/icons/bullet_arrow_up.png" alt="+" onclick="javascript:changeInteger('payment_amount','increment')" />
                    <img src="images/icons/bullet_arrow_down.png" alt="-" onclick="javascript:changeInteger('payment_amount','decrement')"/>
@@ -168,17 +168,17 @@
    
    		<div id='amountTooltip'  style='display:none;visibility:visible' class='ToolTip'>
    			<img src='images/icons/comment.png' alt='Tip' border='0' />
-   			<?php echo $l['Tooltip']['amountTooltip'] ?>
+   			<?php echo t('Tooltip','amountTooltip') ?>
    		</div>
    		</li>
 
-		<label for='payment_date' class='form'><?php echo $l['all']['PaymentDate']?></label>
+		<label for='payment_date' class='form'><?php echo t('all','PaymentDate')?></label>
    		<input value='<?php echo $payment_date ?>' id='payment_date' name='payment_date'  tabindex=108 />
    		<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'payment_date', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d H:i:s', true);">
 		<br/>
 
    		<li class='fieldset'>
-   		<label for='payment_type_id' class='form'><?php echo $l['all']['PaymentType']?></label>
+   		<label for='payment_type_id' class='form'><?php echo t('all','PaymentType')?></label>
    		<?php
    		        include_once('include/management/populate_selectbox.php');
    		        populate_payment_type_id("Select Payment Type", "payment_type_id");
@@ -186,25 +186,25 @@
    		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('paymentTypeIdTooltip')" />
    		<div id='paymentTypeIdTooltip'  style='display:none;visibility:visible' class='ToolTip'>
    			<img src='images/icons/comment.png' alt='Tip' border='0' />
-   			<?php echo $l['Tooltip']['paymentTypeIdTooltip'] ?>
+   			<?php echo t('Tooltip','paymentTypeIdTooltip') ?>
    		</div>
    		</li>
 
 		<li class='fieldset'>
-		<label for='payment_notes' class='form'><?php echo $l['all']['PaymentNotes'] ?></label>
+		<label for='payment_notes' class='form'><?php echo t('all','PaymentNotes') ?></label>
 		<textarea name='payment_notes'  class='form' tabindex=101 ></textarea>
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('paymentNotesTooltip')" /> 
 		
 		<div id='paymentNotesTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['paymentNotesTooltip'] ?>
+			<?php echo t('Tooltip','paymentNotesTooltip') ?>
 		</div>
 		</li>
 	
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' />
 		</li>
 
 		</ul>
@@ -213,7 +213,7 @@
 	</div>
 
 
-	<div class="tabbertab" title="<?php echo $l['title']['Optional']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','Optional'); ?>">
 
 <fieldset>
 
@@ -225,19 +225,19 @@
         <br/>
 
         <br/>
-        <label for='creationdate' class='form'><?php echo $l['all']['CreationDate'] ?></label>
+        <label for='creationdate' class='form'><?php echo t('all','CreationDate') ?></label>
         <input disabled value='<?php if (isset($creationdate)) echo $creationdate ?>' tabindex=313 />
         <br/>
 
-        <label for='creationby' class='form'><?php echo $l['all']['CreationBy'] ?></label>
+        <label for='creationby' class='form'><?php echo t('all','CreationBy') ?></label>
         <input disabled value='<?php if (isset($creationby)) echo $creationby ?>' tabindex=314 />
         <br/>
 
-        <label for='updatedate' class='form'><?php echo $l['all']['UpdateDate'] ?></label>
+        <label for='updatedate' class='form'><?php echo t('all','UpdateDate') ?></label>
         <input disabled value='<?php if (isset($updatedate)) echo $updatedate ?>' tabindex=315 />
         <br/>
 
-        <label for='updateby' class='form'><?php echo $l['all']['UpdateBy'] ?></label>
+        <label for='updateby' class='form'><?php echo t('all','UpdateBy') ?></label>
         <input disabled value='<?php if (isset($updateby)) echo $updateby ?>' tabindex=316 />
         <br/>
 
@@ -245,7 +245,7 @@
         <br/><br/>
         <hr><br/>
 
-        <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000
+        <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000
                 class='button' />
 
 </fieldset>

--- a/bill-payments.php
+++ b/bill-payments.php
@@ -24,7 +24,7 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#"><?php echo $l['Intro']['paymentsmain.php'] ?></a></h2>
+				<h2 id="Intro"><a href="#"><?php echo t('Intro','paymentsmain.php') ?></a></h2>
 
 
 <?php

--- a/bill-paypal-transactions.php
+++ b/bill-paypal-transactions.php
@@ -67,11 +67,11 @@
 
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billpaypaltransactions.php']?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','billpaypaltransactions.php')?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['billpaypaltransactions'] ?>
+			<?php echo t('helpPage','billpaypaltransactions') ?>
 			<br/>
 		</div>
 		<br/>
@@ -161,7 +161,7 @@
 	echo "
 					<thead>
 							<tr>
-							<th colspan='25'>".$l['all']['Records']."</th>
+							<th colspan='25'>".t('all','Records')."</th>
 							</tr>
 
                                                         <tr>
@@ -184,91 +184,91 @@
 		switch($value) {
 
 		case "id":
-			$title = $l['all']['ID'];
+			$title = t('all','ID');
 			break;
 		case "username":
-			$title = $l['all']['Username'];
+			$title = t('all','Username');
 			break;
 		case "password":
-			$title = $l['all']['Password'];
+			$title = t('all','Password');
 			break;
 		case "txnId":
-			$title = $l['all']['TxnId'];
+			$title = t('all','TxnId');
 			break;
 		case "planName":
-			$title = $l['all']['PlanName'];
+			$title = t('all','PlanName');
 			break;
 		case "planId":
-			$title = $l['all']['PlanId'];
+			$title = t('all','PlanId');
 			break;
 		case "quantity":
-			$title = $l['all']['Quantity'];
+			$title = t('all','Quantity');
 			break;
 		case "business_email":
-			$title = $l['all']['ReceiverEmail'];
+			$title = t('all','ReceiverEmail');
 			break;
 		case "business_id":
-			$title = $l['all']['Business'];
+			$title = t('all','Business');
 			break;
 		case "payment_tax":
-			$title = $l['all']['Tax'];
+			$title = t('all','Tax');
 			break;
 		case "payment_cost":
-			$title = $l['all']['Cost'];
+			$title = t('all','Cost');
 			break;
 		case "payment_fee":
-			$title = $l['all']['TransactionFee'];
+			$title = t('all','TransactionFee');
 			break;
 		case "payment_total":
-			$title = $l['all']['TotalCost'];
+			$title = t('all','TotalCost');
 			break;
 		case "payment_currency":
-			$title = $l['all']['PaymentCurrency'];
+			$title = t('all','PaymentCurrency');
 			break;
 		case "first_name":
-			$title = $l['all']['FirstName'];
+			$title = t('all','FirstName');
 			break;
 		case "last_name":
-			$title = $l['all']['LastName'];
+			$title = t('all','LastName');
 			break;
 		case "payer_email":
-			$title = $l['all']['PayerEmail'];
+			$title = t('all','PayerEmail');
 			break;
 		case "payer_address_name":
-			$title = $l['all']['AddressRecipient'];
+			$title = t('all','AddressRecipient');
 			break;
 		case "payer_address_street":
-			$title = $l['all']['Street'];
+			$title = t('all','Street');
 			break;
 		case "payer_address_country":
-			$title = $l['all']['Country'];
+			$title = t('all','Country');
 			break;
 		case "payer_address_country_code":
-			$title = $l['all']['CountryCode'];
+			$title = t('all','CountryCode');
 			break;
 		case "payer_address_city":
-			$title = $l['all']['City'];
+			$title = t('all','City');
 			break;
 		case "payer_address_state":
-			$title = $l['all']['State'];
+			$title = t('all','State');
 			break;
 		case "payer_address_zip":
-			$title = $l['all']['Zip'];
+			$title = t('all','Zip');
 			break;
 		case "payment_date":
-			$title = $l['all']['PaymentDate'];
+			$title = t('all','PaymentDate');
 			break;
 		case "payment_status":
-			$title = $l['all']['PaymentStatus'];
+			$title = t('all','PaymentStatus');
 			break;
 		case "payer_status":
-			$title = $l['all']['PayerStatus'];
+			$title = t('all','PayerStatus');
 			break;
 		case "vendor_type":
-			$title = $l['all']['VendorType'];
+			$title = t('all','VendorType');
 			break;
 		case "payment_address_status":
-			$title = $l['all']['PaymentAddressStatus'];
+			$title = t('all','PaymentAddressStatus');
 			break;
 		default:
 			$title = $value;

--- a/bill-paypal.php
+++ b/bill-paypal.php
@@ -24,7 +24,7 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#"><?php echo $l['Intro']['paypalmain.php'] ?></a></h2>
+				<h2 id="Intro"><a href="#"><?php echo t('Intro','paypalmain.php') ?></a></h2>
 
 
 <?php

--- a/bill-plans-del.php
+++ b/bill-plans-del.php
@@ -96,11 +96,11 @@
 
 <div id="contentnorightbar">
 
-	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billplansdel.php'] ?>
+	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','billplansdel.php') ?>
 	:: <?php if (isset($plans)) { echo $plans; } ?><h144>+</h144></a></h2>
 
 	<div id="helpPage" style="display:none;visibility:visible" >
-		<?php echo $l['helpPage']['billplansdel'] ?>
+		<?php echo t('helpPage','billplansdel') ?>
 		<br/>
 	</div>
 	<?php
@@ -112,17 +112,17 @@
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['PlanRemoval'] ?> </h302>
+		<h302> <?php echo t('title','PlanRemoval') ?> </h302>
 		<br/>
 
-		<label for='planNname' class='form'><?php echo $l['all']['PlanName'] ?></label>
+		<label for='planNname' class='form'><?php echo t('all','PlanName') ?></label>
 		<input name='planName[]' type='text' id='planName' value='<?php echo $plans ?>' tabindex=100 autocomplete="off" />
 		<br/>
 
 		<br/><br/>
 		<hr><br/>
 
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=1000 
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=1000 
 			class='button' />
 
 	</fieldset>

--- a/bill-plans-edit.php
+++ b/bill-plans-edit.php
@@ -224,11 +224,11 @@
 ?>		
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billplansedit.php'] ?>
+		<h2 id="Intro" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','billplansedit.php') ?>
 		:: <?php if (isset($planName)) { echo $planName; } ?><h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['billplansedit'] ?>
+			<?php echo t('helpPage','billplansedit') ?>
 			<br/>
 		</div>
 		<?php
@@ -239,40 +239,40 @@
 
 <div class="tabber">
 
-	<div class="tabbertab" title="<?php echo $l['title']['PlanInfo']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','PlanInfo'); ?>">
 
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['PlanInfo']; ?> </h302>
+		<h302> <?php echo t('title','PlanInfo'); ?> </h302>
 		<br/>
 
 		<ul>
 
                 <li class='fieldset'>
-                <label for='name' class='form'><?php echo $l['all']['PlanName'] ?></label>
+                <label for='name' class='form'><?php echo t('all','PlanName') ?></label>
                 <input name='planName' type='text' id='planName' value='<?php echo $planName ?>' tabindex=100 />
                 <img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planNameTooltip')" />
 
                 <div id='planNameTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['planNameTooltip'] ?>
+                        <?php echo t('Tooltip','planNameTooltip') ?>
                 </div>
                 </li>
 
                 <li class='fieldset'>
-                <label for='planId' class='form'><?php echo $l['all']['PlanId'] ?></label>
+                <label for='planId' class='form'><?php echo t('all','PlanId') ?></label>
                 <input name='planId' type='text' id='planId' value='<?php echo $planId ?>' tabindex=101 />
                 <img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planIdTooltip')" />
 
                 <div id='planIdTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['planIdTooltip'] ?>
+                        <?php echo t('Tooltip','planIdTooltip') ?>
                 </div>
                 </li>
 
                 <li class='fieldset'>
-                <label for='planType' class='form'><?php echo $l['all']['PlanType'] ?></label>
+                <label for='planType' class='form'><?php echo t('all','PlanType') ?></label>
                 <select class='form' tabindex=102 name='planType' >
 			<option value='<?php echo $planType ?>'><?php echo $planType ?></option>
 			<option value=''></option>
@@ -284,14 +284,14 @@
 
                 <div id='planTimeTypeTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['planTimeTypeTooltip'] ?>
+                        <?php echo t('Tooltip','planTimeTypeTooltip') ?>
                 </div>
                 </li>
 
 
 
                 <li class='fieldset'>
-                <label for='planRecurring' class='form'><?php echo $l['all']['PlanRecurring'] ?></label>
+                <label for='planRecurring' class='form'><?php echo t('all','PlanRecurring') ?></label>
                 <select class='form' name='planRecurring' id='planRecurring' tabindex=101>
 			<option value='<?php echo $planRecurring ?>'><?php echo $planRecurring ?></option>
 			<option value=''></option>
@@ -301,12 +301,12 @@
                 <img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planRecurringTooltip')" />
                 <div id='planRecurringTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['planRecurringTooltip'] ?>
+                        <?php echo t('Tooltip','planRecurringTooltip') ?>
                 </div>
                 </li>
 
                 <li class='fieldset'>
-                <label for='planRecurringPeriod' class='form'><?php echo $l['all']['PlanRecurringPeriod'] ?></label>
+                <label for='planRecurringPeriod' class='form'><?php echo t('all','PlanRecurringPeriod') ?></label>
                 <select class='form' name='planRecurringPeriod' id='planRecurringPeriod' tabindex=101 >
 						<option value='<?php echo $planRecurringPeriod ?>'><?php echo $planRecurringPeriod ?></option>
 						<option value=''></option>
@@ -322,13 +322,13 @@
 
                 <div id='planRecurringPeriodTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['planRecurringPeriodTooltip'] ?>
+                        <?php echo t('Tooltip','planRecurringPeriodTooltip') ?>
                 </div>
                 </li>
 
 
                 <li class='fieldset'>
-                <label for='planRecurringBillingSchedule' class='form'><?php echo $l['all']['planRecurringBillingSchedule'] ?></label>
+                <label for='planRecurringBillingSchedule' class='form'><?php echo t('all','planRecurringBillingSchedule') ?></label>
                 <select class='form' name='planRecurringBillingSchedule' id='planRecurringBillingSchedule' tabindex=101 >
 						<option value='<?php echo $planRecurringBillingSchedule ?>'><?php echo $planRecurringBillingSchedule ?></option>
 						<option value=''></option>
@@ -339,7 +339,7 @@
 
                 <div id='planRecurringBillingScheduleToolTip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['planRecurringBillingScheduleTooltip'] ?>
+                        <?php echo t('Tooltip','planRecurringBillingScheduleTooltip') ?>
                 </div>
                 </li>
                 
@@ -347,40 +347,40 @@
 
 
                 <li class='fieldset'>
-                <label for='planCost' class='form'><?php echo $l['all']['PlanCost'] ?></label>
+                <label for='planCost' class='form'><?php echo t('all','PlanCost') ?></label>
                 <input name='planCost' type='text' id='planCost' value='<?php echo $planCost ?>' tabindex=101 />
                 <img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planCostTooltip')" />
 
                 <div id='planCostTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['planCostTooltip'] ?>
+                        <?php echo t('Tooltip','planCostTooltip') ?>
                 </div>
                 </li>
 
                 <li class='fieldset'>
-                <label for='planSetupCost' class='form'><?php echo $l['all']['PlanSetupCost'] ?></label>
+                <label for='planSetupCost' class='form'><?php echo t('all','PlanSetupCost') ?></label>
                 <input name='planSetupCost' type='text' id='planSetupCost' value='<?php echo $planSetupCost ?>' tabindex=101 />
                 <img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planSetupCostTooltip')" />
 
                 <div id='planSetupCostTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['planSetupCostTooltip'] ?>
+                        <?php echo t('Tooltip','planSetupCostTooltip') ?>
                 </div>
                 </li>
 
                 <li class='fieldset'>
-                <label for='planTax' class='form'><?php echo $l['all']['PlanTax'] ?></label>
+                <label for='planTax' class='form'><?php echo t('all','PlanTax') ?></label>
                 <input name='planTax' type='text' id='planTax' value='<?php echo $planTax ?>' tabindex=101 />
                 <img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planTaxTooltip')" />
 
                 <div id='planTaxTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['planTaxTooltip'] ?>
+                        <?php echo t('Tooltip','planTaxTooltip') ?>
                 </div>
                 </li>
 
                 <li class='fieldset'>
-                <label for='planCurrency' class='form'><?php echo $l['all']['PlanCurrency'] ?></label>
+                <label for='planCurrency' class='form'><?php echo t('all','PlanCurrency') ?></label>
                 <select class='form' tabindex=102 name='planCurrency' >
                         <option value='<?php echo $planCurrency ?>'><?php echo $planCurrency ?></option>
                         <option value=''></option>
@@ -408,14 +408,14 @@
 
                 <div id='planCurrencyTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['planCurrencyTooltip'] ?>
+                        <?php echo t('Tooltip','planCurrencyTooltip') ?>
                 </div>
                 </li>
 
 
 
                 <li class='fieldset'>
-                <label for='planActive' class='form'><?php echo $l['all']['PlanActive'] ?></label>
+                <label for='planActive' class='form'><?php echo t('all','PlanActive') ?></label>
                 <select class='form' tabindex=103 name='planActive' >
                         <option value='<?php echo $planActive ?>'><?php echo $planActive ?></option>
                         <option value='yes'>Yes</option>
@@ -425,7 +425,7 @@
 
                 <div id='planCurrencyTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['planActiveTooltip'] ?>
+                        <?php echo t('Tooltip','planActiveTooltip') ?>
                 </div>
                 </li>
 
@@ -435,7 +435,7 @@
 <?php
 /*
                 <li class='fieldset'>
-                <label for='profile' class='form'><?php echo $l['all']['Profile']?></label>
+                <label for='profile' class='form'><?php echo t('all','Profile')?></label>
                 <?php
                         include_once 'include/management/populate_selectbox.php';
                         populate_groups($planGroup,"planGroup");
@@ -444,7 +444,7 @@
 
                 <div id='planGroupTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['planGroupTooltip'] ?>
+                        <?php echo t('Tooltip','planGroupTooltip') ?>
                 </div>
                 </li>
 */
@@ -453,7 +453,7 @@
 			<li class='fieldset'>
 			<br/>
 			<hr><br/>
-			<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000
+			<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000
 				class='button' />
 			</li>
 
@@ -462,16 +462,16 @@
 	</fieldset>
 	</div>
 
-        <div class="tabbertab" title="<?php echo $l['title']['TimeSettings']; ?>">
+        <div class="tabbertab" title="<?php echo t('title','TimeSettings'); ?>">
         <fieldset>
 
-                <h302> <?php echo $l['title']['PlanInfo']; ?> </h302>
+                <h302> <?php echo t('title','PlanInfo'); ?> </h302>
                 <br/>
 
                 <ul>
 
                 <li class='fieldset'>
-                <label for='planTimeType' class='form'><?php echo $l['all']['PlanTimeType'] ?></label>
+                <label for='planTimeType' class='form'><?php echo t('all','PlanTimeType') ?></label>
                 <select class='form' tabindex=102 name='planTimeType' >
 			<option value='<?php echo $planTimeType ?>'><?php echo $planTimeType ?></option>
 			<option value=''></option>
@@ -482,38 +482,38 @@
 
                 <div id='planTimeTypeTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['planTimeTypeTooltip'] ?>
+                        <?php echo t('Tooltip','planTimeTypeTooltip') ?>
                 </div>
                 </li>
 
 
                 <li class='fieldset'>
-                <label for='planTimeBank' class='form'><?php echo $l['all']['PlanTimeBank'] ?></label>
+                <label for='planTimeBank' class='form'><?php echo t('all','PlanTimeBank') ?></label>
                 <input name='planTimeBank' type='text' id='planTimeBank' value='<?php echo $planTimeBank ?>' tabindex=101 />
                 <img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planTimeBankTooltip')" />
 
                 <div id='planTimeBankTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['planTimeBankTooltip'] ?>
+                        <?php echo t('Tooltip','planTimeBankTooltip') ?>
                 </div>
                 </li>
 
 
                 <li class='fieldset'>
-                <label for='planTimeRefillCost' class='form'><?php echo $l['all']['PlanTimeRefillCost'] ?></label>
+                <label for='planTimeRefillCost' class='form'><?php echo t('all','PlanTimeRefillCost') ?></label>
                 <input name='planTimeRefillCost' type='text' id='planTimeRefillCost' value='<?php echo $planTimeRefillCost ?>' tabindex=101 />
                 <img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planTimeRefillCostTooltip')" />
 
                 <div id='planTimeRefillCostTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['planTimeRefillCostTooltip'] ?>
+                        <?php echo t('Tooltip','planTimeRefillCostTooltip') ?>
                 </div>
                 </li>
 
                 <li class='fieldset'>
                 <br/>
                 <hr><br/>
-                <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
+                <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' />
                 </li>
 
                 </ul>
@@ -522,90 +522,90 @@
         </div>
 
 
-        <div class="tabbertab" title="<?php echo $l['title']['BandwidthSettings']; ?>">
+        <div class="tabbertab" title="<?php echo t('title','BandwidthSettings'); ?>">
         <fieldset>
 
-                <h302> <?php echo $l['title']['PlanInfo']; ?> </h302>
+                <h302> <?php echo t('title','PlanInfo'); ?> </h302>
                 <br/>
 
                 <ul>
 
                 <li class='fieldset'>
-                <label for='planBandwidthUp' class='form'><?php echo $l['all']['PlanBandwidthUp'] ?></label>
+                <label for='planBandwidthUp' class='form'><?php echo t('all','PlanBandwidthUp') ?></label>
                 <input name='planBandwidthUp' type='text' id='planBandwidthUp' value='<?php echo $planBandwidthUp ?>' tabindex=101 />
                 <img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planBandwidthUpTooltip')" />
 
                 <div id='planBandwidthUpTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['planBandwidthUpTooltip'] ?>
+                        <?php echo t('Tooltip','planBandwidthUpTooltip') ?>
                 </div>
                 </li>
 
                 <li class='fieldset'>
-                <label for='planBandwidthDown' class='form'><?php echo $l['all']['PlanBandwidthDown'] ?></label>
+                <label for='planBandwidthDown' class='form'><?php echo t('all','PlanBandwidthDown') ?></label>
                 <input name='planBandwidthDown' type='text' id='planBandwidthDown' value='<?php echo $planBandwidthDown ?>' tabindex=101 />
                 <img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planBandwidthDownTooltip')" />
 
                 <div id='planBandwidthDownTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['planBandwidthDownTooltip'] ?>
+                        <?php echo t('Tooltip','planBandwidthDownTooltip') ?>
                 </div>
                 </li>
 
 
 
                 <li class='fieldset'>
-                <label for='planTrafficTotal' class='form'><?php echo $l['all']['PlanTrafficTotal'] ?></label>
+                <label for='planTrafficTotal' class='form'><?php echo t('all','PlanTrafficTotal') ?></label>
                 <input name='planTrafficTotal' type='text' id='planTrafficTotal' value='<?php echo $planTrafficTotal ?>' tabindex=101 />
                 <img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planTrafficTotalTooltip')" />
 
                 <div id='planTrafficTotalTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['planTrafficTotalTooltip'] ?>
+                        <?php echo t('Tooltip','planTrafficTotalTooltip') ?>
                 </div>
                 </li>
 
                 <li class='fieldset'>
-                <label for='planTrafficDown' class='form'><?php echo $l['all']['PlanTrafficDown'] ?></label>
+                <label for='planTrafficDown' class='form'><?php echo t('all','PlanTrafficDown') ?></label>
                 <input name='planTrafficDown' type='text' id='planTrafficDown' value='<?php echo $planTrafficDown ?>' tabindex=101 />
                 <img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planTrafficDownTooltip')" />
 
                 <div id='planTrafficDownTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['planTrafficDownTooltip'] ?>
+                        <?php echo t('Tooltip','planTrafficDownTooltip') ?>
                 </div>
                 </li>
 
 
 
                 <li class='fieldset'>
-                <label for='planTrafficUp' class='form'><?php echo $l['all']['PlanTrafficUp'] ?></label>
+                <label for='planTrafficUp' class='form'><?php echo t('all','PlanTrafficUp') ?></label>
                 <input name='planTrafficUp' type='text' id='planTrafficUp' value='<?php echo $planTrafficUp ?>' tabindex=101 />
                 <img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planTrafficUpTooltip')" />
 
                 <div id='planTrafficUpTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['planTrafficUpTooltip'] ?>
+                        <?php echo t('Tooltip','planTrafficUpTooltip') ?>
                 </div>
                 </li>
 
 
 
                 <li class='fieldset'>
-                <label for='planTrafficRefillCost' class='form'><?php echo $l['all']['PlanTrafficRefillCost'] ?></label>
+                <label for='planTrafficRefillCost' class='form'><?php echo t('all','PlanTrafficRefillCost') ?></label>
                 <input name='planTrafficRefillCost' type='text' id='planTrafficRefillCost' value='<?php echo $planTrafficRefillCost ?>' tabindex=101 />
                 <img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planTrafficRefillCostTooltip')" />
 
                 <div id='planTrafficRefillCostTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['planTrafficRefillCostTooltip'] ?>
+                        <?php echo t('Tooltip','planTrafficRefillCostTooltip') ?>
                 </div>
                 </li>
 
                 <li class='fieldset'>
                 <br/>
                 <hr><br/>
-                <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
+                <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' />
                 </li>
 
                 </ul>
@@ -617,10 +617,10 @@
 
 
 
-        <div class="tabbertab" title="<?php echo $l['title']['Profiles']; ?>">
+        <div class="tabbertab" title="<?php echo t('title','Profiles'); ?>">
         <fieldset>
 
-		<h302> <?php echo $l['title']['Profiles']; ?> </h302>
+		<h302> <?php echo t('title','Profiles'); ?> </h302>
 		
 		<h301> Associated Profiles </h301>
 		<br/>
@@ -635,7 +635,7 @@
 			
 				echo "
 					<li class='fieldset'>
-					<label for='group' class='form'>".$l['all']['Profile']."</label>
+					<label for='group' class='form'>".t('all','Profile')."</label>
 				";
 				populate_groups($profile,"groups[]", "form", "", $profile);
 			
@@ -645,13 +645,13 @@
 			</ul>
 		
 		
-		<h301> <?php echo $l['title']['Profiles']; ?> </h301>
+		<h301> <?php echo t('title','Profiles'); ?> </h301>
 		<br/>
 	
 			<ul>
 			
 					<li class='fieldset'>
-					<label for='profile' class='form'><?php echo $l['all']['Profile']?></label>
+					<label for='profile' class='form'><?php echo t('all','Profile')?></label>
 					<?php  
 						include_once('include/management/populate_selectbox.php');
 						populate_groups("Select Profiles","groups[]");
@@ -668,7 +668,7 @@
 			
 					<div id='groupTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 						<img src='images/icons/comment.png' alt='Tip' border='0' /> 
-						<?php echo $l['Tooltip']['groupTooltip'] ?>
+						<?php echo t('Tooltip','groupTooltip') ?>
 					</div>
 					</li>
 
@@ -676,7 +676,7 @@
 				<li class='fieldset'>
 					<br/>
 					<hr><br/>
-					<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
+					<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' />
 				</li>
 
 			</ul>

--- a/bill-plans-list.php
+++ b/bill-plans-list.php
@@ -58,11 +58,11 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billplanslist.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','billplanslist.php') ?>
 				<h144>+</h144></a></h2>
 				
 				<div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['billplanslist'] ?>
+					<?php echo t('helpPage','billplanslist') ?>
 					<br/>
 				</div>
 				<br/>
@@ -125,17 +125,17 @@
 	echo "<thread> <tr>
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=planid&orderType=$orderTypeNextPage\">
-		".$l['all']['PlanId']."</a>
+		".t('all','PlanId')."</a>
 		</th>
 
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=planname&orderType=$orderTypeNextPage\">
-		".$l['all']['PlanName']."</a>
+		".t('all','PlanName')."</a>
 		</th>
 
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=plantype&orderType=$orderTypeNextPage\">
-		".$l['all']['PlanType']."</a>
+		".t('all','PlanType')."</a>
 		</th>
 	</tr> </thread>";
 
@@ -147,7 +147,7 @@
                                 onClick='javascript:__displayTooltip();'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"bill-plans-edit.php?planName=$row[1]\">
-                                                {$l['button']['EditPlan']}</a>
+                                                {t('button','EditPlan')}</a>
                                         <br/><br/>'
                                 >$row[1]</a>
                         </td>

--- a/bill-plans-new.php
+++ b/bill-plans-new.php
@@ -163,11 +163,11 @@
 
 <div id="contentnorightbar">
 
-	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billplansnew.php'] ?>
+	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','billplansnew.php') ?>
 	<h144>+</h144></a></h2>
 	
 	<div id="helpPage" style="display:none;visibility:visible" >
-		<?php echo $l['helpPage']['billplansnew'] ?>
+		<?php echo t('helpPage','billplansnew') ?>
 		<br/>
 	</div>
 	<?php
@@ -178,38 +178,38 @@
 
 <div class="tabber">
 
-	<div class="tabbertab" title="<?php echo $l['title']['PlanInfo']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','PlanInfo'); ?>">
 	<fieldset>
 
-		<h302> <?php echo $l['title']['PlanInfo']; ?> </h302>
+		<h302> <?php echo t('title','PlanInfo'); ?> </h302>
 		<br/>
 
 		<ul>
 
 		<li class='fieldset'>
-		<label for='name' class='form'><?php echo $l['all']['PlanName'] ?></label>
+		<label for='name' class='form'><?php echo t('all','PlanName') ?></label>
 		<input name='planName' type='text' id='planName' value='' tabindex=100 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planNameTooltip')" /> 
 		
 		<div id='planNameTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['planNameTooltip'] ?>
+			<?php echo t('Tooltip','planNameTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='planId' class='form'><?php echo $l['all']['PlanId'] ?></label>
+		<label for='planId' class='form'><?php echo t('all','PlanId') ?></label>
 		<input name='planId' type='text' id='planId' value='' tabindex=101 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planIdTooltip')" /> 
 		
 		<div id='planIdTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['planIdTooltip'] ?>
+			<?php echo t('Tooltip','planIdTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='planType' class='form'><?php echo $l['all']['PlanType'] ?></label>
+		<label for='planType' class='form'><?php echo t('all','PlanType') ?></label>
                 <select class='form' tabindex=102 name='planType' >
                         <option value='PayPal'>PayPal</option>
                         <option value='2Checkout'>2Checkout</option>
@@ -220,14 +220,14 @@
 		
 		<div id='planTimeTypeTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['planTimeTypeTooltip'] ?>
+			<?php echo t('Tooltip','planTimeTypeTooltip') ?>
 		</div>
 		</li>
 
 
 
 		<li class='fieldset'>
-		<label for='planRecurring' class='form'><?php echo $l['all']['PlanRecurring'] ?></label>
+		<label for='planRecurring' class='form'><?php echo t('all','PlanRecurring') ?></label>
 		<select class='form' name='planRecurring' id='planRecurring' tabindex=101>
 			<option value='No'>No</option>
 			<option value='Yes'>Yes</option>
@@ -235,12 +235,12 @@
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planRecurringTooltip')" /> 
 		<div id='planRecurringTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['planRecurringTooltip'] ?>
+			<?php echo t('Tooltip','planRecurringTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='planRecurringPeriod' class='form'><?php echo $l['all']['PlanRecurringPeriod'] ?></label>
+		<label for='planRecurringPeriod' class='form'><?php echo t('all','PlanRecurringPeriod') ?></label>
 		<select class='form' name='planRecurringPeriod' id='planRecurringPeriod' tabindex=101 >
 			<option value='Never'>Never</option>
 			<option value='Daily'>Daily</option>
@@ -254,12 +254,12 @@
 		
 		<div id='planRecurringPeriodTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['planRecurringPeriodTooltip'] ?>
+			<?php echo t('Tooltip','planRecurringPeriodTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='planRecurringBillingSchedule' class='form'><?php echo $l['all']['planRecurringBillingSchedule'] ?></label>
+		<label for='planRecurringBillingSchedule' class='form'><?php echo t('all','planRecurringBillingSchedule') ?></label>
 		<select class='form' name='planRecurringBillingSchedule' id='planRecurringBillingSchedule' tabindex=101 >
 			<option value='Fixed'>Fixed</option>
 			<option value='Anniversary'>Anniversary</option>
@@ -268,46 +268,46 @@
 		
 		<div id=planRecurringBillingScheduleToolTip  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['planRecurringBillingScheduleTooltip'] ?>
+			<?php echo t('Tooltip','planRecurringBillingScheduleTooltip') ?>
 		</div>
 		</li>
 
 
 		<li class='fieldset'>
-		<label for='planCost' class='form'><?php echo $l['all']['PlanCost'] ?></label>
+		<label for='planCost' class='form'><?php echo t('all','PlanCost') ?></label>
 		<input name='planCost' type='text' id='planCost' value='' tabindex=101 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planCostTooltip')" /> 
 		
 		<div id='planCostTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['planCostTooltip'] ?>
+			<?php echo t('Tooltip','planCostTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='planSetupCost' class='form'><?php echo $l['all']['PlanSetupCost'] ?></label>
+		<label for='planSetupCost' class='form'><?php echo t('all','PlanSetupCost') ?></label>
 		<input name='planSetupCost' type='text' id='planSetupCost' value='' tabindex=101 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planSetupCostTooltip')" /> 
 		
 		<div id='planSetupCostTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['planSetupCostTooltip'] ?>
+			<?php echo t('Tooltip','planSetupCostTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='planTax' class='form'><?php echo $l['all']['PlanTax'] ?></label>
+		<label for='planTax' class='form'><?php echo t('all','PlanTax') ?></label>
 		<input name='planTax' type='text' id='planTax' value='' tabindex=101 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planTaxTooltip')" /> 
 		
 		<div id='planTaxTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['planTaxTooltip'] ?>
+			<?php echo t('Tooltip','planTaxTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='planCurrency' class='form'><?php echo $l['all']['PlanCurrency'] ?></label>
+		<label for='planCurrency' class='form'><?php echo t('all','PlanCurrency') ?></label>
                 <select class='form' tabindex=102 name='planCurrency' >
                         <option value='USD'>USD</option>
                         <option value='EUR'>EUR</option>
@@ -333,7 +333,7 @@
 		
 		<div id='planCurrencyTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['planCurrencyTooltip'] ?>
+			<?php echo t('Tooltip','planCurrencyTooltip') ?>
 		</div>
 		</li>
 	
@@ -341,7 +341,7 @@
 <?php
 /*
                 <li class='fieldset'>
-                <label for='profile' class='form'><?php echo $l['all']['Profile']?></label>
+                <label for='profile' class='form'><?php echo t('all','Profile')?></label>
                 <?php
                         include_once 'include/management/populate_selectbox.php';
                         populate_groups("Select Profile","planGroup");
@@ -350,7 +350,7 @@
 		
 		<div id='planGroupTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['planGroupTooltip'] ?>
+			<?php echo t('Tooltip','planGroupTooltip') ?>
 		</div>
 		</li>
 */
@@ -358,7 +358,7 @@
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' />
 		</li>
 		
 		</ul>
@@ -366,16 +366,16 @@
 	</fieldset>
 	</div>
 
-	<div class="tabbertab" title="<?php echo $l['title']['TimeSettings']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','TimeSettings'); ?>">
 	<fieldset>
 
-		<h302> <?php echo $l['title']['PlanInfo']; ?> </h302>
+		<h302> <?php echo t('title','PlanInfo'); ?> </h302>
 		<br/>
 
 		<ul>
 
 		<li class='fieldset'>
-		<label for='planTimeType' class='form'><?php echo $l['all']['PlanTimeType'] ?></label>
+		<label for='planTimeType' class='form'><?php echo t('all','PlanTimeType') ?></label>
                 <select class='form' tabindex=102 name='planTimeType' >
                         <option value='Accumulative'>Accumulative</option>
                         <option value='Time-To-Finish'>Time-To-Finish</option>
@@ -384,36 +384,36 @@
 		
 		<div id='planTimeTypeTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['planTimeTypeTooltip'] ?>
+			<?php echo t('Tooltip','planTimeTypeTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='planTimeBank' class='form'><?php echo $l['all']['PlanTimeBank'] ?></label>
+		<label for='planTimeBank' class='form'><?php echo t('all','PlanTimeBank') ?></label>
 		<input name='planTimeBank' type='text' id='planTimeBank' value='' tabindex=101 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planTimeBankTooltip')" /> 
 		
 		<div id='planTimeBankTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['planTimeBankTooltip'] ?>
+			<?php echo t('Tooltip','planTimeBankTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='planTimeRefillCost' class='form'><?php echo $l['all']['PlanTimeRefillCost'] ?></label>
+		<label for='planTimeRefillCost' class='form'><?php echo t('all','PlanTimeRefillCost') ?></label>
 		<input name='planTimeRefillCost' type='text' id='planTimeRefillCost' value='' tabindex=101 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planTimeRefillCostTooltip')" /> 
 		
 		<div id='planTimeRefillCostTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['planTimeRefillCostTooltip'] ?>
+			<?php echo t('Tooltip','planTimeRefillCostTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' />
 		</li>
 	
 		</ul>
@@ -422,87 +422,87 @@
 	</div>
 
 
-        <div class="tabbertab" title="<?php echo $l['title']['BandwidthSettings']; ?>">
+        <div class="tabbertab" title="<?php echo t('title','BandwidthSettings'); ?>">
         <fieldset>
 
-                <h302> <?php echo $l['title']['PlanInfo']; ?> </h302>
+                <h302> <?php echo t('title','PlanInfo'); ?> </h302>
                 <br/>
 
                 <ul>
 
 		<li class='fieldset'>
-		<label for='planBandwidthUp' class='form'><?php echo $l['all']['PlanBandwidthUp'] ?></label>
+		<label for='planBandwidthUp' class='form'><?php echo t('all','PlanBandwidthUp') ?></label>
 		<input name='planBandwidthUp' type='text' id='planBandwidthUp' value='' tabindex=101 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planBandwidthUpTooltip')" /> 
 		
 		<div id='planBandwidthUpTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['planBandwidthUpTooltip'] ?>
+			<?php echo t('Tooltip','planBandwidthUpTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='planBandwidthDown' class='form'><?php echo $l['all']['PlanBandwidthDown'] ?></label>
+		<label for='planBandwidthDown' class='form'><?php echo t('all','PlanBandwidthDown') ?></label>
 		<input name='planBandwidthDown' type='text' id='planBandwidthDown' value='' tabindex=101 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planBandwidthDownTooltip')" /> 
 		
 		<div id='planBandwidthDownTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['planBandwidthDownTooltip'] ?>
+			<?php echo t('Tooltip','planBandwidthDownTooltip') ?>
 		</div>
 		</li>
 
 
 
 		<li class='fieldset'>
-		<label for='planTrafficTotal' class='form'><?php echo $l['all']['PlanTrafficTotal'] ?></label>
+		<label for='planTrafficTotal' class='form'><?php echo t('all','PlanTrafficTotal') ?></label>
 		<input name='planTrafficTotal' type='text' id='planTrafficTotal' value='' tabindex=101 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planTrafficTotalTooltip')" /> 
 		
 		<div id='planTrafficTotalTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['planTrafficTotalTooltip'] ?>
+			<?php echo t('Tooltip','planTrafficTotalTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='planTrafficDown' class='form'><?php echo $l['all']['PlanTrafficDown'] ?></label>
+		<label for='planTrafficDown' class='form'><?php echo t('all','PlanTrafficDown') ?></label>
 		<input name='planTrafficDown' type='text' id='planTrafficDown' value='' tabindex=101 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planTrafficDownTooltip')" /> 
 		
 		<div id='planTrafficDownTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['planTrafficDownTooltip'] ?>
+			<?php echo t('Tooltip','planTrafficDownTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='planTrafficUp' class='form'><?php echo $l['all']['PlanTrafficUp'] ?></label>
+		<label for='planTrafficUp' class='form'><?php echo t('all','PlanTrafficUp') ?></label>
 		<input name='planTrafficUp' type='text' id='planTrafficUp' value='' tabindex=101 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planTrafficUpTooltip')" /> 
 		
 		<div id='planTrafficUpTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['planTrafficUpTooltip'] ?>
+			<?php echo t('Tooltip','planTrafficUpTooltip') ?>
 		</div>
 		</li>
 
 
 		<li class='fieldset'>
-		<label for='planTrafficRefillCost' class='form'><?php echo $l['all']['PlanTrafficRefillCost'] ?></label>
+		<label for='planTrafficRefillCost' class='form'><?php echo t('all','PlanTrafficRefillCost') ?></label>
 		<input name='planTrafficRefillCost' type='text' id='planTrafficRefillCost' value='' tabindex=101 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('planTrafficRefillCostTooltip')" /> 
 		
 		<div id='planTrafficRefillCostTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['planTrafficRefillCostTooltip'] ?>
+			<?php echo t('Tooltip','planTrafficRefillCostTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' />
 		</li>
 
 		</ul>
@@ -522,16 +522,16 @@
 
 
 
-        <div class="tabbertab" title="<?php echo $l['title']['Profiles']; ?>">
+        <div class="tabbertab" title="<?php echo t('title','Profiles'); ?>">
         <fieldset>
 
-		<h302> <?php echo $l['title']['Profiles']; ?> </h302>
+		<h302> <?php echo t('title','Profiles'); ?> </h302>
 		<br/>
 	
 			<ul>
 			
 					<li class='fieldset'>
-					<label for='profile' class='form'><?php echo $l['all']['Profile']?></label>
+					<label for='profile' class='form'><?php echo t('all','Profile')?></label>
 					<?php   
 						include_once 'include/management/populate_selectbox.php';
 						populate_groups("Select Profiles","groups[]");
@@ -548,7 +548,7 @@
 			
 					<div id='groupTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 						<img src='images/icons/comment.png' alt='Tip' border='0' /> 
-						<?php echo $l['Tooltip']['groupTooltip'] ?>
+						<?php echo t('Tooltip','groupTooltip') ?>
 					</div>
 					</li>
 
@@ -556,7 +556,7 @@
 				<li class='fieldset'>
 					<br/>
 					<hr><br/>
-					<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
+					<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' />
 				</li>
 
 			</ul>

--- a/bill-plans.php
+++ b/bill-plans.php
@@ -24,7 +24,7 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#"><?php echo $l['Intro']['billplans.php'] ?></a></h2>
+				<h2 id="Intro"><a href="#"><?php echo t('Intro','billplans.php') ?></a></h2>
 
 
 <?php

--- a/bill-pos-del.php
+++ b/bill-pos-del.php
@@ -159,11 +159,11 @@
 
 <div id="contentnorightbar">
 	
-	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billposdel.php'] ?>
+	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','billposdel.php') ?>
 	:: <?php if (isset($username)) { echo $username; } ?><h144>+</h144></a></h2>
 
 	<div id="helpPage" style="display:none;visibility:visible" >
-		<?php echo $l['helpPage']['billposdel'] ?>
+		<?php echo t('helpPage','billposdel') ?>
 		<br/>
 	</div>
 	<?php
@@ -175,14 +175,14 @@
 	
 	<fieldset>
 
-		<h302> <?php echo $l['title']['AccountRemoval'] ?> </h302>
+		<h302> <?php echo t('title','AccountRemoval') ?> </h302>
 		<br/>
 
-		<label for='username' class='form'><?php echo $l['all']['Username']?></label>
+		<label for='username' class='form'><?php echo t('all','Username')?></label>
 		<input name='username[]' type='text' id='username' value='<?php echo $username ?>' tabindex=100 />
 		<br />
 
-		<label for='delradacct' class='form'><?php echo $l['all']['RemoveRadacctRecords']?></label>
+		<label for='delradacct' class='form'><?php echo t('all','RemoveRadacctRecords')?></label>
 		<select class='form' tabindex=102 name='delradacct' tabindex=101>
 			<option value='no'>no</option>
 			<option value='yes'>yes</option>
@@ -191,7 +191,7 @@
 
 		<br/><br/>
 		<hr><br/>
-		<input type="submit" name="submit" value="<?php echo $l['buttons']['apply'] ?>" tabindex=1000 
+		<input type="submit" name="submit" value="<?php echo t('buttons','apply') ?>" tabindex=1000 
 			class='button' />
 
 	</fieldset>

--- a/bill-pos-edit.php
+++ b/bill-pos-edit.php
@@ -588,11 +588,11 @@ function refillSessionTraffic() {
 
 <div id="contentnorightbar">
 
-	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billposedit.php'] ?>
+	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','billposedit.php') ?>
 	<h144>+</h144></a></h2>
 	
 	<div id="helpPage" style="display:none;visibility:visible" >
-		<?php echo $l['helpPage']['billposedit'] ?>
+		<?php echo t('helpPage','billposedit') ?>
 		<br/>
 	</div>
 	<?php
@@ -608,7 +608,7 @@ function refillSessionTraffic() {
 
 <div class="tabber">
 
-     <div class="tabbertab" title="<?php echo $l['title']['AccountInfo']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','AccountInfo'); ?>">
 
 	<fieldset>
 
@@ -616,32 +616,32 @@ function refillSessionTraffic() {
 					include_once('include/management/populate_selectbox.php');
 				?>
 				
-                <h302> <?php echo $l['title']['AccountInfo']; ?> </h302>
+                <h302> <?php echo t('title','AccountInfo'); ?> </h302>
 
                 <ul>
 
                 <div id='UserContainer'>
                 <li class='fieldset'>
-                <label for='username' class='form'><?php echo $l['all']['Username']?></label>
+                <label for='username' class='form'><?php echo t('all','Username')?></label>
 				<input name='username' type='hidden' value='<?php if (isset($username)) echo $username ?>' />
                 <input name='username' type='text' id='username' value='<?php if (isset($username)) echo $username ?>' disabled tabindex=100 />
                 <img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('usernameTooltip')" />
 
                 <div id='usernameTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['usernameTooltip'] ?>
+                        <?php echo t('Tooltip','usernameTooltip') ?>
                 </div>
                 </li>
 
                 <li class='fieldset'>
-                <label for='password' class='form'><?php echo $l['all']['Password']?></label>
+                <label for='password' class='form'><?php echo t('all','Password')?></label>
                 <input name='password' type='text' id='password' value='<?php if (isset($user_password)) echo $user_password ?>'
                         <?php if (isset($hiddenPassword)) echo $hiddenPassword ?> disabled tabindex=101 />
                 <img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('passwordTooltip')" />
 
                 <div id='passwordTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['passwordTooltip'] ?>
+                        <?php echo t('Tooltip','passwordTooltip') ?>
                 </div>
                 </li>
                 </div>
@@ -649,7 +649,7 @@ function refillSessionTraffic() {
 
 
 				<li class='fieldset'>
-				<label for='planName' class='form'><?php echo $l['all']['PlanName'] ?></label>
+				<label for='planName' class='form'><?php echo t('all','PlanName') ?></label>
 				<input name='oldplanName' type='hidden' value='<?php if (isset($bi_planname)) echo $bi_planname ?>' />
 		                <?php
 		                       populate_plans("$bi_planname","planName","form", NULL, $bi_planname);
@@ -658,20 +658,20 @@ function refillSessionTraffic() {
 				
 				<div id='planNameTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 					<img src='images/icons/comment.png' alt='Tip' border='0' />
-					<?php echo $l['Tooltip']['planNameTooltip'] ?>
+					<?php echo t('Tooltip','planNameTooltip') ?>
 				</div>
 				</li>
 	
 
                 <div id='UserContainer'>
                 <li class='fieldset'>
-                <label for='reassignplanprofiles' class='form'><?php echo $l['button']['ReAssignPlanProfiles'] ?></label>
+                <label for='reassignplanprofiles' class='form'><?php echo t('button','ReAssignPlanProfiles') ?></label>
 				<input name='reassignplanprofiles' type='checkbox' value='1' />
                 <img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('reassignplanprofiles')" />
 
                 <div id='reassignplanprofiles'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['reassignplanprofiles'] ?>
+                        <?php echo t('Tooltip','reassignplanprofiles') ?>
                 </div>
                 </li>
 		
@@ -698,7 +698,7 @@ function refillSessionTraffic() {
 				
 			<br/>		
 			
-			<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
+			<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' />
 
 		</li>
 
@@ -709,23 +709,23 @@ function refillSessionTraffic() {
 	</div>
 
 
-        <div class="tabbertab" title="<?php echo $l['title']['UserInfo']; ?>">
+        <div class="tabbertab" title="<?php echo t('title','UserInfo'); ?>">
         <?php
-                $customApplyButton = "<input type='submit' name='submit' value=".$l['buttons']['apply']." class='button' />";
+                $customApplyButton = "<input type='submit' name='submit' value=".t('buttons','apply')." class='button' />";
                 include_once('include/management/userinfo.php');
         ?>
         </div>
 
-        <div class="tabbertab" title="<?php echo $l['title']['BillingInfo']; ?>">
+        <div class="tabbertab" title="<?php echo t('title','BillingInfo'); ?>">
         <?php
-                $customApplyButton = "<input type='submit' name='submit' value=".$l['buttons']['apply']." class='button' />";
+                $customApplyButton = "<input type='submit' name='submit' value=".t('buttons','apply')." class='button' />";
                 include_once('include/management/userbillinfo.php');
         ?>
         </div>
 
 
 
-     <div class="tabbertab" title="<?php echo $l['title']['Profiles']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','Profiles'); ?>">
 
 <?php
         include 'library/opendb.php';
@@ -745,7 +745,7 @@ function refillSessionTraffic() {
         <li class='fieldset'>
 
                 <li class='fieldset'>
-                <label for='profile' class='form'><?php echo $l['all']['Profile']?></label>
+                <label for='profile' class='form'><?php echo t('all','Profile')?></label>
                 <?php
                         populate_groups("Select Profile","newgroups[]");
                 ?>
@@ -760,7 +760,7 @@ function refillSessionTraffic() {
 
                 <div id='groupTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['groupTooltip'] ?>
+                        <?php echo t('Tooltip','groupTooltip') ?>
                 </div>
                 </li>
 
@@ -768,7 +768,7 @@ function refillSessionTraffic() {
 
         <br/>
         <hr><br/>
-        <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+        <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
         </li>
 
         </ul>
@@ -781,7 +781,7 @@ function refillSessionTraffic() {
 
 
 
-        <div class="tabbertab" title="<?php echo $l['title']['Invoices']; ?>">
+        <div class="tabbertab" title="<?php echo t('title','Invoices'); ?>">
         <?php
                 include_once('include/management/userBilling.php');
                 userInvoicesStatus($user_id, 1);

--- a/bill-pos-list.php
+++ b/bill-pos-list.php
@@ -66,11 +66,11 @@
 
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billposlist.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','billposlist.php') ?>
 				<h144>+</h144></a></h2>
 				
                 <div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['billposlist'] ?>
+			<?php echo t('helpPage','billposlist') ?>
 			<br/>
 		</div>
 
@@ -185,31 +185,31 @@
 
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=id&orderType=$orderTypeNextPage\">
-		".$l['all']['ID']."</a>
+		".t('all','ID')."</a>
 		</th>
 
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=contactperson&orderType=$orderTypeNextPage\">
-		".$l['ContactInfo']['ContactPerson']."</a>
+		".t('ContactInfo','ContactPerson')."</a>
 		</th>
 
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=company&orderType=$orderTypeNextPage\">
-		".$l['ContactInfo']['Company']."</a>
+		".t('ContactInfo','Company')."</a>
 		</th>
 
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=username&orderType=$orderTypeNextPage\">
-		".$l['all']['Username']."</a>
+		".t('all','Username')."</a>
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['Password']."
+		".t('all','Password')."
 		</th>
 
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=planname&orderType=$orderTypeNextPage\">
-		".$l['ContactInfo']['PlanName']."</a>
+		".t('ContactInfo','PlanName')."</a>
 		</th>
 
 		</tr> </thread>";
@@ -236,7 +236,7 @@
 					javascript:__displayTooltip();'
                                 tooltipText='
 	                                <a class=\"toolTip\" href=\"bill-pos-edit.php?username=".urlencode($row['username'])."\">
-						{$l['Tooltip']['UserEdit']}</a>
+						{t('Tooltip','UserEdit')}</a>
 					<br/><br/>
 
 					<div id=\"divContainerUserInfo\">

--- a/bill-pos-new.php
+++ b/bill-pos-new.php
@@ -468,11 +468,11 @@
 
 <div id="contentnorightbar">
 
-	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billposnew.php'] ?>
+	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','billposnew.php') ?>
 	<h144>+</h144></a></h2>
 	
 	<div id="helpPage" style="display:none;visibility:visible" >
-		<?php echo $l['helpPage']['billposnew'] ?>
+		<?php echo t('helpPage','billposnew') ?>
 		<br/>
 	</div>
 	<?php
@@ -483,11 +483,11 @@
 
 <div class="tabber">
 
-     <div class="tabbertab" title="<?php echo $l['title']['AccountInfo']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','AccountInfo'); ?>">
 
 	<fieldset>
 
-                <h302> <?php echo $l['title']['AccountInfo']; ?> </h302>
+                <h302> <?php echo t('title','AccountInfo'); ?> </h302>
 
                 <ul>
 
@@ -497,7 +497,7 @@
 				
                 <div id='UserContainer'>
                 <li class='fieldset'>
-                <label for='username' class='form'><?php echo $l['all']['Username']?></label>
+                <label for='username' class='form'><?php echo t('all','Username')?></label>
                 <input name='username' type='text' id='username' value='' tabindex=100 />
                 <input type='button' value='Random' class='button' onclick="javascript:randomAlphanumeric('username',8,<?php
 				echo "'".$configValues['CONFIG_USER_ALLOWEDRANDOMCHARS']."'" ?>)" />
@@ -505,12 +505,12 @@
 
                 <div id='usernameTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['usernameTooltip'] ?>
+                        <?php echo t('Tooltip','usernameTooltip') ?>
                 </div>
                 </li>
 
                 <li class='fieldset'>
-                <label for='password' class='form'><?php echo $l['all']['Password']?></label>
+                <label for='password' class='form'><?php echo t('all','Password')?></label>
                 <input name='password' type='text' id='password' value=''
                         <?php if (isset($hiddenPassword)) echo $hiddenPassword ?> tabindex=101 />
                 <input type='button' value='Random' class='button' onclick="javascript:randomAlphanumeric('password',8,<?php
@@ -519,7 +519,7 @@
 
                 <div id='passwordTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['passwordTooltip'] ?>
+                        <?php echo t('Tooltip','passwordTooltip') ?>
                 </div>
                 </li>
                 </div>
@@ -527,7 +527,7 @@
 
 
 		<li class='fieldset'>
-		<label for='planName' class='form'><?php echo $l['all']['PlanName'] ?></label>
+		<label for='planName' class='form'><?php echo t('all','PlanName') ?></label>
                 <?php
                        populate_plans("Select Plan","planName","form");
                 ?>
@@ -535,13 +535,13 @@
 		
 		<div id='planNameTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['planNameTooltip'] ?>
+			<?php echo t('Tooltip','planNameTooltip') ?>
 		</div>
 		</li>
 	
 
                 <li class='fieldset'>
-                <label for='profile' class='form'><?php echo $l['all']['Profile']?></label>
+                <label for='profile' class='form'><?php echo t('all','Profile')?></label>
                 <?php
                         populate_groups("Select Profile","profiles[]");
                 ?>
@@ -556,12 +556,12 @@
 
                 <div id='groupTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['groupTooltip'] ?>
+                        <?php echo t('Tooltip','groupTooltip') ?>
                 </div>
                 </li>
 
 		<li class='fieldset'>
-		<label for='userupdate' class='form'><?php echo $l['all']['SendWelcomeNotification']?></label>
+		<label for='userupdate' class='form'><?php echo t('all','SendWelcomeNotification')?></label>
 		<input type='checkbox' class='form' name='notificationWelcome' value='1' checked/>
 	        <br/>
 		</li>
@@ -570,7 +570,7 @@
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' />
 		</li>
 
 		</ul>
@@ -580,31 +580,31 @@
 	</div>
 
 
-        <div class="tabbertab" title="<?php echo $l['title']['UserInfo']; ?>">
+        <div class="tabbertab" title="<?php echo t('title','UserInfo'); ?>">
         <?php
-                $customApplyButton = "<input type='submit' name='submit' value=".$l['buttons']['apply']." class='button' />";
+                $customApplyButton = "<input type='submit' name='submit' value=".t('buttons','apply')." class='button' />";
                 include_once('include/management/userinfo.php');
         ?>
         </div>
 
-        <div class="tabbertab" title="<?php echo $l['title']['BillingInfo']; ?>">
+        <div class="tabbertab" title="<?php echo t('title','BillingInfo'); ?>">
         <?php
-                $customApplyButton = "<input type='submit' name='submit' value=".$l['buttons']['apply']." class='button' />";
+                $customApplyButton = "<input type='submit' name='submit' value=".t('buttons','apply')." class='button' />";
                 include_once('include/management/userbillinfo.php');
         ?>
         </div>
 
 
-     <div class="tabbertab" title="<?php echo $l['title']['Advanced']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','Advanced'); ?>">
 
         <fieldset>
 
-                <h302> <?php echo $l['title']['AccountInfo']; ?> </h302>
+                <h302> <?php echo t('title','AccountInfo'); ?> </h302>
 
                 <ul>
 
                 <li class='fieldset'>
-                <label for='passwordType' class='form'><?php echo $l['all']['PasswordType']?> </label>
+                <label for='passwordType' class='form'><?php echo t('all','PasswordType')?> </label>
                 <select class='form' tabindex=102 name='passwordType' >
                         <option value='Cleartext-Password'>Cleartext-Password</option>
                         <option value='User-Password'>User-Password</option>
@@ -618,7 +618,7 @@
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' />
 		</li>
 
 		</ul>

--- a/bill-pos.php
+++ b/bill-pos.php
@@ -24,7 +24,7 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#"><?php echo $l['Intro']['billpos.php'] ?></a></h2>
+				<h2 id="Intro"><a href="#"><?php echo t('Intro','billpos.php') ?></a></h2>
 
 
 <?php

--- a/bill-rates-date.php
+++ b/bill-rates-date.php
@@ -63,10 +63,10 @@
 
 	<div id="contentnorightbar">
 
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billratesdate.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','billratesdate.php'); ?>
 		<h144>+</h144></a></h2>
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['billratesdate'] ?>
+			<?php echo t('helpPage','billratesdate') ?>
 			<br/>
 		</div>
 		<br/>
@@ -185,26 +185,26 @@
 		<th scope='col'>
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&ratename=$ratename&startdate=$startdate&enddate=$enddate&orderBy=username&orderType=$orderTypeNextPage\">
-		".$l['all']['Username']."</a>
+		".t('all','Username')."</a>
 		</th>
 		<th scope='col'>
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&ratename=$ratename&startdate=$startdate&enddate=$enddate&orderBy=nasipaddress&orderType=$orderTypeNextPage\">
-		".$l['all']['NASIPAddress']."</a>
+		".t('all','NASIPAddress')."</a>
 		</th>
 		<th scope='col'>
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&ratename=$ratename&startdate=$startdate&enddate=$enddate&orderBy=acctstarttime&orderType=$orderTypeNextPage\">
-		".$l['all']['LastLoginTime']."</a>
+		".t('all','LastLoginTime')."</a>
 		</th>
 		<th scope='col'>
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&ratename=$ratename&startdate=$startdate&enddate=$enddate&orderBy=acctsessiontime&orderType=$orderTypeNextPage\">
-		".$l['all']['TotalTime']."</a>
+		".t('all','TotalTime')."</a>
 		</th>
 		<th scope='col'>
 		<br/>
-		 ".$l['all']['Billed']."
+		 ".t('all','Billed')."
 		</th>
                 </tr> </thread>";
 

--- a/bill-rates-del.php
+++ b/bill-rates-del.php
@@ -91,10 +91,10 @@
 
 <div id="contentnorightbar">
 
-	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billratesdel.php'] ?>
+	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','billratesdel.php') ?>
 	:: <?php if (isset($ratename)) { echo $ratename; } ?><h144>+</h144></a></h2>
 
-	<div id="helpPage" style="display:none;visibility:visible" >		<?php echo $l['helpPage']['billhsdel'] ?>
+	<div id="helpPage" style="display:none;visibility:visible" >		<?php echo t('helpPage','billhsdel') ?>
 		<br/>
 	</div>
 	<?php
@@ -106,17 +106,17 @@
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['RateInfo'] ?> </h302>
+		<h302> <?php echo t('title','RateInfo') ?> </h302>
 		<br/>
 
-		<label for='ratename' class='form'><?php echo $l['all']['RateName'] ?></label>
+		<label for='ratename' class='form'><?php echo t('all','RateName') ?></label>
 		<input name='ratename[]' type='text' id='ratename' value='<?php echo $ratename ?>' tabindex=100 />
 		<br/>
 
 		<br/><br/>
 		<hr><br/>
 
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=1000 
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=1000 
 			class='button' />
 
 	</fieldset>

--- a/bill-rates-edit.php
+++ b/bill-rates-edit.php
@@ -119,11 +119,11 @@
 ?>
 	<div id="contentnorightbar">
 
-		<h2 id="Intro" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billratesedit.php'] ?>
+		<h2 id="Intro" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','billratesedit.php') ?>
 		:: <?php if (isset($ratename)) { echo $ratename; } ?><h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['billratesedit'] ?>
+			<?php echo t('helpPage','billratesedit') ?>
 			<br/>
 		</div>
 		<?php
@@ -134,23 +134,23 @@
 
 <div class="tabber">
 
-	<div class="tabbertab" title="<?php echo $l['title']['RateInfo']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','RateInfo'); ?>">
 
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['RateInfo']; ?> </h302>
+		<h302> <?php echo t('title','RateInfo'); ?> </h302>
 		<br/>
 
 		<ul>
 
 			<li class='fieldset'>
-			<label for='ratename' class='form'><?php echo $l['all']['RateName'] ?></label>
+			<label for='ratename' class='form'><?php echo t('all','RateName') ?></label>
 			<input disabled name='ratename' type='text' id='ratename' value='<?php echo $ratename ?>' tabindex=100 />
 			</li>
 
 			<li class='fieldset'>
-			<label for='ratetype' class='form'><?php echo $l['all']['RateType'] ?></label>
+			<label for='ratetype' class='form'><?php echo t('all','RateType') ?></label>
 
 	                <input class='integer' name='ratetypenum' type='text' id='ratetypenum' value='<?php echo $ratetypenum ?>' tabindex=101 />
 	                <img src="images/icons/bullet_arrow_up.png" alt="+" onclick="javascript:changeInteger('ratetypenum','increment')" />
@@ -170,12 +170,12 @@
 
 			<div id='rateTypeTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 				<img src='images/icons/comment.png' alt='Tip' border='0' />
-				<?php echo $l['Tooltip']['rateTypeTooltip'] ?>
+				<?php echo t('Tooltip','rateTypeTooltip') ?>
 			</div>
 			</li>
 
 			<li class='fieldset'>
-			<label for='ratecost' class='form'><?php echo $l['all']['RateCost'] ?></label>
+			<label for='ratecost' class='form'><?php echo t('all','RateCost') ?></label>
 			<input class='integer' name='ratecost' type='text' id='ratecost' value='<?php echo $ratecost ?>' tabindex=103 />
         	        <img src="images/icons/bullet_arrow_up.png" alt="+" onclick="javascript:changeInteger('ratecost','increment')" />
 	                <img src="images/icons/bullet_arrow_down.png" alt="-" onclick="javascript:changeInteger('ratecost','decrement')"/>
@@ -183,14 +183,14 @@
 
 			<div id='rateCostTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 				<img src='images/icons/comment.png' alt='Tip' border='0' />
-				<?php echo $l['Tooltip']['rateCostTooltip'] ?>
+				<?php echo t('Tooltip','rateCostTooltip') ?>
 			</div>
 			</li>
 
 			<li class='fieldset'>
 			<br/>
 			<hr><br/>
-			<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000
+			<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000
 				class='button' />
 			</li>
 
@@ -202,7 +202,7 @@
 
 </div>
 
-<div class="tabbertab" title="<?php echo $l['title']['Optional']; ?>">
+<div class="tabbertab" title="<?php echo t('title','Optional'); ?>">
 
 <fieldset>
 
@@ -214,19 +214,19 @@
         <br/>
 
         <br/>
-        <label for='creationdate' class='form'><?php echo $l['all']['CreationDate'] ?></label>
+        <label for='creationdate' class='form'><?php echo t('all','CreationDate') ?></label>
         <input disabled value='<?php if (isset($creationdate)) echo $creationdate ?>' tabindex=313 />
         <br/>
 
-        <label for='creationby' class='form'><?php echo $l['all']['CreationBy'] ?></label>
+        <label for='creationby' class='form'><?php echo t('all','CreationBy') ?></label>
         <input disabled value='<?php if (isset($creationby)) echo $creationby ?>' tabindex=314 />
         <br/>
 
-        <label for='updatedate' class='form'><?php echo $l['all']['UpdateDate'] ?></label>
+        <label for='updatedate' class='form'><?php echo t('all','UpdateDate') ?></label>
         <input disabled value='<?php if (isset($updatedate)) echo $updatedate ?>' tabindex=315 />
         <br/>
 
-        <label for='updateby' class='form'><?php echo $l['all']['UpdateBy'] ?></label>
+        <label for='updateby' class='form'><?php echo t('all','UpdateBy') ?></label>
         <input disabled value='<?php if (isset($updateby)) echo $updateby ?>' tabindex=316 />
         <br/>
 
@@ -234,7 +234,7 @@
         <br/><br/>
         <hr><br/>
 
-        <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000
+        <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000
                 class='button' />
 
 </fieldset>

--- a/bill-rates-list.php
+++ b/bill-rates-list.php
@@ -58,11 +58,11 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billrateslist.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','billrateslist.php') ?>
 				<h144>+</h144></a></h2>
 				
 				<div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['billrateslist'] ?>
+					<?php echo t('helpPage','billrateslist') ?>
 					<br/>
 				</div>
 				<br/>
@@ -124,22 +124,22 @@
 	echo "<thread> <tr>
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=id&orderType=$orderTypeNextPage\">
-		".$l['all']['ID']."</a>
+		".t('all','ID')."</a>
 		</th>
 
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=ratename&orderType=$orderTypeNextPage\">
-		".$l['all']['RateName']."</a>
+		".t('all','RateName')."</a>
 		</th>
 
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=ratetype&orderType=$orderTypeNextPage\">
-		".$l['all']['RateType']."</a>
+		".t('all','RateType')."</a>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=ratecost&orderType=$orderTypeNextPage\">
-		".$l['all']['RateCost']."</a>
+		".t('all','RateCost')."</a>
 		</th>
 
 	</tr> </thread>";
@@ -150,9 +150,9 @@
                         <td> <a class='tablenovisit' href='javascript:return;'
                                 onclick=\"javascript:__displayTooltip();\"
                                 tooltipText=\"
-                                        <a class='toolTip' href='bill-rates-edit.php?ratename=$row[1]'>".$l['Tooltip']['EditRate']."</a>
+                                        <a class='toolTip' href='bill-rates-edit.php?ratename=$row[1]'>".t('Tooltip','EditRate')."</a>
 					<br/>
-                                        <a class='toolTip' href='bill-rates-del.php?ratename=$row[1]'>".$l['Tooltip']['RemoveRate']."</a>
+                                        <a class='toolTip' href='bill-rates-del.php?ratename=$row[1]'>".t('Tooltip','RemoveRate')."</a>
                                         <br/><br/>\"
                               >$row[1]</a>
                         </td>

--- a/bill-rates-new.php
+++ b/bill-rates-new.php
@@ -106,11 +106,11 @@
 
 <div id="contentnorightbar">
 
-	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billratesnew.php'] ?>
+	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','billratesnew.php') ?>
 	<h144>+</h144></a></h2>
 	
 	<div id="helpPage" style="display:none;visibility:visible" >
-		<?php echo $l['helpPage']['billratesnew'] ?>
+		<?php echo t('helpPage','billratesnew') ?>
 		<br/>
 	</div>
 	<?php
@@ -121,28 +121,28 @@
 
 <div class="tabber">
 
-	<div class="tabbertab" title="<?php echo $l['title']['RateInfo']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','RateInfo'); ?>">
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['RateInfo']; ?> </h302>
+		<h302> <?php echo t('title','RateInfo'); ?> </h302>
 		<br/>
 
 		<ul>
 
 		<li class='fieldset'>
-		<label for='name' class='form'><?php echo $l['all']['RateName'] ?></label>
+		<label for='name' class='form'><?php echo t('all','RateName') ?></label>
 		<input name='ratename' type='text' id='ratename' value='' tabindex=100 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('rateNameTooltip')" /> 
 		
 		<div id='rateNameTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['rateNameTooltip'] ?>
+			<?php echo t('Tooltip','rateNameTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='ratetype' class='form'><?php echo $l['all']['RateType'] ?></label>
+		<label for='ratetype' class='form'><?php echo t('all','RateType') ?></label>
 
 		<input class='integer' name='ratetypenum' type='text' id='ratetypenum' value='1' tabindex=101 />
                 <img src="images/icons/bullet_arrow_up.png" alt="+" onclick="javascript:changeInteger('ratetypenum','increment')" />
@@ -160,12 +160,12 @@
 		
 		<div id='rateTypeTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['rateTypeTooltip'] ?>
+			<?php echo t('Tooltip','rateTypeTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='ratecost' class='form'><?php echo $l['all']['RateCost'] ?></label>
+		<label for='ratecost' class='form'><?php echo t('all','RateCost') ?></label>
 		<input class='integer' name='ratecost' type='text' id='ratecost' value='1' tabindex=103 />
                 <img src="images/icons/bullet_arrow_up.png" alt="+" onclick="javascript:changeInteger('ratecost','increment')" />
                 <img src="images/icons/bullet_arrow_down.png" alt="-" onclick="javascript:changeInteger('ratecost','decrement')"/>
@@ -173,14 +173,14 @@
 		
 		<div id='rateCostTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['rateCostTooltip'] ?>
+			<?php echo t('Tooltip','rateCostTooltip') ?>
 		</div>
 		</li>
 	
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' />
 		</li>
 
 		</ul>
@@ -189,7 +189,7 @@
 	</div>
 
 
-	<div class="tabbertab" title="<?php echo $l['title']['Optional']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','Optional'); ?>">
 
 <fieldset>
 
@@ -201,19 +201,19 @@
         <br/>
 
         <br/>
-        <label for='creationdate' class='form'><?php echo $l['all']['CreationDate'] ?></label>
+        <label for='creationdate' class='form'><?php echo t('all','CreationDate') ?></label>
         <input disabled value='<?php if (isset($creationdate)) echo $creationdate ?>' tabindex=313 />
         <br/>
 
-        <label for='creationby' class='form'><?php echo $l['all']['CreationBy'] ?></label>
+        <label for='creationby' class='form'><?php echo t('all','CreationBy') ?></label>
         <input disabled value='<?php if (isset($creationby)) echo $creationby ?>' tabindex=314 />
         <br/>
 
-        <label for='updatedate' class='form'><?php echo $l['all']['UpdateDate'] ?></label>
+        <label for='updatedate' class='form'><?php echo t('all','UpdateDate') ?></label>
         <input disabled value='<?php if (isset($updatedate)) echo $updatedate ?>' tabindex=315 />
         <br/>
 
-        <label for='updateby' class='form'><?php echo $l['all']['UpdateBy'] ?></label>
+        <label for='updateby' class='form'><?php echo t('all','UpdateBy') ?></label>
         <input disabled value='<?php if (isset($updateby)) echo $updateby ?>' tabindex=316 />
         <br/>
 
@@ -221,7 +221,7 @@
         <br/><br/>
         <hr><br/>
 
-        <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000
+        <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000
                 class='button' />
 
 </fieldset>

--- a/bill-rates.php
+++ b/bill-rates.php
@@ -24,7 +24,7 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#"><?php echo $l['Intro']['ratesmain.php'] ?></a></h2>
+				<h2 id="Intro"><a href="#"><?php echo t('Intro','ratesmain.php') ?></a></h2>
 
 
 <?php

--- a/config-backup-createbackups.php
+++ b/config-backup-createbackups.php
@@ -330,10 +330,10 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['configbackupcreatebackups.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','configbackupcreatebackups.php') ?>
 				<h144>+</h144></a></h2>
                 <div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['configbackupcreatebackups'] ?>
+					<?php echo t('helpPage','configbackupcreatebackups') ?>
 					<br/>
 				</div>
                 <?php
@@ -344,11 +344,11 @@
 
 <div class="tabber">
 
-     <div class="tabbertab" title="<?php echo $l['title']['FreeRADIUSTables']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','FreeRADIUSTables'); ?>">
 
         <fieldset>
 
-                <h302> <?php echo $l['title']['Backups']; ?> </h302>
+                <h302> <?php echo t('title','Backups'); ?> </h302>
 		<br/>
 
                 <label class='form'>Select database tables to backup:</label>
@@ -448,7 +448,7 @@
                 <li class='fieldset'>
                 <br/>
                 <hr><br/>
-                <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+                <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
                 </li>
 
 		</ul>
@@ -456,11 +456,11 @@
 
 	</div>
 
-     <div class="tabbertab" title="<?php echo $l['title']['daloRADIUSTables']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','daloRADIUSTables'); ?>">
 
         <fieldset>
 
-                <h302> <?php echo $l['title']['Backups']; ?> </h302>
+                <h302> <?php echo t('title','Backups'); ?> </h302>
 		<br/>
 
                 <label class='form'>Select databases tables to backup:</label>
@@ -734,7 +734,7 @@
                 <li class='fieldset'>
                 <br/>
                 <hr><br/>
-                <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+                <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
                 </li>
 
                 </ul>

--- a/config-backup-managebackups.php
+++ b/config-backup-managebackups.php
@@ -166,10 +166,10 @@
 
 		<div id="contentnorightbar">
 
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['configbackupmanagebackups.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','configbackupmanagebackups.php') ?>
 				<h144>+</h144></a></h2>
                 <div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['configbackupmanagebackups'] ?>
+					<?php echo t('helpPage','configbackupmanagebackups') ?>
 					<br/>
 				</div>
                 <?php
@@ -230,11 +230,11 @@
 				echo "</td>";
 
 				echo "<td>";
-					echo "<a class='tablenovisit' href='?file=$file&action=download' >".$l['all']['Download']."</a>";
+					echo "<a class='tablenovisit' href='?file=$file&action=download' >".t('all','Download')."</a>";
 
 					echo "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;";
 
-					echo "<a class='tablenovisit' href='#' onClick=\"javascript:backupRollback('$file');\">".$l['all']['Rollback']."</a>";
+					echo "<a class='tablenovisit' href='#' onClick=\"javascript:backupRollback('$file');\">".t('all','Rollback')."</a>";
 				echo "</td>";
 
 				}

--- a/config-backup.php
+++ b/config-backup.php
@@ -37,11 +37,11 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['configbackup.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','configbackup.php') ?>
 				<h144>+</h144></a></h2>
                 
 				<div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['configbackup'] ?>
+					<?php echo t('helpPage','configbackup') ?>
 					<br/>
 				</div>
 				<br/>

--- a/config-db.php
+++ b/config-db.php
@@ -159,11 +159,11 @@
 			
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['configdb.php']; ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','configdb.php'); ?>
 				<h144>+</h144></a></h2>
 
                 <div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['configdb'] ?>
+					<?php echo t('helpPage','configdb') ?>
 					<br/>
 				</div>
                 <?php
@@ -174,17 +174,17 @@
 
 <div class="tabber">
 
-     <div class="tabbertab" title="<?php echo $l['title']['Settings']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','Settings'); ?>">
 
         <fieldset>
 
-                <h302><?php echo $l['title']['Settings']; ?></h302>
+                <h302><?php echo t('title','Settings'); ?></h302>
 		<br/>
 
 		<ul>
 
                 <li class='fieldset'>
-                <label for='config_dbengine' class='form'><?php echo $l['all']['DBEngine']?></label>
+                <label for='config_dbengine' class='form'><?php echo t('all','DBEngine')?></label>
 		<select class='form' name="config_dbengine">
 			<option value="<?php echo $configValues['CONFIG_DB_ENGINE'] ?>"> <?php echo $configValues['CONFIG_DB_ENGINE'] ?> </option>
 			<option value=""></option>
@@ -204,34 +204,34 @@
 		</li>
 
 		<li class='fieldset'>
-		<label for='config_dbhost' class='form'><?php echo $l['all']['DatabaseHostname'] ?></label>
+		<label for='config_dbhost' class='form'><?php echo t('all','DatabaseHostname') ?></label>
 		<input type='text' value="<?php echo $configValues['CONFIG_DB_HOST'] ?>" name="config_dbhost" />
 		</li>
 		
 		<li class='fieldset'>
-		<label for='config_dbport' class='form'><?php echo $l['all']['DatabasePort'] ?></label>
+		<label for='config_dbport' class='form'><?php echo t('all','DatabasePort') ?></label>
 		<input type='text' value="<?php echo $configValues['CONFIG_DB_PORT'] ?>" name="config_dbport" />
 		</li>
 
 		<li class='fieldset'>
-		<label for='config_dbuser' class='form'><?php echo $l['all']['DatabaseUser'] ?></label>
+		<label for='config_dbuser' class='form'><?php echo t('all','DatabaseUser') ?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_USER'] ?>" name="config_dbuser" />
 		</li>
 
 		<li class='fieldset'>
-		<label for='config_dbpass' class='form'><?php echo $l['all']['DatabasePass'] ?></label>
+		<label for='config_dbpass' class='form'><?php echo t('all','DatabasePass') ?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_PASS'] ?>" name="config_dbpass" />
 		</li>
 
 		<li class='fieldset'>
-		<label for='db_name' class='form'><?php echo  $l['all']['DatabaseName'] ?></label>
+		<label for='db_name' class='form'><?php echo  t('all','DatabaseName') ?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_NAME'] ?>" name="config_dbname" />
 		</li>
 
                 <li class='fieldset'>
                 <br/>
                 <hr><br/>
-                <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+                <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
                 </li>
 
                 </ul>
@@ -240,177 +240,177 @@
 
 	</div>
 
-     <div class="tabbertab" title="<?php echo $l['title']['DatabaseTables']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','DatabaseTables'); ?>">
 
 		<fieldset>
 
-                <h302><?php echo $l['title']['DatabaseTables']; ?></h302>
+                <h302><?php echo t('title','DatabaseTables'); ?></h302>
 		<br/>
 
 		<ul>
 
 		<li class='fieldset'>
-                <label for='config_dbtbl_radcheck' class='form'><?php echo $l['all']['radcheck']?></label>
+                <label for='config_dbtbl_radcheck' class='form'><?php echo t('all','radcheck')?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_TBL_RADCHECK'] ?>" name="config_dbtbl_radcheck"/>
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_dbtbl_radreply' class='form'><?php echo $l['all']['radreply']?></label>
+                <label for='config_dbtbl_radreply' class='form'><?php echo t('all','radreply')?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_TBL_RADREPLY'] ?>" name="config_dbtbl_radreply" />
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_dbtbl_radgroupreply' class='form'><?php echo $l['all']['radgroupreply']?></label>
+                <label for='config_dbtbl_radgroupreply' class='form'><?php echo t('all','radgroupreply')?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_TBL_RADGROUPREPLY'] ?>" name="config_dbtbl_radgroupreply" />
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_dbtbl_radgroupcheck' class='form'><?php echo $l['all']['radgroupcheck']?></label>
+                <label for='config_dbtbl_radgroupcheck' class='form'><?php echo t('all','radgroupcheck')?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_TBL_RADGROUPCHECK'] ?>" name="config_dbtbl_radgroupcheck" />
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_dbtbl_usergroup' class='form'><?php echo $l['all']['usergroup']?></label>
+                <label for='config_dbtbl_usergroup' class='form'><?php echo t('all','usergroup')?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_TBL_RADUSERGROUP'] ?>" name="config_dbtbl_usergroup" />
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_dbtbl_radacct' class='form'><?php echo $l['all']['radacct']?></label>
+                <label for='config_dbtbl_radacct' class='form'><?php echo t('all','radacct')?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_TBL_RADACCT'] ?>" name="config_dbtbl_radacct" />
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_dbtbl_nas' class='form'><?php echo $l['all']['nas']?></label>
+                <label for='config_dbtbl_nas' class='form'><?php echo t('all','nas')?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_TBL_RADNAS'] ?>" name="config_dbtbl_nas" />
 		</li>
 
 
 				 <li class='fieldset'>
-                <label for='config_dbtbl_hunt' class='form'><?php echo $l['all']['hunt']?></label>
+                <label for='config_dbtbl_hunt' class='form'><?php echo t('all','hunt')?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_TBL_RADHG'] ?>" name="config_dbtbl_hunt" />
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_dbtbl_radpostauth' class='form'><?php echo $l['all']['radpostauth']?></label>
+                <label for='config_dbtbl_radpostauth' class='form'><?php echo t('all','radpostauth')?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_TBL_RADPOSTAUTH'] ?>" name="config_dbtbl_radpostauth" />
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_dbtbl_radippool' class='form'><?php echo $l['all']['radippool']?></label>
+                <label for='config_dbtbl_radippool' class='form'><?php echo t('all','radippool')?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_TBL_RADIPPOOL'] ?>" name="config_dbtbl_radippool" />
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_dbtbl_userinfo' class='form'><?php echo $l['all']['userinfo']?></label>
+                <label for='config_dbtbl_userinfo' class='form'><?php echo t('all','userinfo')?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_TBL_DALOUSERINFO'] ?>" name="config_dbtbl_userinfo" />
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_dbtbl_dictionary' class='form'><?php echo $l['all']['dictionary']?></label>
+                <label for='config_dbtbl_dictionary' class='form'><?php echo t('all','dictionary')?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_TBL_DALODICTIONARY'] ?>" name="config_dbtbl_dictionary" />
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_dbtbl_realms' class='form'><?php echo $l['all']['realms']?></label>
+                <label for='config_dbtbl_realms' class='form'><?php echo t('all','realms')?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_TBL_DALOREALMS'] ?>" name="config_dbtbl_realms" />
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_dbtbl_proxys' class='form'><?php echo $l['all']['proxys']?></label>
+                <label for='config_dbtbl_proxys' class='form'><?php echo t('all','proxys')?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_TBL_DALOPROXYS'] ?>" name="config_dbtbl_proxys" />
 		</li>
 
 				<li class='fieldset'>
-                <label for='config_dbtbl_billingmerchant' class='form'><?php echo $l['all']['billingmerchant']?></label>
+                <label for='config_dbtbl_billingmerchant' class='form'><?php echo t('all','billingmerchant')?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_TBL_DALOBILLINGMERCHANT'] ?>" name="config_dbtbl_billingmerchant" />
 		</li>
 		
                 <li class='fieldset'>
-                <label for='config_dbtbl_billingpaypal' class='form'><?php echo $l['all']['billingpaypal']?></label>
+                <label for='config_dbtbl_billingpaypal' class='form'><?php echo t('all','billingpaypal')?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_TBL_DALOBILLINGPAYPAL'] ?>" name="config_dbtbl_billingpaypal" />
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_dbtbl_billingplans' class='form'><?php echo $l['all']['billingplans']?></label>
+                <label for='config_dbtbl_billingplans' class='form'><?php echo t('all','billingplans')?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_TBL_DALOBILLINGPLANS'] ?>" name="config_dbtbl_billingplans" />
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_dbtbl_rates' class='form'><?php echo $l['all']['billingrates']?></label>
+                <label for='config_dbtbl_rates' class='form'><?php echo t('all','billingrates')?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_TBL_DALOBILLINGRATES'] ?>" name="config_dbtbl_rates" />
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_dbtbl_billinghistory' class='form'><?php echo $l['all']['billinghistory']?></label>
+                <label for='config_dbtbl_billinghistory' class='form'><?php echo t('all','billinghistory')?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_TBL_DALOBILLINGHISTORY'] ?>" name="config_dbtbl_billinghistory" />
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_dbtbl_billinginfo' class='form'><?php echo $l['all']['billinginfo']?></label>
+                <label for='config_dbtbl_billinginfo' class='form'><?php echo t('all','billinginfo')?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_TBL_DALOUSERBILLINFO'] ?>" name="config_dbtbl_billinginfo" />
 		</li>
 
 		<li class='fieldset'>
-        <label for='config_dbtbl_billinginvoice' class='form'><?php echo $l['all']['Invoice']?></label>
+        <label for='config_dbtbl_billinginvoice' class='form'><?php echo t('all','Invoice')?></label>
         <input value="<?php echo $configValues['CONFIG_DB_TBL_DALOBILLINGINVOICE'] ?>" name="config_dbtbl_billinginvoice" />
         </li>
 
 		<li class='fieldset'>
-        <label for='config_dbtbl_billinginvoice_items' class='form'><?php echo $l['all']['InvoiceItems']?></label>
+        <label for='config_dbtbl_billinginvoice_items' class='form'><?php echo t('all','InvoiceItems')?></label>
         <input value="<?php echo $configValues['CONFIG_DB_TBL_DALOBILLINGINVOICEITEMS'] ?>" name="config_dbtbl_billinginvoice_items" />
         </li>
         
         <li class='fieldset'>
-        <label for='config_dbtbl_billinginvoice_status' class='form'><?php echo $l['all']['InvoiceStatus']?></label>
+        <label for='config_dbtbl_billinginvoice_status' class='form'><?php echo t('all','InvoiceStatus')?></label>
         <input value="<?php echo $configValues['CONFIG_DB_TBL_DALOBILLINGINVOICESTATUS'] ?>" name="config_dbtbl_billinginvoice_status" />
         </li>
         
         <li class='fieldset'>
-        <label for='config_dbtbl_billinginvoice_type' class='form'><?php echo $l['all']['InvoiceType']?></label>
+        <label for='config_dbtbl_billinginvoice_type' class='form'><?php echo t('all','InvoiceType')?></label>
         <input value="<?php echo $configValues['CONFIG_DB_TBL_DALOBILLINGINVOICETYPE'] ?>" name="config_dbtbl_billinginvoice_type" />
         </li>
 
 		<li class='fieldset'>
-        <label for='config_dbtbl_payment_type' class='form'><?php echo $l['all']['payment_type']?></label>
+        <label for='config_dbtbl_payment_type' class='form'><?php echo t('all','payment_type')?></label>
         <input value="<?php echo $configValues['CONFIG_DB_TBL_DALOPAYMENTTYPES'] ?>" name="config_dbtbl_payment_type" />
         </li>
 
         <li class='fieldset'>
-        <label for='config_dbtbl_payments' class='form'><?php echo $l['all']['payments']?></label>
+        <label for='config_dbtbl_payments' class='form'><?php echo t('all','payments')?></label>
         <input value="<?php echo $configValues['CONFIG_DB_TBL_DALOPAYMENTS'] ?>" name="config_dbtbl_payments" />
         </li>
 
 
 
                 <li class='fieldset'>
-                <label for='config_dbtbl_operators' class='form'><?php echo $l['all']['operators']?></label>
+                <label for='config_dbtbl_operators' class='form'><?php echo t('all','operators')?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_TBL_DALOOPERATORS'] ?>" name="config_dbtbl_operators" />
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_dbtbl_operators_acl' class='form'><?php echo $l['all']['operators_acl']?></label>
+                <label for='config_dbtbl_operators_acl' class='form'><?php echo t('all','operators_acl')?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_TBL_DALOOPERATORS_ACL'] ?>" name="config_dbtbl_operators_acl" />
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_dbtbl_operators_acl_files' class='form'><?php echo $l['all']['operators_acl_files']?></label>
+                <label for='config_dbtbl_operators_acl_files' class='form'><?php echo t('all','operators_acl_files')?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_TBL_DALOOPERATORS_ACL_FILES'] ?>" name="config_dbtbl_operators_acl_files" />
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_dbtbl_hotspots' class='form'><?php echo $l['all']['hotspots']?></label>
+                <label for='config_dbtbl_hotspots' class='form'><?php echo t('all','hotspots')?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_TBL_DALOHOTSPOTS'] ?>" name="config_dbtbl_hotspots" />
 		</li>
 		
                 <li class='fieldset'>
-                <label for='config_dbtbl_node' class='form'><?php echo $l['all']['node']?></label>
+                <label for='config_dbtbl_node' class='form'><?php echo t('all','node')?></label>
 		<input value="<?php echo $configValues['CONFIG_DB_TBL_DALONODE'] ?>" name="config_dbtbl_node" />
 		</li>
 
                 <li class='fieldset'>
                 <br/>
                 <hr><br/>
-                <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+                <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
                 </li>
 
                 </ul>

--- a/config-interface.php
+++ b/config-interface.php
@@ -58,11 +58,11 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['configinterface.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','configinterface.php') ?>
 				<h144>+</h144></a></h2>
 
                 <div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['configinterface'] ?>
+					<?php echo t('helpPage','configinterface') ?>
 					<br/>
 				</div>
                 <?php
@@ -73,13 +73,13 @@
 
 	<fieldset>
 
-                <h302> <?php echo $l['title']['Settings']; ?> </h302>
+                <h302> <?php echo t('title','Settings'); ?> </h302>
                 <br/>
 
                 <ul>
 
                 <li class='fieldset'>
-                <label for='config_iface_pass_hidden' class='form'><?php echo $l['all']['PasswordHidden']?></label>
+                <label for='config_iface_pass_hidden' class='form'><?php echo t('all','PasswordHidden')?></label>
 		<select name="config_iface_pass_hidden" class='form'>
 			<option value="<?php echo $configValues['CONFIG_IFACE_PASSWORD_HIDDEN'] ?>"> <?php echo $configValues['CONFIG_IFACE_PASSWORD_HIDDEN'] ?> </option>
 			<option value="">  </option>
@@ -89,12 +89,12 @@
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_iface_tablelisting' class='form'><?php echo $l['all']['TablesListing'] ?></label>
+                <label for='config_iface_tablelisting' class='form'><?php echo t('all','TablesListing') ?></label>
 		<input value="<?php echo $configValues['CONFIG_IFACE_TABLES_LISTING'] ?>" name="config_iface_tableslisting" />
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_iface_tableslisting_num' class='form'><?php echo $l['all']['TablesListingNum'] ?></label>
+                <label for='config_iface_tableslisting_num' class='form'><?php echo t('all','TablesListingNum') ?></label>
 		<select class='form' name="config_iface_tableslisting_num">
 			<option value="<?php echo $configValues['CONFIG_IFACE_TABLES_LISTING_NUM'] ?>"> <?php echo $configValues['CONFIG_IFACE_TABLES_LISTING_NUM'] ?> </option>
 			<option value="">  </option>
@@ -104,7 +104,7 @@
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_iface_auto_complete' class='form'><?php echo $l['all']['AjaxAutoComplete'] ?></label>
+                <label for='config_iface_auto_complete' class='form'><?php echo t('all','AjaxAutoComplete') ?></label>
 		<select class='form' name="config_iface_auto_complete">
 			<option value="<?php echo $configValues['CONFIG_IFACE_AUTO_COMPLETE'] ?>"> <?php echo $configValues['CONFIG_IFACE_AUTO_COMPLETE'] ?> </option>
 			<option value="">  </option>
@@ -116,7 +116,7 @@
                 <li class='fieldset'>
                 <br/>
                 <hr><br/>
-                <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+                <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
                 </li>
 
                 </ul>

--- a/config-lang.php
+++ b/config-lang.php
@@ -53,10 +53,10 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['configlang.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','configlang.php') ?>
 				<h144>+</h144></a></h2>
                 <div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['configlang'] ?>
+					<?php echo t('helpPage','configlang') ?>
 					<br/>
 				</div>
                 <?php
@@ -67,14 +67,14 @@
 
         <fieldset>
 
-                <h302> <?php echo $l['title']['Settings']; ?> </h302>
+                <h302> <?php echo t('title','Settings'); ?> </h302>
                 <br/>
 
                 <ul>
 
 
                 <li class='fieldset'>
-                <label for='config_lan' class='form'><?php echo $l['all']['PrimaryLanguage']?></label>
+                <label for='config_lan' class='form'><?php echo t('all','PrimaryLanguage')?></label>
 		<select name="config_lang" class='form'>
 			<option value="en"> English </option>
 			<option value="ru"> Russian </option>
@@ -89,7 +89,7 @@
                 <li class='fieldset'>
                 <br/>
                 <hr><br/>
-                <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+                <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
                 </li>
 
                 </ul>

--- a/config-logging.php
+++ b/config-logging.php
@@ -64,10 +64,10 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['configlogging.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','configlogging.php') ?>
 				<h144>+</h144></a></h2>
                 <div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['configlogging'] ?>
+					<?php echo t('helpPage','configlogging') ?>
 					<br/>
 				</div>
                 <?php
@@ -79,13 +79,13 @@
 
         <fieldset>
 
-                <h302> <?php echo $l['title']['Settings']; ?> </h302>
+                <h302> <?php echo t('title','Settings'); ?> </h302>
 		<br/>
 
                 <ul>
 
                 <li class='fieldset'>
-                <label for='config_pageslogging' class='form'><?php echo $l['all']['PagesLogging'] ?></label>
+                <label for='config_pageslogging' class='form'><?php echo t('all','PagesLogging') ?></label>
 		<select class='form' name="config_pageslogging">
 			<option value="<?php echo $configValues['CONFIG_LOG_PAGES'] ?>"> <?php echo $configValues['CONFIG_LOG_PAGES'] ?> </option>
 			<option value="">  </option>
@@ -95,7 +95,7 @@
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_querieslogging' class='form'><?php echo $l['all']['QueriesLogging'] ?></label>
+                <label for='config_querieslogging' class='form'><?php echo t('all','QueriesLogging') ?></label>
 		<select class='form' name="config_querieslogging">
 			<option value="<?php echo $configValues['CONFIG_LOG_QUERIES'] ?>"> <?php echo $configValues['CONFIG_LOG_QUERIES'] ?> </option>
 			<option value="">  </option>
@@ -105,7 +105,7 @@
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_actionslogging' class='form'><?php echo $l['all']['ActionsLogging'] ?></label>
+                <label for='config_actionslogging' class='form'><?php echo t('all','ActionsLogging') ?></label>
 		<select class='form' name="config_actionslogging">
 			<option value="<?php echo $configValues['CONFIG_LOG_ACTIONS'] ?>"> <?php echo $configValues['CONFIG_LOG_ACTIONS'] ?> </option>
 			<option value="">  </option>
@@ -115,7 +115,7 @@
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_debuglogging' class='form'><?php echo $l['all']['LoggingDebugInfo'] ?></label>
+                <label for='config_debuglogging' class='form'><?php echo t('all','LoggingDebugInfo') ?></label>
 		<select class='form' name="config_debuglogging">
 			<option value="<?php echo $configValues['CONFIG_DEBUG_SQL'] ?>"> <?php echo $configValues['CONFIG_DEBUG_SQL'] ?> </option>
 			<option value="">  </option>
@@ -125,7 +125,7 @@
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_debugpageslogging' class='form'><?php echo $l['all']['LoggingDebugOnPages'] ?></label>
+                <label for='config_debugpageslogging' class='form'><?php echo t('all','LoggingDebugOnPages') ?></label>
 		<select class='form' name="config_debugpageslogging">
 			<option value="<?php echo $configValues['CONFIG_DEBUG_SQL_ONPAGE'] ?>"> <?php echo $configValues['CONFIG_DEBUG_SQL_ONPAGE'] ?> </option>
 			<option value="">  </option>
@@ -135,7 +135,7 @@
 		</li>
 
                 <li class='fieldset'>
-                <label for='config_filenamelogging' class='form'><?php echo $l['all']['FilenameLogging'] ?></label>
+                <label for='config_filenamelogging' class='form'><?php echo t('all','FilenameLogging') ?></label>
 		<input value="<?php echo $configValues['CONFIG_LOG_FILE'] ?>" name="config_filenamelogging" />
 		</li>
 
@@ -143,7 +143,7 @@
                 <li class='fieldset'>
                 <br/>
                 <hr><br/>
-                <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+                <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
                 </li>
 
                 </ul>

--- a/config-mail.php
+++ b/config-mail.php
@@ -60,11 +60,11 @@
 			
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['configmail.php']; ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','configmail.php'); ?>
 				<h144>+</h144></a></h2>
 
                 <div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['configmail'] ?>
+					<?php echo t('helpPage','configmail') ?>
 					<br/>
 				</div>
                 <?php
@@ -75,27 +75,27 @@
 
 <div class="tabber">
 
-     <div class="tabbertab" title="<?php echo $l['title']['Settings']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','Settings'); ?>">
 
         <fieldset>
 
-                <h302><?php echo $l['title']['Settings']; ?></h302>
+                <h302><?php echo t('title','Settings'); ?></h302>
 		<br/>
 
 		<ul>
 
 		<li class='fieldset'>
-		<label for='config_mail_smtpaddr' class='form'><?php echo $l['all']['SMTPServerAddress'] ?></label>
+		<label for='config_mail_smtpaddr' class='form'><?php echo t('all','SMTPServerAddress') ?></label>
 		<input type='text' value="<?php echo $configValues['CONFIG_MAIL_SMTPADDR'] ?>" name="config_mail_smtpaddr" />
 		</li>
 
 		<li class='fieldset'>
-		<label for='config_mail_smtpport' class='form'><?php echo $l['all']['SMTPServerPort'] ?></label>
+		<label for='config_mail_smtpport' class='form'><?php echo t('all','SMTPServerPort') ?></label>
 		<input type='text' value="<?php echo $configValues['CONFIG_MAIL_SMTPPORT'] ?>" name="config_mail_smtpport" />
 		</li>
 
 		<li class='fieldset'>
-		<label for='config_mail_smtp_fromemail' class='form'><?php echo $l['all']['SMTPServerFromEmail'] ?></label>
+		<label for='config_mail_smtp_fromemail' class='form'><?php echo t('all','SMTPServerFromEmail') ?></label>
 		<input type='text' value="<?php echo $configValues['CONFIG_MAIL_SMTPFROM'] ?>" name="config_mail_smtp_fromemail" />
 		</li>
 
@@ -103,7 +103,7 @@
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 		</li>
 
 		</ul>

--- a/config-main.php
+++ b/config-main.php
@@ -39,11 +39,11 @@
 		
 		<div id="contentnorightbar">
 		
-			<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['configmain.php'] ?>
+			<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','configmain.php') ?>
 			<h144>+</h144></a></h2>
                 
 				<div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['configmain'] ?>
+					<?php echo t('helpPage','configmain') ?>
 					<br/>
 				</div>
 				<br/>

--- a/config-maint-disconnect-user.php
+++ b/config-maint-disconnect-user.php
@@ -98,11 +98,11 @@
 		
 		<div id="contentnorightbar">
 		
-			<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['configmaintdisconnectuser.php'] ?>
+			<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','configmaintdisconnectuser.php') ?>
 			<h144>+</h144> </a></h2>
 
 			<div id="helpPage" style="display:none;visibility:visible" >
-				<?php echo $l['helpPage']['configmaintdisconnectuser'] ?>
+				<?php echo t('helpPage','configmaintdisconnectuser') ?>
 				<br/>
 			</div>
 		<?php
@@ -113,7 +113,7 @@
 
 <div class="tabber">
 
-     <div class="tabbertab" title="<?php echo $l['title']['Settings']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','Settings'); ?>">
 
 
 	<fieldset>
@@ -121,20 +121,20 @@
 		<h302> Settings </h302>
 		<br/>
 
-                <label for='username' class='form'><?php echo $l['all']['Username']?></label>
+                <label for='username' class='form'><?php echo t('all','Username')?></label>
                 <input name="username" type="text" id="usernameEdit" autocomplete="off"
 				onClick='javascript:__displayTooltip();' 
-				tooltipText='<?php echo $l['Tooltip']['Username']; ?> <br/>'
+				tooltipText='<?php echo t('Tooltip','Username'); ?> <br/>'
 				value="<?php if (isset($username)) echo $username; ?>" tabindex=100>
 		 <br />
-		<label for='packettype' class='form'><?php echo $l['all']['PacketType'] ?></label>
+		<label for='packettype' class='form'><?php echo t('all','PacketType') ?></label>
                 <select name='packettype' id='packettype' class='form' tabindex=101 >
 			<option value="disconnect"> PoD - Packet of Disconnect </option>
 			<option value="coa"> CoA - Change of Authorization &nbsp;</option>
                 </select>
                 <br/>
 
-                <label for='nasaddr' class='form'><?php echo $l['all']['NasIPHost'] ?></label>
+                <label for='nasaddr' class='form'><?php echo t('all','NasIPHost') ?></label>
                 <input name='nasaddr' type='hidden' id='nasaddr' value='<?php echo $nasaddr ?>' tabindex=102 />
 
 		<select onChange="javascript:setStringTextMulti(this.id,'nasaddr','nassecret')" id='naslist' tabindex=103 
@@ -181,7 +181,7 @@
                 <br/>
 
                 <input name='nassecret' type='hidden' type='hidden' id='nassecret' value='' tabindex=104 />
-                <label for='nasport' class='form'><?php echo $l['all']['NasPorts'] ?></label>
+                <label for='nasport' class='form'><?php echo t('all','NasPorts') ?></label>
                 <input name='nasport' type='hidden' id='nasport' value='3799' tabindex=106 />
 		<select onChange="javascript:setStringText(this.id,'nasport')" id='nasportlist' tabindex=107 
 			class='form'>
@@ -191,7 +191,7 @@
 		</select>
                 <br/>
 
-		<label for='customattributes' class='form'><?php echo $l['all']['customAttributes'] ?></label>
+		<label for='customattributes' class='form'><?php echo t('all','customAttributes') ?></label>
 		<textarea class='form' name='customattributes'><?php echo $customAttributes; ?></textarea>
 
 
@@ -199,46 +199,46 @@
                 <br/><br/>
                 <hr><br/>
 
-                <input type='submit' name='submit' value='<?php echo $l['button']['DisconnectUser'] ?>' class='button' />
+                <input type='submit' name='submit' value='<?php echo t('button','DisconnectUser') ?>' class='button' />
 
         </fieldset>
 
 	</div>
 
 
-     <div class="tabbertab" title="<?php echo $l['title']['Advanced']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','Advanced'); ?>">
 
         <fieldset>
 
                 <h302> Advanced </h302>
                 <br/>
 
-                <label for='debug' class='form'><?php echo $l['all']['Debug'] ?></label>
+                <label for='debug' class='form'><?php echo t('all','Debug') ?></label>
                 <select name='debug' id='debug' class='form' tabindex=106 >
                         <option value="yes"> Yes </option>
                         <option value="no"> No </option>
                 </select>
                 <br/>
 
-                <label for='timeout' class='form'><?php echo $l['all']['Timeout'] ?></label>
+                <label for='timeout' class='form'><?php echo t('all','Timeout') ?></label>
                 <input class="integer" name='timeout' type='text' id='timeout' value='3' tabindex=107 />
                 <img src="images/icons/bullet_arrow_up.png" alt="+" onclick="javascript:changeInteger('timeout','increment')" />
                 <img src="images/icons/bullet_arrow_down.png" alt="-" onclick="javascript:changeInteger('timeout','decrement')"/>   
                 <br/>
 
-                <label for='retries' class='form'><?php echo $l['all']['Retries'] ?></label>
+                <label for='retries' class='form'><?php echo t('all','Retries') ?></label>
                 <input class="integer" name='retries' type='text' id='retries' value='3' tabindex=108 />
                 <img src="images/icons/bullet_arrow_up.png" alt="+" onclick="javascript:changeInteger('retries','increment')" />
                 <img src="images/icons/bullet_arrow_down.png" alt="-" onclick="javascript:changeInteger('retries','decrement')"/>   
                 <br/>
 
-                <label for='count' class='form'><?php echo $l['all']['Count'] ?></label>
+                <label for='count' class='form'><?php echo t('all','Count') ?></label>
                 <input class="integer" name='count' type='text' id='count' value='1' tabindex=109 />
                 <img src="images/icons/bullet_arrow_up.png" alt="+" onclick="javascript:changeInteger('count','increment')" />
                 <img src="images/icons/bullet_arrow_down.png" alt="-" onclick="javascript:changeInteger('count','decrement')"/>   
                 <br/>
 
-                <label for='requests' class='form'><?php echo $l['all']['Requests'] ?></label>
+                <label for='requests' class='form'><?php echo t('all','Requests') ?></label>
                 <input class="integer" name='requests' type='text' id='requests' value='3' tabindex=110 />
                 <img src="images/icons/bullet_arrow_up.png" alt="+" onclick="javascript:changeInteger('requests','increment')" />
                 <img src="images/icons/bullet_arrow_down.png" alt="-" onclick="javascript:changeInteger('requests','decrement')"/>   
@@ -247,7 +247,7 @@
                 <br/><br/>
                 <hr><br/>
 
-                <input type='submit' name='submit' value='<?php echo $l['button']['DisconnectUser'] ?>' class='button' />
+                <input type='submit' name='submit' value='<?php echo t('button','DisconnectUser') ?>' class='button' />
 
         </fieldset>
 

--- a/config-maint-test-user.php
+++ b/config-maint-test-user.php
@@ -83,11 +83,11 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['configmainttestuser.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','configmainttestuser.php') ?>
 				<h144>+</h144> </a></h2>
 
 		                <div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['configmainttestuser'] ?>
+					<?php echo t('helpPage','configmainttestuser') ?>
 					<br/>
 				</div>
                 <?php
@@ -98,38 +98,38 @@
 
 <div class="tabber">
 
-     <div class="tabbertab" title="<?php echo $l['title']['Settings']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','Settings'); ?>">
 
         <fieldset>
 
                 <h302> Test User Connectivity </h302>
                 <br/>
 
-                <label for='username' class='form'><?php echo $l['all']['Username']?></label>
+                <label for='username' class='form'><?php echo t('all','Username')?></label>
                 <input name='username' type='text' id='username' value='<?php echo $username ?>' tabindex=100 />
                 <br />
 
 
-                <label for='password' class='form'><?php echo $l['all']['Password']?></label>
+                <label for='password' class='form'><?php echo t('all','Password')?></label>
                 <input name='password' type='text' id='password' value='<?php echo $password ?>' tabindex=101 />
                 <br />
 
-                <label for='radius' class='form'><?php echo $l['all']['RadiusServer'] ?>
+                <label for='radius' class='form'><?php echo t('all','RadiusServer') ?>
 			</label>
                 <input name='radius' type='text' id='radius' value='<?php echo $radius ?>' tabindex=102 />
                 <br />
 
-                <label for='radiusport' class='form'><?php echo $l['all']['RadiusPort'] ?>
+                <label for='radiusport' class='form'><?php echo t('all','RadiusPort') ?>
 			</label>
                 <input name='radiusport' type='text' id='radiusport' value='<?php echo $radiusport ?>' tabindex=103 />
                 <br />
 
-                <label for='nasport' class='form'><?php echo $l['all']['NasPorts'] ?>
+                <label for='nasport' class='form'><?php echo t('all','NasPorts') ?>
 			</label>
                 <input name='nasport' type='text' id='nasport' value='<?php echo $nasport ?>' tabindex=104 />
                 <br />
 
-                <label for='secret' class='form'><?php echo $l['all']['NasSecret'] ?>
+                <label for='secret' class='form'><?php echo t('all','NasSecret') ?>
 			</label>
                 <input name='secret' type='text' id='secret' value='<?php echo $secret ?>' tabindex=105 />
                 <br />
@@ -144,45 +144,45 @@
 	</div>
 
 
-     <div class="tabbertab" title="<?php echo $l['title']['Advanced']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','Advanced'); ?>">
 
 	<fieldset>
 
                 <h302> Advanced </h302>
                 <br/>
 
-                <label for='debug' class='form'><?php echo $l['all']['Debug'] ?></label>
+                <label for='debug' class='form'><?php echo t('all','Debug') ?></label>
                 <select name='debug' id='debug' class='form' tabindex=106 >
                         <option value="yes"> Yes </option>
                         <option value="no"> No </option>
                 </select>
                 <br/>
 
-                <label for='timeout' class='form'><?php echo $l['all']['Timeout'] ?></label>
+                <label for='timeout' class='form'><?php echo t('all','Timeout') ?></label>
                 <input class="integer" name='timeout' type='text' id='timeout' value='3' tabindex=107 />
                 <img src="images/icons/bullet_arrow_up.png" alt="+" onclick="javascript:changeInteger('timeout','increment')" />
                 <img src="images/icons/bullet_arrow_down.png" alt="-" onclick="javascript:changeInteger('timeout','decrement')"/>
                 <br/>
 
-                <label for='retries' class='form'><?php echo $l['all']['Retries'] ?></label>
+                <label for='retries' class='form'><?php echo t('all','Retries') ?></label>
                 <input class="integer" name='retries' type='text' id='retries' value='3' tabindex=108 />
                 <img src="images/icons/bullet_arrow_up.png" alt="+" onclick="javascript:changeInteger('retries','increment')" />
                 <img src="images/icons/bullet_arrow_down.png" alt="-" onclick="javascript:changeInteger('retries','decrement')"/>
                 <br/>
 
-                <label for='count' class='form'><?php echo $l['all']['Count'] ?></label>
+                <label for='count' class='form'><?php echo t('all','Count') ?></label>
                 <input class="integer" name='count' type='text' id='count' value='1' tabindex=109 />
                 <img src="images/icons/bullet_arrow_up.png" alt="+" onclick="javascript:changeInteger('count','increment')" />
                 <img src="images/icons/bullet_arrow_down.png" alt="-" onclick="javascript:changeInteger('count','decrement')"/>
                 <br/>
 
-                <label for='requests' class='form'><?php echo $l['all']['Requests'] ?></label>
+                <label for='requests' class='form'><?php echo t('all','Requests') ?></label>
                 <input class="integer" name='requests' type='text' id='requests' value='3' tabindex=110 />
                 <img src="images/icons/bullet_arrow_up.png" alt="+" onclick="javascript:changeInteger('requests','increment')" />
                 <img src="images/icons/bullet_arrow_down.png" alt="-" onclick="javascript:changeInteger('requests','decrement')"/>
                 <br/>
 
-                <label for='dictionaryPath' class='form'><?php echo $l['all']['RADIUSDictionaryPath'] ?></label>
+                <label for='dictionaryPath' class='form'><?php echo t('all','RADIUSDictionaryPath') ?></label>
                 <input name='dictionaryPath' type='text' id='dictionaryPath' value='<?php echo $dictionaryPath ?>' tabindex=111 />
                 <br />
 

--- a/config-maint.php
+++ b/config-maint.php
@@ -37,11 +37,11 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['configmaint.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','configmaint.php') ?>
 				<h144>+</h144></a></h2>
                 
 				<div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['configmaint'] ?>
+					<?php echo t('helpPage','configmaint') ?>
 					<br/>
 				</div>
 				<br/>

--- a/config-operators-del.php
+++ b/config-operators-del.php
@@ -107,11 +107,11 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['configoperatorsdel.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','configoperatorsdel.php') ?>
 				<h144>+</h144></a></h2>
 				
                 <div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['configoperatorsdel'] ?>
+					<?php echo t('helpPage','configoperatorsdel') ?>
 					<br/>
 				</div>
                 <?php
@@ -134,7 +134,7 @@
                 <br/><br/>
                 <hr><br/>
 
-                <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+                <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 
 	</fieldset>
 

--- a/config-operators-edit.php
+++ b/config-operators-edit.php
@@ -197,11 +197,11 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['configoperatorsedit.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','configoperatorsedit.php') ?>
 				<h144>+</h144></a></h2>
 				
                 <div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['configoperatorsedit'] ?>
+					<?php echo t('helpPage','configoperatorsedit') ?>
 					<br/>
 				</div>
                 <?php
@@ -234,7 +234,7 @@
                 <br/><br/>
                 <hr><br/>
 
-                <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+                <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 
 	</fieldset>
 
@@ -260,7 +260,7 @@
 	<br/><br/>
 	<hr><br/>
 
-	<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+	<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 	</fieldset>
 	
 	</div>

--- a/config-operators-list.php
+++ b/config-operators-list.php
@@ -58,11 +58,11 @@
 
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['configoperatorslist.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','configoperatorslist.php') ?>
 				<h144>+</h144></a></h2>
 				
                 <div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['configoperatorslist'] ?>
+					<?php echo t('helpPage','configoperatorslist') ?>
 					<br/>
 				</div>
 				<br/>
@@ -122,21 +122,21 @@
 		<th scope='col'>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=id&orderType=asc\">
 			<img src='images/icons/arrow_up.png' alt='>' border='0' /></a>
-		".$l['all']['ID']. " 
+		".t('all','ID'). " 
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=id&orderType=desc\">
 			<img src='images/icons/arrow_down.png' alt='<' border='0' /></a>
 		</th>
 		<th scope='col'>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=Username&orderType=asc\">
 			<img src='images/icons/arrow_up.png' alt='>' border='0' /></a>
-		".$l['all']['Username']." 
+		".t('all','Username')." 
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=Username&orderType=desc\">
 			<img src='images/icons/arrow_down.png' alt='<' border='0' /></a>
 		</th>
 		<th scope='col'>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=Value&orderType=asc\">
 			<img src='images/icons/arrow_up.png' alt='>' border='0' /></a>
-		".$l['all']['Password']." 
+		".t('all','Password')." 
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=Value&orderType=desc\">
 			<img src='images/icons/arrow_down.png' alt='<' border='0' /></a>
 		</th>
@@ -167,7 +167,7 @@
 		echo "<tr>
 			<td> <input type='checkbox' name='operator_username[]' value='$row[1]'>$row[0]</td>
 			<td> <a class='tablenovisit' href='config-operators-edit.php?operator_username=$row[1]' title='".
-			$l['Tooltip']['UserEdit']."'>$row[1]</a> </td>
+			t('Tooltip','UserEdit')."'>$row[1]</a> </td>
 			";
                 if ($configValues['CONFIG_IFACE_PASSWORD_HIDDEN'] == "yes") {
                         echo "<td>[Password is hidden]</td>";

--- a/config-operators-new.php
+++ b/config-operators-new.php
@@ -177,11 +177,11 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['configoperatorsnew.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','configoperatorsnew.php') ?>
 				<h144>+</h144></a></h2>
 				
                 <div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['configoperatorsnew'] ?>
+					<?php echo t('helpPage','configoperatorsnew') ?>
 					<br/>
 				</div>
                 <?php
@@ -214,7 +214,7 @@
                 <br/><br/>
                 <hr><br/>
 
-                <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+                <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 
 	</fieldset>
 
@@ -238,7 +238,7 @@
 	<br/><br/>
 	<hr><br/>
 	
-	<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+	<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 	</fieldset>
 	</div>
 	

--- a/config-operators.php
+++ b/config-operators.php
@@ -36,10 +36,10 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['configoperators.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','configoperators.php') ?>
 				<h144>+</h144></a></h2>
 					<div id="helpPage" style="display:none;visibility:visible" >
-						<?php echo $l['helpPage']['configoperators'] ?>
+						<?php echo t('helpPage','configoperators') ?>
 						<br/>
 					</div>
                 <?php

--- a/config-reports-dashboard.php
+++ b/config-reports-dashboard.php
@@ -57,11 +57,11 @@
 			
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['configdashboard.php']; ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','configdashboard.php'); ?>
 				<h144>+</h144></a></h2>
 
                 <div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['configdashboard'] ?>
+					<?php echo t('helpPage','configdashboard') ?>
 					<br/>
 				</div>
                 <?php
@@ -72,22 +72,22 @@
 
 <div class="tabber">
 
-     <div class="tabbertab" title="<?php echo $l['title']['Dashboard']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','Dashboard'); ?>">
 
         <fieldset>
 
-                <h302><?php echo $l['title']['Settings']; ?></h302>
+                <h302><?php echo t('title','Settings'); ?></h302>
 		<br/>
 
 		<ul>
 
 		<li class='fieldset'>
-		<label for='config_dashboard_dalo_secretkey' class='form'><?php echo $l['all']['DashboardSecretKey'] ?></label>
+		<label for='config_dashboard_dalo_secretkey' class='form'><?php echo t('all','DashboardSecretKey') ?></label>
 		<input type='text' value="<?php echo $configValues['CONFIG_DASHBOARD_DALO_SECRETKEY'] ?>" name="config_dashboard_dalo_secretkey" />
 		</li>
 
 		<li class='fieldset'>
-		<label for='config_dashboard_dalo_debug' class='form'><?php echo $l['all']['DashboardDebug']?></label>
+		<label for='config_dashboard_dalo_debug' class='form'><?php echo t('all','DashboardDebug')?></label>
 		<select class='form' name="config_dashboard_dalo_debug">
 			<option value="<?php echo $configValues['CONFIG_DASHBOARD_DALO_DEBUG'] ?>"> <?php echo $configValues['CONFIG_DASHBOARD_DALO_DEBUG'] ?> </option>
 			<option value=""></option>
@@ -99,7 +99,7 @@
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 		</li>
 		
 		</ul>
@@ -109,29 +109,29 @@
 	</div>
 
 
-     <div class="tabbertab" title="<?php echo $l['title']['Settings']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','Settings'); ?>">
 
         <fieldset>
 
-                <h302><?php echo $l['title']['Settings']; ?></h302>
+                <h302><?php echo t('title','Settings'); ?></h302>
 		<br/>
 		
 		<ul>
 		
 		<li class='fieldset'>
-		<label for='config_dashboard_dalo_delay_soft' class='form'><?php echo $l['all']['DashboardDelaySoft'] ?></label>
+		<label for='config_dashboard_dalo_delay_soft' class='form'><?php echo t('all','DashboardDelaySoft') ?></label>
 		<input type='text' value="<?php echo $configValues['CONFIG_DASHBOARD_DALO_DELAYSOFT'] ?>" name="config_dashboard_dalo_delay_soft" />
 		</li>
 		
 		<li class='fieldset'>
-		<label for='config_dashboard_dalo_delay_hard' class='form'><?php echo $l['all']['DashboardDelayHard'] ?></label>
+		<label for='config_dashboard_dalo_delay_hard' class='form'><?php echo t('all','DashboardDelayHard') ?></label>
 		<input type='text' value="<?php echo $configValues['CONFIG_DASHBOARD_DALO_DELAYHARD'] ?>" name="config_dashboard_dalo_delay_hard" />
 		</li>
 
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 		</li>
 
 		</ul>

--- a/config-reports.php
+++ b/config-reports.php
@@ -39,11 +39,11 @@
 		
 		<div id="contentnorightbar">
 		
-			<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['configmain.php'] ?>
+			<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','configmain.php') ?>
 			<h144>+</h144></a></h2>
                 
 				<div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['configmain'] ?>
+					<?php echo t('helpPage','configmain') ?>
 					<br/>
 				</div>
 				<br/>

--- a/config-user.php
+++ b/config-user.php
@@ -61,11 +61,11 @@
 			
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['configuser.php']; ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','configuser.php'); ?>
 				<h144>+</h144></a></h2>
 
                 <div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['configuser'] ?>
+					<?php echo t('helpPage','configuser') ?>
 					<br/>
 				</div>
                 <?php
@@ -76,17 +76,17 @@
 
 <div class="tabber">
 
-     <div class="tabbertab" title="<?php echo $l['title']['Settings']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','Settings'); ?>">
 
         <fieldset>
 
-                <h302><?php echo $l['title']['Settings']; ?></h302>
+                <h302><?php echo t('title','Settings'); ?></h302>
 		<br/>
 
 		<ul>
 
 		<li class='fieldset'>
-		<label for='' class='form'><?php echo $l['all']['DBPasswordEncryption']?></label>
+		<label for='' class='form'><?php echo t('all','DBPasswordEncryption')?></label>
 		<select class='form' name="config_db_pass_encrypt">
 			<option value="<?php echo $configValues['CONFIG_DB_PASSWORD_ENCRYPTION'] ?>"> <?php echo $configValues['CONFIG_DB_PASSWORD_ENCRYPTION'] ?> </option>
 			<option value=""></option>
@@ -98,7 +98,7 @@
 		
 
 		<li class='fieldset'>
-		<label for='config_user_allowedrandomchars' class='form'><?php echo $l['all']['RandomChars'] ?></label>
+		<label for='config_user_allowedrandomchars' class='form'><?php echo t('all','RandomChars') ?></label>
 		<input type='text' value="<?php echo htmlentities($configValues['CONFIG_USER_ALLOWEDRANDOMCHARS']) ?>" name="config_user_allowedrandomchars" />
 		</li>
 
@@ -109,7 +109,7 @@
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 		</li>
 
 		</ul>

--- a/daloradius-users/acct-date.php
+++ b/daloradius-users/acct-date.php
@@ -53,11 +53,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctdate.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','acctdate.php'); ?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['acctdate'] ?>
+			<?php echo t('helpPage','acctdate') ?>
 			<br/>
 		</div>
 		<br/>
@@ -135,57 +135,57 @@
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&startdate=$startdate&enddate=$enddate&orderBy=radacctid&orderType=$orderType\">
-		".$l['all']['ID']."</a>
+		".t('all','ID')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&startdate=$startdate&enddate=$enddate&orderBy=hotspot&orderType=$orderType\">
-		".$l['all']['HotSpot']."</a>
+		".t('all','HotSpot')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&startdate=$startdate&enddate=$enddate&orderBy=username&orderType=$orderType\">
-		".$l['all']['Username']."</a>
+		".t('all','Username')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&startdate=$startdate&enddate=$enddate&orderBy=framedipaddress&orderType=$orderType\">
-		".$l['all']['IPAddress']."</a>
+		".t('all','IPAddress')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&startdate=$startdate&enddate=$enddate&orderBy=acctstarttime&orderType=$orderType\">
-		".$l['all']['StartTime']."</a>
+		".t('all','StartTime')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&startdate=$startdate&enddate=$enddate&orderBy=acctstoptime&orderType=$orderType\">
-		".$l['all']['StopTime']."</a>
+		".t('all','StopTime')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&startdate=$startdate&enddate=$enddate&orderBy=acctsessiontime&orderType=$orderType\">
-		".$l['all']['TotalTime']."</a>
+		".t('all','TotalTime')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&startdate=$startdate&enddate=$enddate&orderBy=acctinputoctets&orderType=$orderType\">
-		".$l['all']['Upload']." (".$l['all']['Bytes'].")</a>
+		".t('all','Upload')." (".t('all','Bytes').")</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&startdate=$startdate&enddate=$enddate&orderBy=acctoutputoctets&orderType=$orderType\">
-		".$l['all']['Download']." (".$l['all']['Bytes'].")</a>
+		".t('all','Download')." (".t('all','Bytes').")</a>
 		</th>
 		<th scope='col'>
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&startdate=$startdate&enddate=$enddate&orderBy=acctterminatecause&orderType=$orderType\">
-		 ".$l['all']['Termination']."</a>
+		 ".t('all','Termination')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&startdate=$startdate&enddate=$enddate&orderBy=nasipaddress&orderType=$orderType\">
-		".$l['all']['NASIPAddress']."</a>
+		".t('all','NASIPAddress')."</a>
 		</th>
                 </tr> </thread>";
 

--- a/daloradius-users/acct-main.php
+++ b/daloradius-users/acct-main.php
@@ -34,11 +34,11 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['acctmain.php'];?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','acctmain.php');?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['acctmain'] ?>
+			<?php echo t('helpPage','acctmain') ?>
 			<br/>
 		</div>
 		<br/>

--- a/daloradius-users/bill-invoice-report.php
+++ b/daloradius-users/bill-invoice-report.php
@@ -63,11 +63,11 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billinvoicereport.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','billinvoicereport.php') ?>
 				<h144>+</h144></a></h2>
 				
 				<div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['billinvoicelist'] ?>
+					<?php echo t('helpPage','billinvoicelist') ?>
 					<br/>
 				</div>
 				<br/>
@@ -167,31 +167,31 @@
 	echo "<thread> <tr>
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=id&orderType=$orderTypeNextPage\">
-		".$l['all']['Invoice']."</a>
+		".t('all','Invoice')."</a>
 		</th>
 
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=date&orderType=$orderTypeNextPage\">
-		".$l['all']['Date']."</a>
+		".t('all','Date')."</a>
 		</th>
 		
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=totalbilled&orderType=$orderTypeNextPage\">
-		".$l['all']['TotalBilled']."</a>
+		".t('all','TotalBilled')."</a>
 		</th>
 		
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=totalpayed&orderType=$orderTypeNextPage\">
-		".$l['all']['TotalPayed']."</a>
+		".t('all','TotalPayed')."</a>
 		</th>
 		
 		<th scope='col'> 
-		".$l['all']['Balance']."
+		".t('all','Balance')."
 		</th>
 		
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=status_id&orderType=$orderTypeNextPage\">
-		".$l['all']['Status']."</a>
+		".t('all','Status')."</a>
 		</th>
 		
 	</tr> </thread>";

--- a/daloradius-users/bill-invoice-show.php
+++ b/daloradius-users/bill-invoice-show.php
@@ -115,11 +115,11 @@
 
 <div id="contentnorightbar">
 
-	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billinvoiceedit.php'] ?>
+	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','billinvoiceedit.php') ?>
 	<h144>+</h144></a></h2>
 	
 	<div id="helpPage" style="display:none;visibility:visible" >
-		<?php echo $l['helpPage']['billinvoicesedit'] ?>
+		<?php echo t('helpPage','billinvoicesedit') ?>
 		<br/>
 	</div>
 	<?php
@@ -128,11 +128,11 @@
 
 	<form action="<?php echo $_SERVER['PHP_SELF']; ?>" method="post">
 
-	<div class="tabbertab" title="<?php echo $l['title']['Invoice']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','Invoice'); ?>">
 	<fieldset>
 
 		<h2> Invoice Details </h2>
-		<h302> <?php echo $l['title']['Invoice']; ?> </h302>
+		<h302> <?php echo t('title','Invoice'); ?> </h302>
 
 		<ul>
 
@@ -144,38 +144,38 @@
 		<br/><br/>
 
 		<li class='fieldset'>
-		<label for='' class='form'><?php echo $l['all']['TotalBilled']?></label>
+		<label for='' class='form'><?php echo t('all','TotalBilled')?></label>
 		<input name='' type='text' disabled id='' value='<?php echo $invoiceDetails['totalbilled']?>' tabindex=101 />
 		</li>
 		
 		<li class='fieldset'>
-		<label for='' class='form'><?php echo $l['all']['TotalPayed']?></label>
+		<label for='' class='form'><?php echo t('all','TotalPayed')?></label>
 		<input name='' type='text' disabled id='' value='<?php echo $invoiceDetails['totalpayed']?>' tabindex=101 />
 		</li>
 		
 		<li class='fieldset'>
-		<label for='' class='form'><?php echo $l['all']['Balance']?></label>
+		<label for='' class='form'><?php echo t('all','Balance')?></label>
 		<input name='' type='text' disabled id='' value='<?php echo (float) ($invoiceDetails['totalpayed'] - $invoiceDetails['totalbilled'])?>' tabindex=101 />
 		</li>
 		
 		<li class='fieldset'>
-		<label for='' class='form'><?php echo $l['all']['InvoiceStatus']?></label>
+		<label for='' class='form'><?php echo t('all','InvoiceStatus')?></label>
 		<input name='' type='text' disabled id='' value='<?php echo $invoiceDetails['status']?>' tabindex=101 />
 		</li>
 		
 		<li class='fieldset'>
-		<label for='' class='form'><?php echo $l['all']['InvoiceType']?></label>
+		<label for='' class='form'><?php echo t('all','InvoiceType')?></label>
 		<input name='' type='text' disabled id='' value='<?php echo $invoiceDetails['type']?>' tabindex=101 />
 		</li>
 
 		<br/>
 
-		<label for='invoice_date' class='form'><?php echo $l['all']['Date']?></label>		
+		<label for='invoice_date' class='form'><?php echo t('all','Date')?></label>		
 		<input disabled value='<?php echo $invoiceDetails['date']?>' id='invoice_date' name='invoice_date'  tabindex=108 />
 		<br/>
 
 
-		<label for='invoice_notes' class='form'><?php echo $l['ContactInfo']['Notes']?></label>
+		<label for='invoice_notes' class='form'><?php echo t('ContactInfo','Notes')?></label>
 		<textarea disabled class='form' name='invoice_notes' ><?php echo $invoiceDetails['notes']?></textarea>
 
 		<li class='fieldset'>
@@ -194,11 +194,11 @@
 
 
 			
-	<div class="tabbertab" title="<?php echo $l['title']['Items']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','Items'); ?>">
 	<fieldset>
 
 		<h2> Item Listing </h2>
-		<h302> <?php echo $l['title']['Items']; ?> </h302>
+		<h302> <?php echo t('title','Items'); ?> </h302>
 
 		<input type="hidden" value="0" id="counter" />
 

--- a/daloradius-users/billing-main.php
+++ b/daloradius-users/billing-main.php
@@ -35,11 +35,11 @@
 
 	<div id="contentnorightbar">
 
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['billmain.php'];?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','billmain.php');?>
 		<h144>+</h144></a></h2>
 	
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['billmain'] ?>
+			<?php echo t('helpPage','billmain') ?>
 			<br/>
 		</div>
 		<br/>

--- a/daloradius-users/graph-main.php
+++ b/daloradius-users/graph-main.php
@@ -35,11 +35,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['graphmain.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','graphmain.php'); ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['graphmain'] ?>
+			<?php echo t('helpPage','graphmain') ?>
 			<br/>
 		</div>
 		<br/>

--- a/daloradius-users/graphs-overall_download.php
+++ b/daloradius-users/graphs-overall_download.php
@@ -52,11 +52,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['graphsoveralldownload.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','graphsoveralldownload.php'); ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['graphsoveralldownload'] ?>
+			<?php echo t('helpPage','graphsoveralldownload') ?>
 			<br/>
 		</div>
 		<br/>

--- a/daloradius-users/graphs-overall_logins.php
+++ b/daloradius-users/graphs-overall_logins.php
@@ -53,11 +53,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['graphsoveralllogins.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','graphsoveralllogins.php'); ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['graphsoveralllogins'] ?>
+			<?php echo t('helpPage','graphsoveralllogins') ?>
 			<br/>
 		</div>
 		<br/>

--- a/daloradius-users/graphs-overall_upload.php
+++ b/daloradius-users/graphs-overall_upload.php
@@ -53,11 +53,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['graphsoverallupload.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','graphsoverallupload.php'); ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['graphsoverallupload'] ?>
+			<?php echo t('helpPage','graphsoverallupload') ?>
 			<br/>
 		</div>
 		<br/>

--- a/daloradius-users/include/common/notificationsUserInvoice.php
+++ b/daloradius-users/include/common/notificationsUserInvoice.php
@@ -111,14 +111,14 @@
 		$balance = (float) ($invoiceDetails['totalpayed'] - $invoiceDetails['totalbilled']);
 		$invoice_details = "";
 		$invoice_details .= "".
-		"<b>".$l['all']['ClientName']."</b>: ".$invoiceDetails['contactperson']."<br/>".
-		"<b>".$l['all']['Invoice']."</b>: ".$invoice_id."<br/>".
-		"<b>".$l['all']['Date']."</b>: ".$invoiceDetails['date']."<br/>".
-		"<b>".$l['all']['TotalBilled']."</b>: ".$invoiceDetails['totalbilled']."<br/>".
-		"<b>".$l['all']['TotalPayed']."</b>: ".$invoiceDetails['totalpayed']."<br/>".
-		"<b>".$l['all']['Balance']."</b>: ".$balance."<br/>".
-		"<b>".$l['all']['Status']."</b>: ".$invoiceDetails['status']."<br/>".
-		"<b>".$l['ContactInfo']['Notes']."</b>: ".$invoiceDetails['notes']."<br/><br/><br/>";
+		"<b>".t('all','ClientName')."</b>: ".$invoiceDetails['contactperson']."<br/>".
+		"<b>".t('all','Invoice')."</b>: ".$invoice_id."<br/>".
+		"<b>".t('all','Date')."</b>: ".$invoiceDetails['date']."<br/>".
+		"<b>".t('all','TotalBilled')."</b>: ".$invoiceDetails['totalbilled']."<br/>".
+		"<b>".t('all','TotalPayed')."</b>: ".$invoiceDetails['totalpayed']."<br/>".
+		"<b>".t('all','Balance')."</b>: ".$balance."<br/>".
+		"<b>".t('all','Status')."</b>: ".$invoiceDetails['status']."<br/>".
+		"<b>".t('ContactInfo','Notes')."</b>: ".$invoiceDetails['notes']."<br/><br/><br/>";
 		
 		$customerInfo['invoice_details'] = $invoice_details;
 		

--- a/daloradius-users/include/management/userinfo.php
+++ b/daloradius-users/include/management/userinfo.php
@@ -19,15 +19,15 @@ echo "
 	<h301> Personal </h301>
 	<br/>
 
-	<label for='username' class='form'>".$l['ContactInfo']['FirstName']."</label>
+	<label for='username' class='form'>".t('ContactInfo','FirstName')."</label>
         <input value='"; if (isset($ui_firstname)) echo $ui_firstname; echo "' name='firstname' tabindex=300 />
 	<br/>
 	
-	<label for='lastname' class='form'>".$l['ContactInfo']['LastName']."</label>
+	<label for='lastname' class='form'>".t('ContactInfo','LastName')."</label>
         <input value='"; if (isset($ui_lastname)) echo $ui_lastname; echo "' name='lastname' tabindex=301 />
 	<br/>
 
-	<label for='email' class='form'>".$l['ContactInfo']['Email']."</label>
+	<label for='email' class='form'>".t('ContactInfo','Email')."</label>
         <input value='"; if (isset($ui_email)) echo $ui_email; echo "' name='email' tabindex=302 />
         <br/>
 
@@ -35,43 +35,43 @@ echo "
 	<h301> Business </h301>
 	<br/>
 
-	<label for='department' class='form'>".$l['ContactInfo']['Department']."</label>
+	<label for='department' class='form'>".t('ContactInfo','Department')."</label>
         <input value='"; if (isset($ui_department)) echo $ui_department; echo "' name='department' tabindex=303 />
         <br/>
 
-	<label for='company' class='form'>".$l['ContactInfo']['Company']."</label>
+	<label for='company' class='form'>".t('ContactInfo','Company')."</label>
 	<input value='"; if (isset($ui_company)) echo $ui_company; echo "' name='company' tabindex=304 />
         <br/>
 
-	<label for='workphone' class='form'>".$l['ContactInfo']['WorkPhone']."</label>
+	<label for='workphone' class='form'>".t('ContactInfo','WorkPhone')."</label>
 	<input value='"; if (isset($ui_workphone)) echo $ui_workphone; echo "' name='workphone' tabindex=305 />
         <br/>
 
-	<label for='homephone' class='form'>".$l['ContactInfo']['HomePhone']."</label>
+	<label for='homephone' class='form'>".t('ContactInfo','HomePhone')."</label>
 	<input value='"; if (isset($ui_homephone)) echo $ui_homephone; echo "' name='homephone' tabindex=306 />
         <br/>
 
-	<label for='mobilephone' class='form'>".$l['ContactInfo']['MobilePhone']."</label>
+	<label for='mobilephone' class='form'>".t('ContactInfo','MobilePhone')."</label>
 	<input value='"; if (isset($ui_mobilephone)) echo $ui_mobilephone; echo "' name='mobilephone' tabindex=307 />
         <br/>
 
-        <label for='address' class='form'>".$l['ContactInfo']['Address']."</label>
+        <label for='address' class='form'>".t('ContactInfo','Address')."</label>
         <input value='"; if (isset($ui_address)) echo $ui_address; echo "' name='address' tabindex=308 />
         <br/>
 
-        <label for='city' class='form'>".$l['ContactInfo']['City']."</label>
+        <label for='city' class='form'>".t('ContactInfo','City')."</label>
         <input value='"; if (isset($ui_city)) echo $ui_city; echo "' name='city' tabindex=309 />
         <br/>
 
-        <label for='state' class='form'>".$l['ContactInfo']['State']."</label>
+        <label for='state' class='form'>".t('ContactInfo','State')."</label>
         <input value='"; if (isset($ui_state)) echo $ui_state; echo "' name='state' tabindex=310 />
         <br/>
 
-        <label for='country' class='form'>".$l['ContactInfo']['Country']."</label>
+        <label for='country' class='form'>".t('ContactInfo','Country')."</label>
         <input value='"; if (isset($ui_country)) echo $ui_country; echo "' name='country' tabindex=310 />
         <br/>
         
-        <label for='zip' class='form'>".$l['ContactInfo']['Zip']."</label>
+        <label for='zip' class='form'>".t('ContactInfo','Zip')."</label>
         <input value='"; if (isset($ui_zip)) echo $ui_zip; echo "' name='zip' tabindex=311 />
         <br/>
 
@@ -79,7 +79,7 @@ echo "
 	<br/>
 	<hr><br/>
 
-	<input type='submit' name='submit' value=".$l['buttons']['apply']." class='button' />
+	<input type='submit' name='submit' value=".t('buttons','apply')." class='button' />
 
 </fieldset>
 

--- a/daloradius-users/include/menu/menu-items.php
+++ b/daloradius-users/include/menu/menu-items.php
@@ -8,18 +8,18 @@
 
                                 <h2>
                                 
-                                <?php echo $l['all']['copyright1']; ?>
+                                <?php echo t('all','copyright1'); ?>
                                 
 				                                </h2>
 
                                 <ul id="nav">
 				<a name='top'></a>
 
-				<li><a href="index.php" <?php echo ($m_active == "Home") ? "class=\"active\"" : ""?>><?php echo $l['menu']['Home']; ?></a></li>
-				<li><a href="pref-main.php" <?php echo ($m_active == "Preferences") ? "class=\"active\"" : ""?>><?php echo $l['menu']['Preferences']; ?></li>
-				<li><a href="acct-main.php" <?php echo ($m_active == "Accounting") ? "class=\"active\"" : "" ?>><?php echo $l['menu']['Accounting']; ?></a></li>
-				<li><a href="billing-main.php" <?php echo ($m_active == "Billing") ? "class=\"active\"" : "" ?>><?php echo $l['menu']['Billing']; ?></a></li>
-				<li><a href="graph-main.php" <?php echo ($m_active == "Graphs") ? "class=\"active\"" : ""?>><?php echo $l['menu']['Graphs']; ?></li>
+				<li><a href="index.php" <?php echo ($m_active == "Home") ? "class=\"active\"" : ""?>><?php echo t('menu','Home'); ?></a></li>
+				<li><a href="pref-main.php" <?php echo ($m_active == "Preferences") ? "class=\"active\"" : ""?>><?php echo t('menu','Preferences'); ?></li>
+				<li><a href="acct-main.php" <?php echo ($m_active == "Accounting") ? "class=\"active\"" : "" ?>><?php echo t('menu','Accounting'); ?></a></li>
+				<li><a href="billing-main.php" <?php echo ($m_active == "Billing") ? "class=\"active\"" : "" ?>><?php echo t('menu','Billing'); ?></a></li>
+				<li><a href="graph-main.php" <?php echo ($m_active == "Graphs") ? "class=\"active\"" : ""?>><?php echo t('menu','Graphs'); ?></li>
 
                                 </ul>
 

--- a/daloradius-users/lang/main.php
+++ b/daloradius-users/lang/main.php
@@ -19,11 +19,11 @@
  *
  *********************************************************************************************************
  */
- 
+
 	include_once('library/config_read.php');
-	
+
 	switch($configValues['CONFIG_LANG']) {
-	
+
 		case "en":
 			include (dirname(__FILE__)."/en.php");
 			break;
@@ -36,6 +36,33 @@
 		default:
 			include (dirname(__FILE__)."/en.php");
 			break;
+	}
+
+	// Translation function
+	function t($a, $b = null, $c = null, $d = null)
+	{
+		global $l;
+
+		$t = null;
+
+		if($b === null) {
+			$t = isset($l[$a]) ? $l[$a] : null;
+		}
+		else if($c === null) {
+			$t = isset($l[$a][$b]) ? $l[$a][$b] : null;
+		}
+		else if($d === null) {
+			$t = isset($l[$a][$b][$c]) ? $l[$a][$b][$c] : null;
+		}
+		else {
+			$t = isset($l[$a][$b][$c][$d]) ? $l[$a][$b][$c][$d] : null;
+		}
+
+		if($t === null) {
+			$t = 'Lang Error!';
+		}
+
+		return $t;
 	}
 
 ?>

--- a/daloradius-users/login.php
+++ b/daloradius-users/login.php
@@ -62,22 +62,22 @@ body {
 		
 		<h2>
 		
-		<?php echo $l['all']['copyright1']; ?>	
+		<?php echo t('all','copyright1'); ?>	
 		</h2>
 		<br/>
 		
 		<ul id="subnav">
 		
-		<li><?php echo $l['all']['daloRADIUS'] ?></li>
+		<li><?php echo t('all','daloRADIUS') ?></li>
 		
 		</ul>
 	</div>
 	
 	<div id="sidebar">
 	
-	<h2><?php echo $l['text']['LoginRequired'] ?></h2>
+	<h2><?php echo t('text','LoginRequired') ?></h2>
 
-	<h3><?php echo $l['text']['LoginPlease'] ?></h3>
+	<h3><?php echo t('text','LoginPlease') ?></h3>
 
 		<form name="login" action="dologin.php" class="sidebar" method="post" >
 			<ul class="subnav">
@@ -93,18 +93,18 @@ body {
 
 	<div id="contentnorightbar">
 
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['login.php'] ?></a></h2>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','login.php') ?></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['login'] ?>
+			<?php echo t('helpPage','login') ?>
 		</div>
 
-		<?php echo $l['helpPage']['loginUsersPortal'] ?>
+		<?php echo t('helpPage','loginUsersPortal') ?>
 
 <?php
 	if ($error) {
 		echo $error;
-		echo $l['messages']['loginerror'];
+		echo t('messages','loginerror');
 }
 ?>
 

--- a/daloradius-users/menu-accounting.php
+++ b/daloradius-users/menu-accounting.php
@@ -41,7 +41,7 @@
 	<h3>Users Accounting</h3>
 	<ul class="subnav">
 	
-		<li><a href="javascript:document.acctdate.submit();"><b>&raquo;</b><?php echo $l['button']['DateAccounting'] ?><a>
+		<li><a href="javascript:document.acctdate.submit();"><b>&raquo;</b><?php echo t('button','DateAccounting') ?><a>
 			<form name="acctdate" action="acct-date.php" method="get" class="sidebar">
 			<input name="startdate" type="text" id="startdate" 
 				value="<?php if (isset($accounting_date_startdate)) echo $accounting_date_startdate;

--- a/daloradius-users/menu-billing.php
+++ b/daloradius-users/menu-billing.php
@@ -73,11 +73,11 @@
 		<li>
 			<form name="billinvoicereport" action="bill-invoice-report.php" method="get" class="sidebar">
 			
-				<h109><?php echo $l['button']['BetweenDates']; ?></h109> <br/>
+				<h109><?php echo t('button','BetweenDates'); ?></h109> <br/>
 				
 				<input name="startdate" type="text" id="startdate" 
 			                                onClick='javascript:__displayTooltip();'
-			                                tooltipText='<?php echo $l['Tooltip']['Date']; ?> <br/>'
+			                                tooltipText='<?php echo t('Tooltip','Date'); ?> <br/>'
 					value="<?php if (isset($billinvoice_startdate)) echo $billinvoice_startdate;
 									else echo date("Y-m-01"); ?>">
 				<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'startdate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
@@ -85,7 +85,7 @@
 			
 				<input name="enddate" type="text" id="enddate" 
 			                                onClick='javascript:__displayTooltip();'
-			                                tooltipText='<?php echo $l['Tooltip']['Date']; ?> <br/>'
+			                                tooltipText='<?php echo t('Tooltip','Date'); ?> <br/>'
 					value="<?php if (isset($billinvoice_enddate)) echo $billinvoice_enddate;
 									else echo date("Y-m-t"); ?>">
 				<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'enddate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
@@ -100,17 +100,17 @@
 					<br/>
 					
 					<br/>
-				<input class="sidebutton" type="submit" name="submit" value="<?php echo $l['button']['GenerateReport'] ?>" tabindex=3 />
+				<input class="sidebutton" type="submit" name="submit" value="<?php echo t('button','GenerateReport') ?>" tabindex=3 />
 				
 			</form>
 			</li>
 
 			
-		<li><a href="javascript:document.billinvoiceedit.submit();""><b>&raquo;</b><?php echo $l['button']['ShowInvoice'] ?><a>
+		<li><a href="javascript:document.billinvoiceedit.submit();""><b>&raquo;</b><?php echo t('button','ShowInvoice') ?><a>
 			<form name="billinvoiceedit" action="bill-invoice-show.php" method="get" class="sidebar">
 			<input name="invoice_id" type="text" id="invoiceIdEdit" <?php if ($autoComplete) echo "autocomplete='off'"; ?>
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['invoiceID']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','invoiceID'); ?> <br/>'
 				value="<?php if (isset($edit_invoiceid)) echo $edit_invoiceid; ?>" tabindex=3>
 			</form></li>
 			

--- a/daloradius-users/menu-graphs.php
+++ b/daloradius-users/menu-graphs.php
@@ -31,7 +31,7 @@
 	<ul class="subnav">
 
 		<li><a href="javascript:document.overall_logins.submit();"><b>&raquo;</b>
-			<?php echo $l['button']['UserLogins'] ?></a>
+			<?php echo t('button','UserLogins') ?></a>
 			<form name="overall_logins" action="graphs-overall_logins.php" method="post" class="sidebar">
 			<select class="generic" name="type" type="text">
 				<option value="daily"> Daily
@@ -43,7 +43,7 @@
 
 
 		<li><a href="javascript:document.overall_download.submit();"><b>&raquo;</b>
-			<?php echo $l['button']['UserDownloads'] ?></a>
+			<?php echo t('button','UserDownloads') ?></a>
 			<form name="overall_download" action="graphs-overall_download.php" method="post" class="sidebar">
 			<select class="generic" name="type" type="text">
 				<option value="daily"> Daily
@@ -55,7 +55,7 @@
 
 
 		<li><a href="javascript:document.overall_upload.submit();"><b>&raquo;</b>
-			<?php echo $l['button']['UserUploads'] ?></a>
+			<?php echo t('button','UserUploads') ?></a>
 			<form name="overall_upload" action="graphs-overall_upload.php" method="post" class="sidebar">
 			<select class="generic" name="type" type="text">
 				<option value="daily"> Daily

--- a/daloradius-users/menu-home.php
+++ b/daloradius-users/menu-home.php
@@ -53,9 +53,9 @@
 
 	<ul class="subnav">
 
-	<li><a href="pref-main.php"><b>&raquo;</b><?php echo $l['button']['Preferences'] ?></a></li>
-	<li><a href="acct-main.php"><b>&raquo;</b><?php echo $l['button']['Accounting'] ?></a></li>
-	<li><a href="graph-main.php"><b>&raquo;</b><?php echo $l['button']['Graphs'] ?></a></li>
+	<li><a href="pref-main.php"><b>&raquo;</b><?php echo t('button','Preferences') ?></a></li>
+	<li><a href="acct-main.php"><b>&raquo;</b><?php echo t('button','Accounting') ?></a></li>
+	<li><a href="graph-main.php"><b>&raquo;</b><?php echo t('button','Graphs') ?></a></li>
 
 	</ul>
 	

--- a/daloradius-users/menu-preferences.php
+++ b/daloradius-users/menu-preferences.php
@@ -63,9 +63,9 @@
 	<h3>Settings</h3>
 	<ul class="subnav">
 	
-	<li><a href="pref-portal-password-edit.php"><b>&raquo;</b><?php echo $l['button']['ChangePortalPassword'] ?></a></li>
-	<li><a href="pref-auth-password-edit.php"><b>&raquo;</b><?php echo $l['button']['ChangeAuthPassword'] ?></a></li>
-	<li><a href="pref-userinfo-edit.php"><b>&raquo;</b><?php echo $l['button']['EditUserInfo'] ?></a></li>
+	<li><a href="pref-portal-password-edit.php"><b>&raquo;</b><?php echo t('button','ChangePortalPassword') ?></a></li>
+	<li><a href="pref-auth-password-edit.php"><b>&raquo;</b><?php echo t('button','ChangeAuthPassword') ?></a></li>
+	<li><a href="pref-userinfo-edit.php"><b>&raquo;</b><?php echo t('button','EditUserInfo') ?></a></li>
 
 	</ul>
 

--- a/daloradius-users/page-footer.php
+++ b/daloradius-users/page-footer.php
@@ -21,7 +21,7 @@
  */
  
 echo '
-	<p><br/> '.$l['all']['copyright2'].'
+	<p><br/> '.t('all','copyright2').'
 	<br />
 	</p>
 ';

--- a/daloradius-users/pref-auth-password-edit.php
+++ b/daloradius-users/pref-auth-password-edit.php
@@ -154,11 +154,11 @@ function verifyPassword(passwordStr1, passwordStr2) {
 ?>		
 	<div id="contentnorightbar">
 
-		<h2 id="Intro" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['prefpasswordedit.php'] ?>
+		<h2 id="Intro" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','prefpasswordedit.php') ?>
 		:: <?php if (isset($login)) { echo $login; } ?><h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['prefpasswordedit'] ?>
+			<?php echo t('helpPage','prefpasswordedit') ?>
 			<br/>
 		</div>
 		<?php
@@ -169,26 +169,26 @@ function verifyPassword(passwordStr1, passwordStr2) {
 
         <fieldset>
 
-			<h302> <?php echo $l['title']['ChangePassword']; ?> </h302>
+			<h302> <?php echo t('title','ChangePassword'); ?> </h302>
 			<br/>
 
 			<ul>
 
 
 			<li class='fieldset'>
-			<label for='currentpassword' class='form'><?php echo $l['all']['CurrentPassword'] ?></label>
+			<label for='currentpassword' class='form'><?php echo t('all','CurrentPassword') ?></label>
 			<input name='currentpassword' type='password' id='currentpassword' value='<?php echo $currentpassword ?>' 
 				tabindex=101 />
 			</li>
 
 			<li class='fieldset'>
-			<label for='newpassword' class='form'><?php echo $l['all']['NewPassword'] ?></label>
+			<label for='newpassword' class='form'><?php echo t('all','NewPassword') ?></label>
 			<input name='newpassword' type='password' id='newpassword' value='<?php echo $newpassword ?>' 
 				tabindex=101 />
 			</li>
 
 			<li class='fieldset'>
-			<label for='verifypassword' class='form'><?php echo $l['all']['VerifyPassword'] ?></label>
+			<label for='verifypassword' class='form'><?php echo t('all','VerifyPassword') ?></label>
 			<input name='verifypassword' type='password' id='verifypassword' value='<?php echo $verifypassword ?>' 
 				tabindex=101 />
 			</li>
@@ -198,7 +198,7 @@ function verifyPassword(passwordStr1, passwordStr2) {
 			<li class='fieldset'>
 			<br/>
 			<hr><br/>
-			<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000
+			<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000
 					class='button' onClick="return verifyPassword('newpassword','verifypassword');" />
 		</li>
 

--- a/daloradius-users/pref-main.php
+++ b/daloradius-users/pref-main.php
@@ -35,11 +35,11 @@
 
 	<div id="contentnorightbar">
 
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['prefmain.php'];?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','prefmain.php');?>
 		<h144>+</h144></a></h2>
 	
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['prefmain'] ?>
+			<?php echo t('helpPage','prefmain') ?>
 			<br/>
 		</div>
 		<br/>

--- a/daloradius-users/pref-portal-password-edit.php
+++ b/daloradius-users/pref-portal-password-edit.php
@@ -123,11 +123,11 @@ function verifyPassword(passwordStr1, passwordStr2) {
 ?>		
 	<div id="contentnorightbar">
 
-		<h2 id="Intro" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['prefpasswordedit.php'] ?>
+		<h2 id="Intro" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','prefpasswordedit.php') ?>
 		:: <?php if (isset($login)) { echo $login; } ?><h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['prefpasswordedit'] ?>
+			<?php echo t('helpPage','prefpasswordedit') ?>
 			<br/>
 		</div>
 		<?php
@@ -138,26 +138,26 @@ function verifyPassword(passwordStr1, passwordStr2) {
 
         <fieldset>
 
-			<h302> <?php echo $l['title']['ChangePassword']; ?> </h302>
+			<h302> <?php echo t('title','ChangePassword'); ?> </h302>
 			<br/>
 
 			<ul>
 
 
 			<li class='fieldset'>
-			<label for='currentpassword' class='form'><?php echo $l['all']['CurrentPassword'] ?></label>
+			<label for='currentpassword' class='form'><?php echo t('all','CurrentPassword') ?></label>
 			<input name='currentpassword' type='password' id='currentpassword' value='<?php echo $currentpassword ?>' 
 				tabindex=101 />
 			</li>
 
 			<li class='fieldset'>
-			<label for='newpassword' class='form'><?php echo $l['all']['NewPassword'] ?></label>
+			<label for='newpassword' class='form'><?php echo t('all','NewPassword') ?></label>
 			<input name='newpassword' type='password' id='newpassword' value='<?php echo $newpassword ?>' 
 				tabindex=101 />
 			</li>
 
 			<li class='fieldset'>
-			<label for='verifypassword' class='form'><?php echo $l['all']['VerifyPassword'] ?></label>
+			<label for='verifypassword' class='form'><?php echo t('all','VerifyPassword') ?></label>
 			<input name='verifypassword' type='password' id='verifypassword' value='<?php echo $verifypassword ?>' 
 				tabindex=101 />
 			</li>
@@ -167,7 +167,7 @@ function verifyPassword(passwordStr1, passwordStr2) {
 			<li class='fieldset'>
 			<br/>
 			<hr><br/>
-			<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000
+			<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000
 					class='button' onClick="return verifyPassword('newpassword','verifypassword');" />
 		</li>
 

--- a/daloradius-users/pref-userinfo-edit.php
+++ b/daloradius-users/pref-userinfo-edit.php
@@ -142,11 +142,11 @@
 ?>		
 	<div id="contentnorightbar">
 
-		<h2 id="Intro" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['prefuserinfoedit.php'] ?>
+		<h2 id="Intro" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','prefuserinfoedit.php') ?>
 		:: <?php if (isset($login)) { echo $login; } ?><h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['prefuserinfoedit'] ?>
+			<?php echo t('helpPage','prefuserinfoedit') ?>
 			<br/>
 		</div>
 		<?php

--- a/gis-editmap.php
+++ b/gis-editmap.php
@@ -61,11 +61,11 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['giseditmap.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','giseditmap.php'); ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['giseditmap'] ?>
+			<?php echo t('helpPage','giseditmap') ?>
 			<br/>
 		</div>
 		<?php
@@ -106,14 +106,14 @@ function load() {
 		}
 
 
-		map.openInfoWindow(map.getCenter(), document.createTextNode("<?php echo $l['messages']['gisedit1']; ?>"));
+		map.openInfoWindow(map.getCenter(), document.createTextNode("<?php echo t('messages','gisedit1'); ?>"));
 
 		GEvent.addListener(map, "click", function(marker, point) {
 		var geopoint = point;
 		if (marker) {
-			var remove_val=confirm("<?php echo $l['messages']['gisedit2']; ?>")
+			var remove_val=confirm("<?php echo t('messages','gisedit2'); ?>")
 			if (remove_val==true) {
-			var hotspot_name=prompt("<?php echo $l['messages']['gisedit3']; ?>","")
+			var hotspot_name=prompt("<?php echo t('messages','gisedit3'); ?>","")
 				if (hotspot_name!=null && hotspot_name!="") {
 					map.removeOverlay(marker);
 					document.editmaps.type.value = "del";
@@ -122,11 +122,11 @@ function load() {
 				}
 			}
 		  } else {
-			var add_val=confirm("<?php echo $l['messages']['gisedit4']; ?>" + " Geocode: " + geopoint)
+			var add_val=confirm("<?php echo t('messages','gisedit4'); ?>" + " Geocode: " + geopoint)
 			if (add_val==true) {
-				var hotspot_name=prompt("<?php echo $l['messages']['gisedit5']; ?>","")
+				var hotspot_name=prompt("<?php echo t('messages','gisedit5'); ?>","")
 				if (hotspot_name!=null && hotspot_name!="") {
-					var hotspot_mac=prompt("<?php echo $l['messages']['gisedit6'] ; ?>","")
+					var hotspot_mac=prompt("<?php echo t('messages','gisedit6') ; ?>","")
 					if (hotspot_mac!=null && hotspot_mac!="") {
 						map.addOverlay(new GMarker(point));
 						document.editmaps.type.value = "add";

--- a/gis-main.php
+++ b/gis-main.php
@@ -37,11 +37,11 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['gismain.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','gismain.php'); ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['gismain'] ?>
+			<?php echo t('helpPage','gismain') ?>
 			<br/>
 		</div>
 		<?php

--- a/gis-viewmap.php
+++ b/gis-viewmap.php
@@ -21,11 +21,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['gisviewmap.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','gisviewmap.php'); ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['gisviewmap'] ?>
+			<?php echo t('helpPage','gisviewmap') ?>
 			<br/>
 		</div>
 		<br/>
@@ -53,7 +53,7 @@ map.enableContinuousZoom();
 map.setCenter(new GLatLng(0, 0), 1, G_HYBRID_MAP);
 
 map.openInfoWindow(map.getCenter(),
-	document.createTextNode("<?php echo $l['messages']['gisviewwelcome']; ?>"));
+	document.createTextNode("<?php echo t('messages','gisviewwelcome'); ?>"));
 
 
 

--- a/graph-main.php
+++ b/graph-main.php
@@ -17,11 +17,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['graphmain.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','graphmain.php'); ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['graphmain'] ?>
+			<?php echo t('helpPage','graphmain') ?>
 			<br/>
 		</div>
 		<br/>

--- a/graphs-alltime_logins.php
+++ b/graphs-alltime_logins.php
@@ -30,11 +30,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['graphsalltimelogins.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','graphsalltimelogins.php'); ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['graphsalltimelogins'] ?>
+			<?php echo t('helpPage','graphsalltimelogins') ?>
 			<br/>
 		</div>
 		<br/>

--- a/graphs-alltime_traffic_compare.php
+++ b/graphs-alltime_traffic_compare.php
@@ -28,11 +28,11 @@
 
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['graphsalltimetrafficcompare.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','graphsalltimetrafficcompare.php'); ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['graphsalltimetrafficcompare'] ?>
+			<?php echo t('helpPage','graphsalltimetrafficcompare') ?>
 			<br/>
 		</div>
 		<br/>

--- a/graphs-logged_users.php
+++ b/graphs-logged_users.php
@@ -32,11 +32,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['graphsloggedusers.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','graphsloggedusers.php'); ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['graphsloggedusers'] ?>
+			<?php echo t('helpPage','graphsloggedusers') ?>
 			<br/>
 		</div>
 		<br/>

--- a/graphs-overall_download.php
+++ b/graphs-overall_download.php
@@ -37,11 +37,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['graphsoveralldownload.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','graphsoveralldownload.php'); ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['graphsoveralldownload'] ?>
+			<?php echo t('helpPage','graphsoveralldownload') ?>
 			<br/>
 		</div>
 		<br/>

--- a/graphs-overall_logins.php
+++ b/graphs-overall_logins.php
@@ -38,11 +38,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['graphsoveralllogins.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','graphsoveralllogins.php'); ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['graphsoveralllogins'] ?>
+			<?php echo t('helpPage','graphsoveralllogins') ?>
 			<br/>
 		</div>
 		<br/>

--- a/graphs-overall_upload.php
+++ b/graphs-overall_upload.php
@@ -38,11 +38,11 @@
 
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['graphsoverallupload.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','graphsoverallupload.php'); ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['graphsoverallupload'] ?>
+			<?php echo t('helpPage','graphsoverallupload') ?>
 			<br/>
 		</div>
 		<br/>

--- a/include/common/notificationsBatchDetails.php
+++ b/include/common/notificationsBatchDetails.php
@@ -119,43 +119,43 @@
 
 		$batch_details .= "<table $tableTags><tr $tableTrTags>
 					<td>
-			".$l['all']['BatchName']."
+			".t('all','BatchName')."
 			</td>
 
 			<td>
-			".$l['all']['HotSpot']."
+			".t('all','HotSpot')."
 			</td>
 
 			<td>
-			".$l['all']['BatchStatus']."
+			".t('all','BatchStatus')."
 			</td>
 
 			<td>
-			".$l['all']['TotalUsers']."
+			".t('all','TotalUsers')."
 			</td>
 
 			<td>
-			".$l['all']['ActiveUsers']."
+			".t('all','ActiveUsers')."
 			</td>
 
 			<td>
-			".$l['all']['PlanName']."
+			".t('all','PlanName')."
 			</td>
 
 			<td>
-			".$l['all']['PlanCost']."
+			".t('all','PlanCost')."
 			</td>
 
 			<td>
-			".$l['all']['BatchCost']."
+			".t('all','BatchCost')."
 			</td>
 
 			<td>
-			".$l['all']['CreationDate']."
+			".t('all','CreationDate')."
 			</td>
 
 			<td>
-			".$l['all']['CreationBy']."
+			".t('all','CreationBy')."
 			</td>
 
 			</tr>";
@@ -311,15 +311,15 @@
 
 		$batch_active_users = "<table $tableTags><tr $tableTrTags'>
 			<td>
-			".$l['all']['BatchName']."
+			".t('all','BatchName')."
 			</td>
 
 			<td>
-			".$l['all']['Username']."
+			".t('all','Username')."
 			</td>
 
 			<td>
-			".$l['all']['StartTime']."
+			".t('all','StartTime')."
 			</td>
 
 			</tr>";

--- a/include/common/notificationsUserDetailsInvoice.php
+++ b/include/common/notificationsUserDetailsInvoice.php
@@ -137,32 +137,32 @@
 		$service_plan_info .= "".
 
 					"<tr $tableTrTags'>
-					<td>".$l['all']['Username']."</td>
+					<td>".t('all','Username')."</td>
 					<td>".$row['username']."</td>
 					</tr>".
 		
 					"<tr $tableTrTags'>
-					<td>".$l['all']['PlanName']."</td>
+					<td>".t('all','PlanName')."</td>
 					<td>".$row['planname']."</td>
 					</tr>".
 					"<tr $tableTrTags'>
-					<td>".$l['all']['PlanRecurring']."</td>
+					<td>".t('all','PlanRecurring')."</td>
 					<td>".$row['planRecurring']."</td>
 					</tr>".
 					"<tr $tableTrTags'>
-					<td>".$l['all']['PlanRecurringPeriod']."</td>
+					<td>".t('all','PlanRecurringPeriod')."</td>
 					<td>".$row['planRecurringPeriod']."</td>
 					</tr>".
 					"<tr $tableTrTags'>
-					<td>".$l['all']['PlanCost']."</td>
+					<td>".t('all','PlanCost')."</td>
 					<td>".$row['planCost']."</td>
 					</tr>".
 					"<tr $tableTrTags'>
-					<td>".$l['all']['NextBill']."</td>
+					<td>".t('all','NextBill')."</td>
 					<td>".$row['nextbill']."</td>
 					</tr>".
 					"<tr $tableTrTags'>
-					<td>".$l['all']['BillDue']."</td>
+					<td>".t('all','BillDue')."</td>
 					<td>".$row['billdue']."</td>
 					</tr>".
 					"";
@@ -239,43 +239,43 @@
 		
 		$batch_details .= "<table $tableTags><tr $tableTrTags>
 					<td> 
-			".$l['all']['BatchName']."
+			".t('all','BatchName')."
 			</td>
 	
 			<td> 
-			".$l['all']['HotSpot']."
+			".t('all','HotSpot')."
 			</td>
 	
 			<td> 
-			".$l['all']['BatchStatus']."
+			".t('all','BatchStatus')."
 			</td>
 			
 			<td> 
-			".$l['all']['TotalUsers']."
+			".t('all','TotalUsers')."
 			</td>
 	
 			<td> 
-			".$l['all']['ActiveUsers']."
+			".t('all','ActiveUsers')."
 			</td>
 	
 			<td> 
-			".$l['all']['PlanName']."
+			".t('all','PlanName')."
 			</td>
 	
 			<td> 
-			".$l['all']['PlanCost']."
+			".t('all','PlanCost')."
 			</td>
 	
 			<td> 
-			".$l['all']['BatchCost']."
+			".t('all','BatchCost')."
 			</td>
 	
 			<td> 
-			".$l['all']['CreationDate']."
+			".t('all','CreationDate')."
 			</td>
 	
 			<td> 
-			".$l['all']['CreationBy']."
+			".t('all','CreationBy')."
 			</td>
 	
 			</tr>";
@@ -431,15 +431,15 @@
 		
 		$batch_active_users = "<table $tableTags><tr $tableTrTags'>
 			<td> 
-			".$l['all']['BatchName']."
+			".t('all','BatchName')."
 			</td>
 	
 			<td> 
-			".$l['all']['Username']."
+			".t('all','Username')."
 			</td>
 	
 			<td> 
-			".$l['all']['StartTime']."
+			".t('all','StartTime')."
 			</td>
 	
 			</tr>";

--- a/include/common/notificationsUserInvoice.php
+++ b/include/common/notificationsUserInvoice.php
@@ -107,14 +107,14 @@
 		$balance = (float) ($invoiceDetails['totalpayed'] - $invoiceDetails['totalbilled']);
 		$invoice_details = "";
 		$invoice_details .= "".
-		"<b>".$l['all']['ClientName']."</b>: ".$invoiceDetails['contactperson']."<br/>".
-		"<b>".$l['all']['Invoice']."</b>: ".$invoice_id."<br/>".
-		"<b>".$l['all']['Date']."</b>: ".$invoiceDetails['date']."<br/>".
-		"<b>".$l['all']['TotalBilled']."</b>: ".$invoiceDetails['totalbilled']."<br/>".
-		"<b>".$l['all']['TotalPayed']."</b>: ".$invoiceDetails['totalpayed']."<br/>".
-		"<b>".$l['all']['Balance']."</b>: ".$balance."<br/>".
-		"<b>".$l['all']['Status']."</b>: ".$invoiceDetails['status']."<br/>".
-		"<b>".$l['ContactInfo']['Notes']."</b>: ".$invoiceDetails['notes']."<br/><br/><br/>";
+		"<b>".t('all','ClientName')."</b>: ".$invoiceDetails['contactperson']."<br/>".
+		"<b>".t('all','Invoice')."</b>: ".$invoice_id."<br/>".
+		"<b>".t('all','Date')."</b>: ".$invoiceDetails['date']."<br/>".
+		"<b>".t('all','TotalBilled')."</b>: ".$invoiceDetails['totalbilled']."<br/>".
+		"<b>".t('all','TotalPayed')."</b>: ".$invoiceDetails['totalpayed']."<br/>".
+		"<b>".t('all','Balance')."</b>: ".$balance."<br/>".
+		"<b>".t('all','Status')."</b>: ".$invoiceDetails['status']."<br/>".
+		"<b>".t('ContactInfo','Notes')."</b>: ".$invoiceDetails['notes']."<br/><br/><br/>";
 		
 		$customerInfo['invoice_details'] = $invoice_details;
 		

--- a/include/management/attributes.php
+++ b/include/management/attributes.php
@@ -1,6 +1,6 @@
 
 <fieldset>
-	<h302> <?php echo $l['title']['Attributes']; ?> </h302>
+	<h302> <?php echo t('title','Attributes'); ?> </h302>
 	<br/>
 
 	<input checked type='radio' value="" name="" onclick="javascript:toggleAttributeSelectbox();"/>
@@ -72,7 +72,7 @@
 		</ul>
 
 <br/>
-<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 
 </fieldset>
 <br/>

--- a/include/management/contactinfo.php
+++ b/include/management/contactinfo.php
@@ -10,66 +10,66 @@
 	<h302> Contact Info </h302>
 	<br/>
 
-	<label for='ownername' class='form'><?php echo $l['ContactInfo']['OwnerName'] ?></label>
+	<label for='ownername' class='form'><?php echo t('ContactInfo','OwnerName') ?></label>
 	<input name='owner' type='text' id='owner' value='<?php if (isset($owner)) echo $owner; ?>' 
 		tabindex=300 />
 	<br/>
 
-	<label for='emailowner' class='form'><?php echo $l['ContactInfo']['OwnerEmail'] ?></label>
+	<label for='emailowner' class='form'><?php echo t('ContactInfo','OwnerEmail') ?></label>
 	<input name='email_owner' type='text' id='email_owner' value='<?php if (isset($email_owner)) echo $email_owner; ?>'
 		tabindex=301 />
 	<br/>
 
-	<label for='managername' class='form'><?php echo $l['ContactInfo']['ManagerName'] ?></label>
+	<label for='managername' class='form'><?php echo t('ContactInfo','ManagerName') ?></label>
 	<input name='manager' type='text' id='manager' value='<?php if (isset($manager)) echo $manager; ?>'
 		tabindex=302 />
 	<br/>
 
-	<label for='emailmanager' class='form'><?php echo $l['ContactInfo']['ManagerEmail'] ?></label>
+	<label for='emailmanager' class='form'><?php echo t('ContactInfo','ManagerEmail') ?></label>
 	<input name='email_manager' type='text' id='email_manager' value='<?php if (isset($email_manager)) echo $email_manager; ?>'
 		tabindex=303 />
 	<br/>
 
-	<label for='company' class='form'><?php echo $l['ContactInfo']['Company'] ?></label>
+	<label for='company' class='form'><?php echo t('ContactInfo','Company') ?></label>
 	<input name='company' type='text' id='company' value='<?php if (isset($company)) echo $company; ?>'
 		tabindex=304 />
 	<br/>
 
-	<label for='address' class='form'><?php echo $l['ContactInfo']['Address'] ?></label>
+	<label for='address' class='form'><?php echo t('ContactInfo','Address') ?></label>
         <textarea class='form' name='address' value='<?php if (isset($address)) echo $address; ?>' tabindex=305 ></textarea>
 	<br/>
 
-	<label for='phone1' class='form'><?php echo $l['ContactInfo']['Phone1'] ?></label>
+	<label for='phone1' class='form'><?php echo t('ContactInfo','Phone1') ?></label>
 	<input name='phone1' type='text' id='phone1' value='<?php if (isset($phone1)) echo $phone1; ?>'
 		tabindex=306 />
 	<br/>
 
-	<label for='phone2' class='form'><?php echo $l['ContactInfo']['Phone2'] ?></label>
+	<label for='phone2' class='form'><?php echo t('ContactInfo','Phone2') ?></label>
 	<input name='phone2' type='text' id='phone2' value='<?php if (isset($phone2)) echo $phone2; ?>'
 		tabindex=307 />
 	<br/>
 
-	<label for='hotspot_type' class='form'><?php echo $l['ContactInfo']['HotspotType'] ?></label>
+	<label for='hotspot_type' class='form'><?php echo t('ContactInfo','HotspotType') ?></label>
 	<input name='hotspot_type' type='text' id='hotspot_type' value='<?php if (isset($hotspot_type)) echo $hotspot_type; ?>'
 		tabindex=308 />
 	<br/>
 
-	<label for='companywebsite' class='form'><?php echo $l['ContactInfo']['CompanyWebsite'] ?></label>
+	<label for='companywebsite' class='form'><?php echo t('ContactInfo','CompanyWebsite') ?></label>
 	<input name='companywebsite' type='text' id='companywebsite' value='<?php if (isset($companywebsite)) echo $companywebsite; ?>'
 		tabindex=309 />
 	<br/>
 
-	<label for='companyemail' class='form'><?php echo $l['ContactInfo']['CompanyEmail'] ?></label>
+	<label for='companyemail' class='form'><?php echo t('ContactInfo','CompanyEmail') ?></label>
 	<input name='companyemail' type='text' id='companyemail' value='<?php if (isset($companyemail)) echo $companyemail; ?>'
 		tabindex=310 />
 	<br/>
 
-	<label for='companyphone' class='form'><?php echo $l['ContactInfo']['CompanyPhone'] ?></label>
+	<label for='companyphone' class='form'><?php echo t('ContactInfo','CompanyPhone') ?></label>
 	<input name='companyphone' type='text' id='companyphone' value='<?php if (isset($companyphone)) echo $companyphone; ?>'
 		tabindex=311 />
 	<br/>
 
-	<label for='companycontact' class='form'><?php echo $l['ContactInfo']['CompanyContact'] ?></label>
+	<label for='companycontact' class='form'><?php echo t('ContactInfo','CompanyContact') ?></label>
 	<input name='companycontact' type='text' id='companycontact' value='<?php if (isset($companycontact)) echo $companycontact; ?>'
 		tabindex=312 />
 	<br/>
@@ -79,19 +79,19 @@
         <br/>
 
         <br/>
-        <label for='creationdate' class='form'><?php echo $l['all']['CreationDate'] ?></label>
+        <label for='creationdate' class='form'><?php echo t('all','CreationDate') ?></label>
         <input disabled value='<?php if (isset($creationdate)) echo $creationdate ?>' tabindex=313 />
         <br/>
 
-        <label for='creationby' class='form'><?php echo $l['all']['CreationBy'] ?></label>
+        <label for='creationby' class='form'><?php echo t('all','CreationBy') ?></label>
         <input disabled value='<?php if (isset($creationby)) echo $creationby ?>' tabindex=314 />
         <br/>
 
-        <label for='updatedate' class='form'><?php echo $l['all']['UpdateDate'] ?></label>
+        <label for='updatedate' class='form'><?php echo t('all','UpdateDate') ?></label>
         <input disabled value='<?php if (isset($updatedate)) echo $updatedate ?>' tabindex=315 />
         <br/>
 
-        <label for='updateby' class='form'><?php echo $l['all']['UpdateBy'] ?></label>
+        <label for='updateby' class='form'><?php echo t('all','UpdateBy') ?></label>
         <input disabled value='<?php if (isset($updateby)) echo $updateby ?>' tabindex=316 />
         <br/>
 
@@ -99,7 +99,7 @@
         <br/><br/>
         <hr><br/>
 
-        <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000
+        <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000
 		class='button' />
 
 </fieldset>

--- a/include/management/groups.php
+++ b/include/management/groups.php
@@ -46,7 +46,7 @@
 	$res = $dbSocket->query($sql);
 
 	if ($res->numRows() == 0) {
-		echo "<center> ".$l['messages']['nogroupdefinedforuser']." <br/></center>";
+		echo "<center> ".t('messages','nogroupdefinedforuser')." <br/></center>";
 	} else {
 
 		$counter = 0;
@@ -56,7 +56,7 @@
 			echo "
 
 				<li class='fieldset'>
-				<label for='group' class='form'>".$l['all'][$groupTerminology]." #".($counter+1)."</label>
+				<label for='group' class='form'>".t('all')[$groupTerminology]." #".($counter+1)."</label>
 				<select name='groups[]' id='usergroup$counter' tabindex=105 class='form' >
 					<option value='$row[0]'>$row[0]</option>
 					<option value=''></option>
@@ -64,7 +64,7 @@
 				</select>
 
 				<br/>
-				<label for='groupPriority' class='form'>".$l['all'][$groupTerminologyPriority]."</label>
+				<label for='groupPriority' class='form'>".t('all')[$groupTerminologyPriority]."</label>
 				<input class='integer' value='$row[1]' name='groups_priority[]' id='group_priority$counter' >
 				<img src=\"images/icons/bullet_arrow_up.png\" alt=\"+\" 
 					onclick=\"javascript:changeInteger('group_priority$counter','increment')\" />

--- a/include/management/operatorinfo.php
+++ b/include/management/operatorinfo.php
@@ -92,19 +92,19 @@ echo "
                 <input disabled type='text' value='"; if (isset($operator_lastlogin)) 
 			echo $operator_lastlogin; echo "' />
 	        <br/>
-	        <label for='creationdate' class='form'>".$l['all']['CreationDate']."</label>
+	        <label for='creationdate' class='form'>".t('all','CreationDate')."</label>
 	        <input disabled type='text' value='"; if (isset($operator_creationdate)) 
 			echo $operator_creationdate; echo "' />
 	        <br/>
-	        <label for='creationby' class='form'>".$l['all']['CreationBy']."</label>
+	        <label for='creationby' class='form'>".t('all','CreationBy')."</label>
 	        <input disabled type='text' value='"; if (isset($operator_creationby)) 
 			echo $operator_creationby; echo "' />
 	        <br/>
-                <label for='updatedate' class='form'>".$l['all']['UpdateDate']."</label>
+                <label for='updatedate' class='form'>".t('all','UpdateDate')."</label>
                 <input disabled type='text' value='"; if (isset($operator_updatedate))
                         echo $operator_updatedate; echo "' />
                 <br/>
-                <label for='updateby' class='form'>".$l['all']['UpdateBy']."</label>
+                <label for='updateby' class='form'>".t('all','UpdateBy')."</label>
                 <input disabled type='text' value='"; if (isset($operator_updateby))
                         echo $operator_updateby; echo "' />
                 <br/>
@@ -112,7 +112,7 @@ echo "
                 <br/><br/>
                 <hr><br/>
 
-                <input type='submit' name='submit' value='".$l['buttons']['apply']."' class='button' />
+                <input type='submit' name='submit' value='".t('buttons','apply')."' class='button' />
 
         </fieldset>
 

--- a/include/management/plans_profiles.php
+++ b/include/management/plans_profiles.php
@@ -44,7 +44,7 @@
 	$res = $dbSocket->query($sql);
 
 	if ($res->numRows() == 0) {
-		echo "<center> ".$l['messages']['nogroupdefinedforuser']." <br/></center>";
+		echo "<center> ".t('messages','nogroupdefinedforuser')." <br/></center>";
 	} else {
 
 		$counter = 0;
@@ -54,7 +54,7 @@
 			echo "
 
 				<li class='fieldset'>
-				<label for='group' class='form'>".$l['all'][$groupTerminology]." #".($counter+1)."</label>
+				<label for='group' class='form'>".t('all')[$groupTerminology]." #".($counter+1)."</label>
 				<select name='groups[]' id='usergroup$counter' tabindex=105 class='form' >
 					<option value='$row[0]'>$row[0]</option>
 					<option value=''></option>
@@ -62,7 +62,7 @@
 				</select>
 
 				<br/>
-				<label for='groupPriority' class='form'>".$l['all'][$groupTerminologyPriority]."</label>
+				<label for='groupPriority' class='form'>".t('all')[$groupTerminologyPriority]."</label>
 				<input class='integer' value='$row[1]' name='groups_priority[]' id='group_priority$counter' >
 				<img src=\"images/icons/bullet_arrow_up.png\" alt=\"+\" 
 					onclick=\"javascript:changeInteger('group_priority$counter','increment')\" />

--- a/include/management/userbillinfo.php
+++ b/include/management/userbillinfo.php
@@ -17,55 +17,55 @@ echo "
 	<h301> Billing Information </h301>
 	<br/>
 
-	<label for='planname' class='form'>".$l['ContactInfo']['PlanName']."</label>
+	<label for='planname' class='form'>".t('ContactInfo','PlanName')."</label>
 	<input value='"; if (isset($bi_planname)) echo $bi_planname; echo "' name='bi_planname' disabled tabindex=401 />
         <br/>
 
-	<label for='contactperson' class='form'>".$l['ContactInfo']['ContactPerson']."</label>
+	<label for='contactperson' class='form'>".t('ContactInfo','ContactPerson')."</label>
         <input value='"; if (isset($bi_contactperson)) echo $bi_contactperson; echo "' name='bi_contactperson' id='bi_contactperson' tabindex=400 />
 	<br/>
 
-	<label for='company' class='form'>".$l['ContactInfo']['Company']."</label>
+	<label for='company' class='form'>".t('ContactInfo','Company')."</label>
 	<input value='"; if (isset($bi_company)) echo $bi_company; echo "' name='bi_company' id='bi_company' tabindex=401 />
         <br/>
 	
-	<label for='email' class='form'>".$l['ContactInfo']['Email']."</label>
+	<label for='email' class='form'>".t('ContactInfo','Email')."</label>
         <input value='"; if (isset($bi_email)) echo $bi_email; echo "' name='bi_email' id='bi_email' tabindex=402 />
         <br/>
 
-	<label for='phone' class='form'>".$l['ContactInfo']['Phone']."</label>
+	<label for='phone' class='form'>".t('ContactInfo','Phone')."</label>
 	<input value='"; if (isset($bi_phone)) echo $bi_phone; echo "' name='bi_phone' id='bi_phone' tabindex=403 />
         <br/>
 
-	<label for='address' class='form'>".$l['ContactInfo']['Address']."</label>
+	<label for='address' class='form'>".t('ContactInfo','Address')."</label>
 	<input value='"; if (isset($bi_address)) echo $bi_address; echo "' name='bi_address' id='bi_address' tabindex=404 />
         <br/>
 
-	<label for='city' class='form'>".$l['ContactInfo']['City']."</label>
+	<label for='city' class='form'>".t('ContactInfo','City')."</label>
 	<input value='"; if (isset($bi_city)) echo $bi_city; echo "' name='bi_city' id='bi_city' tabindex=405 />
         <br/>
 
-	<label for='state' class='form'>".$l['ContactInfo']['State']."</label>
+	<label for='state' class='form'>".t('ContactInfo','State')."</label>
 	<input value='"; if (isset($bi_state)) echo $bi_state; echo "' name='bi_state' id='bi_state' tabindex=406 />
         <br/>
         
-	<label for='country' class='form'>".$l['ContactInfo']['Country']."</label>
+	<label for='country' class='form'>".t('ContactInfo','Country')."</label>
 	<input value='"; if (isset($bi_country)) echo $bi_country; echo "' name='bi_country' id='bi_country' tabindex=406 />
         <br/>
 
-	<label for='zip' class='form'>".$l['ContactInfo']['Zip']."</label>
+	<label for='zip' class='form'>".t('ContactInfo','Zip')."</label>
 	<input value='"; if (isset($bi_zip)) echo $bi_zip; echo "' name='bi_zip' id='bi_zip' tabindex=407 />
         <br/>
 
-	<label for='PostalInvoice' class='form'>".$l['all']['PostalInvoice']."</label>
+	<label for='PostalInvoice' class='form'>".t('all','PostalInvoice')."</label>
 	<input value='"; if (isset($bi_postalinvoice)) echo $bi_postalinvoice; echo "' name='bi_postalinvoice' tabindex=411 />
         <br/>
 
-	<label for='FaxInvoice' class='form'>".$l['all']['FaxInvoice']."</label>
+	<label for='FaxInvoice' class='form'>".t('all','FaxInvoice')."</label>
 	<input value='"; if (isset($bi_faxinvoice)) echo $bi_faxinvoice; echo "' name='bi_faxinvoice' tabindex=411 />
         <br/>
 
-	<label for='EmailInvoice' class='form'>".$l['all']['EmailInvoice']."</label>
+	<label for='EmailInvoice' class='form'>".t('all','EmailInvoice')."</label>
 	<input value='"; if (isset($bi_emailinvoice)) echo $bi_emailinvoice; echo "' name='bi_emailinvoice' tabindex=411 />
         <br/>
 
@@ -74,28 +74,28 @@ echo "
 	<h301> Payment Details </h301>
 	<br/>
 
-	<label for='PaymentMethod' class='form'>".$l['ContactInfo']['PaymentMethod']."</label>
+	<label for='PaymentMethod' class='form'>".t('ContactInfo','PaymentMethod')."</label>
 	<input value='"; if (isset($bi_paymentmethod)) echo $bi_paymentmethod; echo "' name='bi_paymentmethod' tabindex=411 />
         <br/>
 
-	<label for='Cash' class='form'>".$l['ContactInfo']['Cash']."</label>
+	<label for='Cash' class='form'>".t('ContactInfo','Cash')."</label>
 	<input value='"; if (isset($bi_cash)) echo $bi_cash; echo "' name='bi_cash' tabindex=411 />
         <br/>
 
-	<label for='CreditCardName' class='form'>".$l['ContactInfo']['CreditCardName']."</label>
+	<label for='CreditCardName' class='form'>".t('ContactInfo','CreditCardName')."</label>
 	<input value='"; if (isset($bi_creditcardname)) echo $bi_creditcardname; echo "' name='bi_creditcardname' tabindex=411 />
         <br/>
 
-	<label for='CreditCardNumber' class='form'>".$l['ContactInfo']['CreditCardNumber']."</label>
+	<label for='CreditCardNumber' class='form'>".t('ContactInfo','CreditCardNumber')."</label>
 	<input value='"; if (isset($bi_creditcardnumber)) echo $bi_creditcardnumber; echo "' name='bi_creditcardnumber' tabindex=411 />
         <br/>
 
-	<label for='CreditCardVerificationNumber' class='form'>".$l['ContactInfo']['CreditCardVerificationNumber']."</label>
+	<label for='CreditCardVerificationNumber' class='form'>".t('ContactInfo','CreditCardVerificationNumber')."</label>
 	<br/>
 	<input value='"; if (isset($bi_creditcardverification)) echo $bi_creditcardverification; echo "' name='bi_creditcardverification' tabindex=411 />
         <br/>
 
-	<label for='CreditCardType' class='form'>".$l['ContactInfo']['CreditCardType']."</label>
+	<label for='CreditCardType' class='form'>".t('ContactInfo','CreditCardType')."</label>
 	<select class='form' name='bi_creditcardtype'>
 		<option value='"; if (isset($bi_creditcardtype)) echo $bi_creditcardtype; echo "'>";if (isset($bi_creditcardtype)) echo $bi_creditcardtype; echo "</option>
 		<option value=''></option>
@@ -105,7 +105,7 @@ echo "
 	</select>
         <br/>
 
-	<label for='CreditCardExpiration' class='form'>".$l['ContactInfo']['CreditCardExpiration']."</label>
+	<label for='CreditCardExpiration' class='form'>".t('ContactInfo','CreditCardExpiration')."</label>
 	<input value='"; if (isset($bi_creditcardexp)) echo $bi_creditcardexp; echo "' name='bi_creditcardexp' tabindex=411 />
         <br/>
 
@@ -115,7 +115,7 @@ echo "
 	<h301> Promotion Details </h301>
 	<br/>
 
-	<label for='Lead' class='form'>".$l['all']['Lead']."</label>
+	<label for='Lead' class='form'>".t('all','Lead')."</label>
 	<select class='form' name='bi_lead'>
 		<option value='"; if (isset($bi_lead)) echo $bi_lead; echo "'>";if (isset($bi_lead)) echo $bi_lead; echo "</option>
 		<option value=''></option>
@@ -126,11 +126,11 @@ echo "
 	</select>
         <br/>
 
-	<label for='Coupon' class='form'>".$l['all']['Coupon']."</label>
+	<label for='Coupon' class='form'>".t('all','Coupon')."</label>
 	<input value='"; if (isset($bi_coupon)) echo $bi_coupon; echo "' name='bi_coupon' tabindex=411 />
         <br/>
 
-	<label for='OrderTaker' class='form'>".$l['all']['OrderTaker']."</label>
+	<label for='OrderTaker' class='form'>".t('all','OrderTaker')."</label>
 	<input value='"; if (isset($bi_ordertaker)) echo $bi_ordertaker; echo "' name='bi_ordertaker' tabindex=411 />
         <br/>
 
@@ -138,7 +138,7 @@ echo "
 	<h301> Other </h301>
 	<br/>
 
-	<label for='notes' class='form'>".$l['ContactInfo']['Notes']."</label>
+	<label for='notes' class='form'>".t('ContactInfo','Notes')."</label>
 	<textarea class='form' name='bi_notes' tabindex=412 >"; if (isset($bi_notes)) echo $bi_notes; echo "</textarea> 
         <br/>
 
@@ -154,45 +154,45 @@ echo "
 
 echo "
 
-	<label for='userupdate' class='form'>".$l['ContactInfo']['EnableUserUpdate']."</label>
+	<label for='userupdate' class='form'>".t('ContactInfo','EnableUserUpdate')."</label>
 	<input type='checkbox' class='form' name='changeUserBillInfo' value='$bi_changeuserbillinfo' $isBIChecked tabindex=413 />
         <br/>
 	<br/>
 
-	<label for='BillStatus' class='form'>".$l['all']['BillStatus']."</label>
+	<label for='BillStatus' class='form'>".t('all','BillStatus')."</label>
 	<input value='"; if (isset($bi_billstatus)) echo $bi_billstatus; echo "' name='bi_billstatus' disabled tabindex=411 />
         <br/>
 
-	<label for='LastBill' class='form'>".$l['all']['LastBill']."</label>
+	<label for='LastBill' class='form'>".t('all','LastBill')."</label>
 	<input value='"; if (isset($bi_lastbill)) echo $bi_lastbill; echo "' name='bi_lastbill' disabled tabindex=411 />
         <br/>
 
-	<label for='NextBill' class='form'>".$l['all']['NextBill']."</label>
+	<label for='NextBill' class='form'>".t('all','NextBill')."</label>
 	<input value='"; if (isset($bi_nextbill)) echo $bi_nextbill; echo "' name='bi_nextbill' disabled tabindex=411 />
         <br/>
 
-	<label for='BillDue' class='form'>".$l['all']['BillDue']."</label>
+	<label for='BillDue' class='form'>".t('all','BillDue')."</label>
 	<input value='"; if (isset($bi_billdue)) echo $bi_billdue; echo "' name='bi_billdue' tabindex=411 />
         <br/>
         
-	<label for='NextInvoiceDue' class='form'>".$l['all']['NextInvoiceDue']."</label>
+	<label for='NextInvoiceDue' class='form'>".t('all','NextInvoiceDue')."</label>
 	<input value='"; if (isset($bi_nextinvoicedue)) echo $bi_nextinvoicedue; echo "' name='bi_nextinvoicedue' tabindex=411 />
         <br/>
         
 	<br/>
-	<label for='creationdate' class='form'>".$l['all']['CreationDate']."</label>
+	<label for='creationdate' class='form'>".t('all','CreationDate')."</label>
 	<input disabled value='"; if (isset($ui_creationdate)) echo $ui_creationdate; echo "' tabindex=414 />
         <br/>
 
-	<label for='creationby' class='form'>".$l['all']['CreationBy']."</label>
+	<label for='creationby' class='form'>".t('all','CreationBy')."</label>
 	<input disabled value='"; if (isset($ui_creationby)) echo $ui_creationby; echo "' tabindex=415 />
         <br/>
 
-	<label for='updatedate' class='form'>".$l['all']['UpdateDate']."</label>
+	<label for='updatedate' class='form'>".t('all','UpdateDate')."</label>
 	<input disabled value='"; if (isset($ui_updatedate)) echo $ui_updatedate; echo "' tabindex=416 />
         <br/>
 
-	<label for='updateby' class='form'>".$l['all']['UpdateBy']."</label>
+	<label for='updateby' class='form'>".t('all','UpdateBy')."</label>
 	<input disabled value='"; if (isset($ui_updateby)) echo $ui_updateby; echo "' tabindex=417 />
         <br/>
 

--- a/include/management/userinfo.php
+++ b/include/management/userinfo.php
@@ -19,15 +19,15 @@ echo "
 	<h301> Personal </h301>
 	<br/>
 
-	<label for='username' class='form'>".$l['ContactInfo']['FirstName']."</label>
+	<label for='username' class='form'>".t('ContactInfo','FirstName')."</label>
         <input value='"; if (isset($ui_firstname)) echo $ui_firstname; echo "' name='firstname' id='firstname' tabindex=300 />
 	<br/>
 	
-	<label for='lastname' class='form'>".$l['ContactInfo']['LastName']."</label>
+	<label for='lastname' class='form'>".t('ContactInfo','LastName')."</label>
         <input value='"; if (isset($ui_lastname)) echo $ui_lastname; echo "' name='lastname' id='lastname' tabindex=301 />
 	<br/>
 
-	<label for='email' class='form'>".$l['ContactInfo']['Email']."</label>
+	<label for='email' class='form'>".t('ContactInfo','Email')."</label>
         <input value='"; if (isset($ui_email)) echo $ui_email; echo "' name='email' id='email' tabindex=302 />
         <br/>
 
@@ -42,43 +42,43 @@ echo "
 	<h301> Business </h301>
 	<br/>
 
-	<label for='department' class='form'>".$l['ContactInfo']['Department']."</label>
+	<label for='department' class='form'>".t('ContactInfo','Department')."</label>
         <input value='"; if (isset($ui_department)) echo $ui_department; echo "' name='department' tabindex=303 />
         <br/>
 
-	<label for='company' class='form'>".$l['ContactInfo']['Company']."</label>
+	<label for='company' class='form'>".t('ContactInfo','Company')."</label>
 	<input value='"; if (isset($ui_company)) echo $ui_company; echo "' name='company' id='company' tabindex=304 />
         <br/>
 
-	<label for='workphone' class='form'>".$l['ContactInfo']['WorkPhone']."</label>
+	<label for='workphone' class='form'>".t('ContactInfo','WorkPhone')."</label>
 	<input value='"; if (isset($ui_workphone)) echo $ui_workphone; echo "' name='workphone' id='workphone' tabindex=305 />
         <br/>
 
-	<label for='homephone' class='form'>".$l['ContactInfo']['HomePhone']."</label>
+	<label for='homephone' class='form'>".t('ContactInfo','HomePhone')."</label>
 	<input value='"; if (isset($ui_homephone)) echo $ui_homephone; echo "' name='homephone' tabindex=306 />
         <br/>
 
-	<label for='mobilephone' class='form'>".$l['ContactInfo']['MobilePhone']."</label>
+	<label for='mobilephone' class='form'>".t('ContactInfo','MobilePhone')."</label>
 	<input value='"; if (isset($ui_mobilephone)) echo $ui_mobilephone; echo "' name='mobilephone' tabindex=307 />
         <br/>
 
-	<label for='address' class='form'>".$l['ContactInfo']['Address']."</label>
+	<label for='address' class='form'>".t('ContactInfo','Address')."</label>
 	<input value='"; if (isset($ui_address)) echo $ui_address; echo "' name='address' id='address' tabindex=308 />
         <br/>
 
-	<label for='city' class='form'>".$l['ContactInfo']['City']."</label>
+	<label for='city' class='form'>".t('ContactInfo','City')."</label>
 	<input value='"; if (isset($ui_city)) echo $ui_city; echo "' name='city' id='city' tabindex=309 />
         <br/>
 
-	<label for='state' class='form'>".$l['ContactInfo']['State']."</label>
+	<label for='state' class='form'>".t('ContactInfo','State')."</label>
 	<input value='"; if (isset($ui_state)) echo $ui_state; echo "' name='state' id='state' tabindex=310 />
         <br/>
         
-	<label for='country' class='form'>".$l['ContactInfo']['Country']."</label>
+	<label for='country' class='form'>".t('ContactInfo','Country')."</label>
 	<input value='"; if (isset($ui_country)) echo $ui_country; echo "' name='country' id='country' tabindex=310 />
         <br/>
 
-	<label for='zip' class='form'>".$l['ContactInfo']['Zip']."</label>
+	<label for='zip' class='form'>".t('ContactInfo','Zip')."</label>
 	<input value='"; if (isset($ui_zip)) echo $ui_zip; echo "' name='zip' id='zip' tabindex=311 />
         <br/>
 
@@ -86,7 +86,7 @@ echo "
 	<h301> Other </h301>
 	<br/>
 
-	<label for='notes' class='form'>".$l['ContactInfo']['Notes']."</label>
+	<label for='notes' class='form'>".t('ContactInfo','Notes')."</label>
 	<textarea class='form' name='notes' tabindex=312 >"; if (isset($ui_notes)) echo $ui_notes; echo "</textarea> 
         <br/>
 
@@ -111,32 +111,32 @@ echo "
 	
 echo "
 
-	<label for='userupdate' class='form'>".$l['ContactInfo']['EnableUserUpdate']."</label>
+	<label for='userupdate' class='form'>".t('ContactInfo','EnableUserUpdate')."</label>
 	<input type='checkbox' class='form' name='changeUserInfo' value='$ui_changeuserinfo' $isUIChecked tabindex=313 />
         <br/>
         
-	<label for='userupdate' class='form'>".$l['ContactInfo']['EnablePortalLogin']."</label>
+	<label for='userupdate' class='form'>".t('ContactInfo','EnablePortalLogin')."</label>
 	<input type='checkbox' class='form' name='enableUserPortalLogin' value='$ui_enableUserPortalLogin' $isenableUserPortalLogin tabindex=313 />
         <br/>
 
-	<label for='portalLoginPassword' class='form'>".$l['ContactInfo']['PortalLoginPassword']."</label>
+	<label for='portalLoginPassword' class='form'>".t('ContactInfo','PortalLoginPassword')."</label>
 	<input name='portalLoginPassword' id='portalLoginPassword' value='"; if (isset($ui_PortalLoginPassword)) echo $ui_PortalLoginPassword; echo "' tabindex=314 />
         <br/>
 
 	<br/>
-	<label for='creationdate' class='form'>".$l['all']['CreationDate']."</label>
+	<label for='creationdate' class='form'>".t('all','CreationDate')."</label>
 	<input disabled value='"; if (isset($ui_creationdate)) echo $ui_creationdate; echo "' tabindex=314 />
         <br/>
 
-	<label for='creationby' class='form'>".$l['all']['CreationBy']."</label>
+	<label for='creationby' class='form'>".t('all','CreationBy')."</label>
 	<input disabled value='"; if (isset($ui_creationby)) echo $ui_creationby; echo "' tabindex=315 />
         <br/>
 
-	<label for='updatedate' class='form'>".$l['all']['UpdateDate']."</label>
+	<label for='updatedate' class='form'>".t('all','UpdateDate')."</label>
 	<input disabled value='"; if (isset($ui_updatedate)) echo $ui_updatedate; echo "' tabindex=316 />
         <br/>
 
-	<label for='updateby' class='form'>".$l['all']['UpdateBy']."</label>
+	<label for='updateby' class='form'>".t('all','UpdateBy')."</label>
 	<input disabled value='"; if (isset($ui_updateby)) echo $ui_updateby; echo "' tabindex=317 />
         <br/>
 

--- a/include/menu/menu-items.php
+++ b/include/menu/menu-items.php
@@ -8,22 +8,22 @@
 
                                 <h2>
                                 
-                                <?php echo $l['all']['copyright1']; ?>
+                                <?php echo t('all','copyright1'); ?>
                                 
 				                                </h2>
 
                                 <ul id="nav">
 				<a name='top'></a>
 
-				<li><a href="index.php" <?php echo ($m_active == "Home") ? "class=\"active\"" : ""?>><?php echo $l['menu']['Home']; ?></a></li>
-				<li><a href="mng-main.php" <?php echo ($m_active == "Management") ? "class=\"active\"" : "" ?>><?php echo $l['menu']['Managment']; ?></a></li>
-				<li><a href="rep-main.php" <?php echo ($m_active == "Reports") ? "class=\"active\"" : "" ?>><?php echo $l['menu']['Reports']; ?></a></li>
-				<li><a href="acct-main.php" <?php echo ($m_active == "Accounting") ? "class=\"active\"" : "" ?>><?php echo $l['menu']['Accounting']; ?></a></li>
-				<li><a href="bill-main.php" <?php echo ($m_active == "Billing") ? "class=\"active\"" : "" ?>><?php echo $l['menu']['Billing']; ?></a></li>
-				<li><a href="gis-main.php" <?php echo ($m_active == "Gis") ? "class=\"active\"" : ""?>><?php echo $l['menu']['Gis']; ?></a></li>
-				<li><a href="graph-main.php" <?php echo ($m_active == "Graphs") ? "class=\"active\"" : ""?>><?php echo $l['menu']['Graphs']; ?></li>
-				<li><a href="config-main.php" <?php echo ($m_active == "Config") ? "class=\"active\"" : ""?>><?php echo $l['menu']['Config']; ?></li>
-				<li><a href="help-main.php" <?php echo ($m_active == "Help") ? "class=\"active\"" : ""?>><?php echo $l['menu']['Help']; ?></a></li>
+				<li><a href="index.php" <?php echo ($m_active == "Home") ? "class=\"active\"" : ""?>><?php echo t('menu','Home'); ?></a></li>
+				<li><a href="mng-main.php" <?php echo ($m_active == "Management") ? "class=\"active\"" : "" ?>><?php echo t('menu','Managment'); ?></a></li>
+				<li><a href="rep-main.php" <?php echo ($m_active == "Reports") ? "class=\"active\"" : "" ?>><?php echo t('menu','Reports'); ?></a></li>
+				<li><a href="acct-main.php" <?php echo ($m_active == "Accounting") ? "class=\"active\"" : "" ?>><?php echo t('menu','Accounting'); ?></a></li>
+				<li><a href="bill-main.php" <?php echo ($m_active == "Billing") ? "class=\"active\"" : "" ?>><?php echo t('menu','Billing'); ?></a></li>
+				<li><a href="gis-main.php" <?php echo ($m_active == "Gis") ? "class=\"active\"" : ""?>><?php echo t('menu','Gis'); ?></a></li>
+				<li><a href="graph-main.php" <?php echo ($m_active == "Graphs") ? "class=\"active\"" : ""?>><?php echo t('menu','Graphs'); ?></li>
+				<li><a href="config-main.php" <?php echo ($m_active == "Config") ? "class=\"active\"" : ""?>><?php echo t('menu','Config'); ?></li>
+				<li><a href="help-main.php" <?php echo ($m_active == "Help") ? "class=\"active\"" : ""?>><?php echo t('menu','Help'); ?></a></li>
 
                                 </ul>
 

--- a/lang/main.php
+++ b/lang/main.php
@@ -60,5 +60,32 @@
 			include (dirname(__FILE__)."/en.php");
 			break;
 	}
+	
+	// Translation function
+	function t($a, $b = null, $c = null, $d = null)
+	{
+		global $l;
+
+		$t = null;
+
+		if($b === null) {
+			$t = isset($l[$a]) ? $l[$a] : null;
+		}
+		else if($c === null) {
+			$t = isset($l[$a][$b]) ? $l[$a][$b] : null;
+		}
+		else if($d === null) {
+			$t = isset($l[$a][$b][$c]) ? $l[$a][$b][$c] : null;
+		}
+		else {
+			$t = isset($l[$a][$b][$c][$d]) ? $l[$a][$b][$c][$d] : null;
+		}
+
+		if($t === null) {
+			$t = 'Lang Error!';
+		}
+
+		return $t;
+	}
 
 ?>

--- a/library/exten-welcome_page.php
+++ b/library/exten-welcome_page.php
@@ -26,7 +26,7 @@ echo "
 	<center>
 
 		<h2> daloRADIUS Web Management Server </h2>
-		<h3> ".$l['all']['daloRADIUSVersion']." </h3>
+		<h3> ".t('all','daloRADIUSVersion')." </h3>
 		<h4> <a href=\"mailto:liran.tal@gmail.com\"> Liran Tal </a> </h4>
 		<br/><br/><br/>
 		<img src='images/daloradius_logo.jpg' border=0 />

--- a/login.php
+++ b/login.php
@@ -28,13 +28,13 @@
 				
 				<h2>
 				
-				<?php echo $l['all']['copyright1']; ?>	
+				<?php echo t('all','copyright1'); ?>	
 				</h2>
 				<br/>
 				
 				<ul id="subnav">
 				
-				<li><?php echo $l['all']['daloRADIUS'] ?></li>
+				<li><?php echo t('all','daloRADIUS') ?></li>
 				
 				</ul>
 		
@@ -42,9 +42,9 @@
 		
 		<div id="sidebar">
 		
-		<h2><?php echo $l['text']['LoginRequired'] ?></h2>
+		<h2><?php echo t('text','LoginRequired') ?></h2>
 				
-		<h3><?php echo $l['text']['LoginPlease'] ?></h3>
+		<h3><?php echo t('text','LoginPlease') ?></h3>
 
 				<form name="login" action="dologin.php" class="sidebar" method="post" >
 					<ul class="subnav">
@@ -74,16 +74,16 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['login.php'] ?></a></h2>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','login.php') ?></a></h2>
 				
                                 <div id="helpPage" style="display:none;visibility:visible" >				
-					<?php echo $l['helpPage']['login'] ?>
+					<?php echo t('helpPage','login') ?>
 				</div>
 				
 <?php
 	 if ($error) { 
 		echo $error;
-		echo $l['messages']['loginerror'];
+		echo t('messages','loginerror');
 	}
 ?>
 				

--- a/menu-accounting-custom.php
+++ b/menu-accounting-custom.php
@@ -40,15 +40,15 @@
 
 	<form name="acctcustomquery" action="acct-custom-query.php" method="get" class="sidebar">
 
-	<input class="sidebutton" type="submit" name="submit" value="<?php echo $l['button']['ProcessQuery'] ?>" tabindex=3 />
+	<input class="sidebutton" type="submit" name="submit" value="<?php echo t('button','ProcessQuery') ?>" tabindex=3 />
 	<br/><br/>	
 
-	<h109><?php echo $l['button']['BetweenDates']; ?></h109> <br/>
+	<h109><?php echo t('button','BetweenDates'); ?></h109> <br/>
 	
 
                                                         <input name="startdate" type="text" id="startdate" 
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['Date']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','Date'); ?> <br/>'
 value="<?php if (isset($accounting_custom_startdate)) echo $accounting_custom_startdate;
 						else echo date("Y-m-01"); ?>">
 <img src="library/js_date/calendar.gif" onclick="showChooser(this, 'startdate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
@@ -56,7 +56,7 @@ value="<?php if (isset($accounting_custom_startdate)) echo $accounting_custom_st
 
                                                         <input name="enddate" type="text" id="enddate" 
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['Date']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','Date'); ?> <br/>'
 value="<?php if (isset($accounting_custom_enddate)) echo $accounting_custom_enddate;
 						else echo date("Y-m-t"); ?>">
 <img src="library/js_date/calendar.gif" onclick="showChooser(this, 'enddate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
@@ -64,7 +64,7 @@ value="<?php if (isset($accounting_custom_enddate)) echo $accounting_custom_endd
 
 
 		<br/><br/>
-		<h109><?php echo $l['button']['Where']; ?></h109> <br/>
+		<h109><?php echo t('button','Where'); ?></h109> <br/>
 			<center>
 			<select name="fields" size="1" class="generic" >
 				<option value="RadAcctId"> RadAcctId </option>
@@ -100,11 +100,11 @@ value="<?php if (isset($accounting_custom_enddate)) echo $accounting_custom_endd
 			</center>
 		<input type="text" name="where_field" 
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['Filter']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','Filter'); ?> <br/>'
 			value="<?php if (isset($accounting_custom_value)) echo $accounting_custom_value; ?>" />
 
 		<br/><br/>
-		<h109><?php echo $l['button']['AccountingFieldsinQuery']; ?></h109><br/>
+		<h109><?php echo t('button','AccountingFieldsinQuery'); ?></h109><br/>
 		<input type="checkbox" name="sqlfields[]" value="RadAcctId" /> <h109> RadAcctId </h109> <br/>
 		<input type="checkbox" name="sqlfields[]" value="AcctSessionId" /> <h109> AcctSessionId </h109> <br/>
 		<input type="checkbox" name="sqlfields[]" value="AcctUniqueId" /> <h109> AcctUniqueId</h109> <br/>
@@ -133,7 +133,7 @@ value="<?php if (isset($accounting_custom_enddate)) echo $accounting_custom_endd
 		<a class="table" href="javascript:SetChecked(1,'sqlfields[]','acctcustomquery')">All</a>
 		<a class="table" href="javascript:SetChecked(0,'sqlfields[]','acctcustomquery')">None</a>
 		<br/><br/>
-		<h109><?php echo $l['button']['OrderBy'] ?><h109> <br/>
+		<h109><?php echo t('button','OrderBy') ?><h109> <br/>
 			<center>
 			<select name="orderBy" size="1">
 				<option value="RadAcctId"> RadAcctId </option>
@@ -170,7 +170,7 @@ value="<?php if (isset($accounting_custom_enddate)) echo $accounting_custom_endd
 
 
 	<br/>
-	<input class="sidebutton" type="submit" name="submit" value="<?php echo $l['button']['ProcessQuery'] ?>" tabindex=3 />
+	<input class="sidebutton" type="submit" name="submit" value="<?php echo t('button','ProcessQuery') ?>" tabindex=3 />
 	</form></li>
 				
 

--- a/menu-accounting-hotspot.php
+++ b/menu-accounting-hotspot.php
@@ -41,7 +41,7 @@
 	<h3>Hotspots Accounting</h3>
 	<ul class="subnav">
 
-		<li><a href="javascript:document.accthotspot.submit();"><b>&raquo;</b><?php echo $l['button']['HotspotAccounting'] ?><a>
+		<li><a href="javascript:document.accthotspot.submit();"><b>&raquo;</b><?php echo t('button','HotspotAccounting') ?><a>
 			<form name="accthotspot" action="acct-hotspot-accounting.php" method="post" class="sidebar">
 				<select name="hotspot" size="3">
 <?php
@@ -66,7 +66,7 @@
 				</select>
 				</form></li>
 			
-				<li><a href="acct-hotspot-compare.php"><b>&raquo;</b><?php echo $l['button']['HotspotsComparison'] ?>
+				<li><a href="acct-hotspot-compare.php"><b>&raquo;</b><?php echo t('button','HotspotsComparison') ?>
 					</a></li>
 			</ul>
 			

--- a/menu-accounting-maintenance.php
+++ b/menu-accounting-maintenance.php
@@ -37,9 +37,9 @@
 	<h3>Maintenance</h3>
 	<ul class="subnav">
 
-		<li><a href="acct-maintenance-cleanup.php"><b>&raquo;</b><?php echo $l['button']['CleanupStaleSessions'] ?>
+		<li><a href="acct-maintenance-cleanup.php"><b>&raquo;</b><?php echo t('button','CleanupStaleSessions') ?>
 			</a></li>
-		<li><a href="acct-maintenance-delete.php"><b>&raquo;</b><?php echo $l['button']['DeleteAccountingRecords'] ?>
+		<li><a href="acct-maintenance-delete.php"><b>&raquo;</b><?php echo t('button','DeleteAccountingRecords') ?>
 			</a></li>
 	</ul>
 

--- a/menu-accounting-plans.php
+++ b/menu-accounting-plans.php
@@ -42,16 +42,16 @@
 	<h3>Accounting</h3>
 	<ul class="subnav">
 	
-		<li><a href="javascript:document.acctdate.submit();"><b>&raquo;</b><?php echo $l['button']['PlanUsage'] ?></a>
+		<li><a href="javascript:document.acctdate.submit();"><b>&raquo;</b><?php echo t('button','PlanUsage') ?></a>
 			<form name="acctdate" action="acct-plans-usage.php" method="get" class="sidebar">
 			<input name="username" type="text" id="usernamePlan" <?php if ($autoComplete) echo "autocomplete='off'"; ?>
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['Username']; ?>'
+                                tooltipText='<?php echo t('Tooltip','Username'); ?>'
 				value="<?php if (isset($accounting_plan_username)) echo $accounting_plan_username;  ?>">
 
 			<input name="startdate" type="text" id="startdate" 
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['Date']; ?>'
+                                tooltipText='<?php echo t('Tooltip','Date'); ?>'
 				value="<?php if (isset($accounting_plan_startdate)) echo $accounting_plan_startdate;
 			else echo date("Y-m-01"); ?>">
 			
@@ -62,7 +62,7 @@
 
 			<input name="enddate" type="text" id="enddate" 
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['Date']; ?>'
+                                tooltipText='<?php echo t('Tooltip','Date'); ?>'
 				value="<?php if (isset($accounting_plan_enddate)){ echo $accounting_plan_enddate;}
 				else { echo date("Y-m-t");} ?>">
 			<img src="library/js_date/calendar.gif" 

--- a/menu-accounting.php
+++ b/menu-accounting.php
@@ -42,39 +42,39 @@
 	<h3>Users Accounting</h3>
 	<ul class="subnav">
 	
-		<li><a href="javascript:document.acctusername.submit();"><b>&raquo;</b><?php echo $l['button']['UserAccounting'] ?></a>
+		<li><a href="javascript:document.acctusername.submit();"><b>&raquo;</b><?php echo t('button','UserAccounting') ?></a>
 			<form name="acctusername" action="acct-username.php" method="get" class="sidebar">
 			<input name="username" type="text" id="usernameAcct" <?php if ($autoComplete) echo "autocomplete='off'"; ?>
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['Username']; ?>'
+                                tooltipText='<?php echo t('Tooltip','Username'); ?>'
 				value="<?php if (isset($accounting_username)) echo $accounting_username; ?>">
 			</form></li>
 
-		<li><a href="javascript:document.acctipaddress.submit();"><b>&raquo;</b><?php echo $l['button']['IPAccounting'] ?></a>
+		<li><a href="javascript:document.acctipaddress.submit();"><b>&raquo;</b><?php echo t('button','IPAccounting') ?></a>
 			<form name="acctipaddress" action="acct-ipaddress.php" method="get" class="sidebar">
 			<input name="ipaddress" type="text" 
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['IPAddress']; ?>'
+                                tooltipText='<?php echo t('Tooltip','IPAddress'); ?>'
 				value="<?php if (isset($accounting_ipaddress)) echo $accounting_ipaddress; ?>">
 			</form></li>
 
-		<li><a href="javascript:document.acctnasipaddress.submit();"><b>&raquo;</b><?php echo $l['button']['NASIPAccounting'] ?></a>
+		<li><a href="javascript:document.acctnasipaddress.submit();"><b>&raquo;</b><?php echo t('button','NASIPAccounting') ?></a>
 			<form name="acctnasipaddress" action="acct-nasipaddress.php" method="get" class="sidebar">
 			<input name="nasipaddress" type="text" 
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['IPAddress']; ?>'
+                                tooltipText='<?php echo t('Tooltip','IPAddress'); ?>'
 				value="<?php if (isset($accounting_nasipaddress)) echo $accounting_nasipaddress; ?>">
 			</form></li>
 
-		<li><a href="javascript:document.acctdate.submit();"><b>&raquo;</b><?php echo $l['button']['DateAccounting'] ?></a>
+		<li><a href="javascript:document.acctdate.submit();"><b>&raquo;</b><?php echo t('button','DateAccounting') ?></a>
 			<form name="acctdate" action="acct-date.php" method="get" class="sidebar">
 			<input name="username" type="text" id="usernameDate" <?php if ($autoComplete) echo "autocomplete='off'"; ?>
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['Username']; ?>'
+                                tooltipText='<?php echo t('Tooltip','Username'); ?>'
 				value="<?php if (isset($accounting_date_username)) echo $accounting_date_username;  ?>">
 			<input name="startdate" type="text" id="startdate" 
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['Date']; ?>'
+                                tooltipText='<?php echo t('Tooltip','Date'); ?>'
 				value="<?php if (isset($accounting_date_startdate)) echo $accounting_date_startdate;
 			else echo date("Y-m-01"); ?>">
 			
@@ -85,7 +85,7 @@
 
 			<input name="enddate" type="text" id="enddate" 
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['Date']; ?>'
+                                tooltipText='<?php echo t('Tooltip','Date'); ?>'
 				value="<?php if (isset($accounting_date_enddate)){ echo $accounting_date_enddate;}
 				else { echo date("Y-m-t");} ?>">
 			<img src="library/js_date/calendar.gif" 
@@ -95,8 +95,8 @@
 
 			</form></li>
 
-		<li><a href="acct-all.php"><b>&raquo;</b><?php echo $l['button']['AllRecords'] ?></a></li>
-		<li><a href="acct-active.php"><b>&raquo;</b><?php echo $l['button']['ActiveRecords'] ?></a></li>
+		<li><a href="acct-all.php"><b>&raquo;</b><?php echo t('button','AllRecords') ?></a></li>
+		<li><a href="acct-active.php"><b>&raquo;</b><?php echo t('button','ActiveRecords') ?></a></li>
 
 	</ul>
 

--- a/menu-bill-history.php
+++ b/menu-bill-history.php
@@ -37,10 +37,10 @@
 
         <form name="billhistory" action="bill-history-query.php" method="get" class="sidebar">
 
-        <input class="sidebutton" type="submit" name="submit" value="<?php echo $l['button']['ProcessQuery'] ?>" tabindex=3 />
+        <input class="sidebutton" type="submit" name="submit" value="<?php echo t('button','ProcessQuery') ?>" tabindex=3 />
 	<br/><br/>
 
-		<h109><?php echo $l['button']['BetweenDates']; ?></h109> <br/>
+		<h109><?php echo t('button','BetweenDates'); ?></h109> <br/>
 
                         <input name="startdate" type="text" id="startdate"
                                 value="<?php if (isset($billing_date_startdate)) echo $billing_date_startdate;
@@ -62,11 +62,11 @@
 			<br/><br/>
 
 
-		<h109><?php echo $l['all']['Username']; ?></h109> <br/>
+		<h109><?php echo t('all','Username'); ?></h109> <br/>
                         <input name="username" type="text"
                                 value="<?php if (isset($billing_history_username)) echo $billing_history_username; else echo "*"; ?>">
 
-		<h109><?php echo $l['all']['BillAction']; ?></h109> <br/>
+		<h109><?php echo t('all','BillAction'); ?></h109> <br/>
                         <select name="billaction" size="1">
                                 <option value="<?php if (isset($billing_history_billaction)) echo $billing_history_billaction; else echo "%"; ?>">
                                         <?php if (isset($billing_history_billaction)) echo $billing_history_billaction; else echo "Any"; ?>
@@ -79,31 +79,31 @@
 
 
                 <br/><br/>
-                <h109><?php echo $l['button']['AccountingFieldsinQuery']; ?></h109><br/>
-                <input type="checkbox" name="sqlfields[]" value="id" /> <h109> <?php echo $l['all']['ID']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="username" checked /> <h109><?php echo $l['all']['Username']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="planId" checked /> <h109><?php echo $l['all']['PlanId']; ?> </h109> <br/>
+                <h109><?php echo t('button','AccountingFieldsinQuery'); ?></h109><br/>
+                <input type="checkbox" name="sqlfields[]" value="id" /> <h109> <?php echo t('all','ID'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="username" checked /> <h109><?php echo t('all','Username'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="planId" checked /> <h109><?php echo t('all','PlanId'); ?> </h109> <br/>
 
-                <input type="checkbox" name="sqlfields[]" value="billAmount"  checked /> <h109><?php echo $l['all']['BillAmount']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="billAction"  checked /> <h109><?php echo $l['all']['BillAction']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="billPerformer"  checked /> <h109><?php echo $l['all']['BillPerformer']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="billReason"  /> <h109><?php echo $l['all']['BillReason']; ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="billAmount"  checked /> <h109><?php echo t('all','BillAmount'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="billAction"  checked /> <h109><?php echo t('all','BillAction'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="billPerformer"  checked /> <h109><?php echo t('all','BillPerformer'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="billReason"  /> <h109><?php echo t('all','BillReason'); ?> </h109> <br/>
 
-                <input type="checkbox" name="sqlfields[]" value="paymentmethod"  checked /> <h109><?php echo $l['ContactInfo']['PaymentMethod']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="cash"  /> <h109><?php echo $l['ContactInfo']['Cash']; ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="paymentmethod"  checked /> <h109><?php echo t('ContactInfo','PaymentMethod'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="cash"  /> <h109><?php echo t('ContactInfo','Cash'); ?> </h109> <br/>
 
-                <input type="checkbox" name="sqlfields[]" value="creditcardname"  /> <h109><?php echo $l['ContactInfo']['CreditCardName']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="creditcardnumber"  /> <h109><?php echo $l['ContactInfo']['CreditCardNumber']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="creditcardverification"  /> <h109><?php echo $l['ContactInfo']['CreditCardVerificationNumber']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="creditcardtype"  /> <h109><?php echo $l['ContactInfo']['CreditCardType']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="creditcardexp"  /> <h109><?php echo $l['ContactInfo']['CreditCardExpiration']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="coupon"  /> <h109><?php echo $l['all']['Coupon']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="discount"  /> <h109><?php echo $l['all']['Discount']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="notes"  /> <h109><?php echo $l['ContactInfo']['Notes']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="creationdate"  /> <h109><?php echo $l['all']['CreationDate']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="creationby"  /> <h109><?php echo $l['all']['CreationBy']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="updatedate"  /> <h109><?php echo $l['all']['UpdateDate']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="updateby"  /> <h109><?php echo $l['all']['UpdateBy']; ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="creditcardname"  /> <h109><?php echo t('ContactInfo','CreditCardName'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="creditcardnumber"  /> <h109><?php echo t('ContactInfo','CreditCardNumber'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="creditcardverification"  /> <h109><?php echo t('ContactInfo','CreditCardVerificationNumber'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="creditcardtype"  /> <h109><?php echo t('ContactInfo','CreditCardType'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="creditcardexp"  /> <h109><?php echo t('ContactInfo','CreditCardExpiration'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="coupon"  /> <h109><?php echo t('all','Coupon'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="discount"  /> <h109><?php echo t('all','Discount'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="notes"  /> <h109><?php echo t('ContactInfo','Notes'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="creationdate"  /> <h109><?php echo t('all','CreationDate'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="creationby"  /> <h109><?php echo t('all','CreationBy'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="updatedate"  /> <h109><?php echo t('all','UpdateDate'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="updateby"  /> <h109><?php echo t('all','UpdateBy'); ?> </h109> <br/>
 
                 Select:
                 <a class="table" href="javascript:SetChecked(1,'sqlfields[]','billhistory')">All</a>
@@ -111,7 +111,7 @@
 
 
                 <br/><br/>
-                <h109><?php echo $l['button']['OrderBy'] ?><h109> <br/>
+                <h109><?php echo t('button','OrderBy') ?><h109> <br/>
                         <center>
                         <select name="orderBy" size="1">
                                 <option value="id"> Id </option>
@@ -126,7 +126,7 @@
                         </center>
 
         <br/>
-        <input class="sidebutton" type="submit" name="submit" value="<?php echo $l['button']['ProcessQuery'] ?>" tabindex=3 />
+        <input class="sidebutton" type="submit" name="submit" value="<?php echo t('button','ProcessQuery') ?>" tabindex=3 />
 
 
 

--- a/menu-bill-invoice.php
+++ b/menu-bill-invoice.php
@@ -30,13 +30,13 @@
 	<h3>Invoice Management</h3>
 	<ul class="subnav">
 	
-		<li><a href="javascript:document.invoicelist.submit();"><b>&raquo;</b><?php echo $l['button']['ListInvoices'] ?></a>
+		<li><a href="javascript:document.invoicelist.submit();"><b>&raquo;</b><?php echo t('button','ListInvoices') ?></a>
 		
 			<form name="invoicelist" action="bill-invoice-list.php" method="get" class="sidebar">
             	<input name="username" type="text" id="invoiceUsername" 
                 autocomplete='off'
                 onClick='javascript:__displayTooltip();'
-				tooltipText='<?php echo $l['Tooltip']['Username']; ?> <br/>'
+				tooltipText='<?php echo t('Tooltip','Username'); ?> <br/>'
                 value="<?php if (isset($edit_invoiceUsername)) echo $edit_invoiceUsername; ?>" tabindex=3>
                 
 			<?php
@@ -48,24 +48,24 @@
 			</form>
 		
 		</li>
-		<li><a href="javascript:document.invoicenew.submit();"><b>&raquo;</b><?php echo $l['button']['NewInvoice'] ?></a>
+		<li><a href="javascript:document.invoicenew.submit();"><b>&raquo;</b><?php echo t('button','NewInvoice') ?></a>
 		<form name="invoicenew" action="bill-invoice-new.php" method="get" class="sidebar">
             	<input name="username" type="text" id="invoiceUsernameNew" 
                 autocomplete='off'
                 onClick='javascript:__displayTooltip();'
-				tooltipText='<?php echo $l['Tooltip']['Username']; ?> <br/>'
+				tooltipText='<?php echo t('Tooltip','Username'); ?> <br/>'
                 value="<?php if (isset($edit_invoiceUsername)) echo $edit_invoiceUsername; ?>" tabindex=3>
 		</form>
 		</li>
-		<li><a href="javascript:document.billinvoiceedit.submit();""><b>&raquo;</b><?php echo $l['button']['EditInvoice'] ?><a>
+		<li><a href="javascript:document.billinvoiceedit.submit();""><b>&raquo;</b><?php echo t('button','EditInvoice') ?><a>
 			<form name="billinvoiceedit" action="bill-invoice-edit.php" method="get" class="sidebar">
 			<input name="invoice_id" type="text" id="invoiceIdEdit" <?php if ($autoComplete) echo "autocomplete='off'"; ?>
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['invoiceID']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','invoiceID'); ?> <br/>'
 				value="<?php if (isset($edit_invoiceid)) echo $edit_invoiceid; ?>" tabindex=3>
 			</form></li>
 			
-		<li><a href="bill-invoice-del.php"><b>&raquo;</b><?php echo $l['button']['RemoveInvoice'] ?></a></li>
+		<li><a href="bill-invoice-del.php"><b>&raquo;</b><?php echo t('button','RemoveInvoice') ?></a></li>
 		
 	</ul>
 	
@@ -77,11 +77,11 @@
 		
 			<form name="billinvoicereport" action="bill-invoice-report.php" method="get" class="sidebar">
 			
-				<h109><?php echo $l['button']['BetweenDates']; ?></h109> <br/>
+				<h109><?php echo t('button','BetweenDates'); ?></h109> <br/>
 				
 				<input name="startdate" type="text" id="startdate" 
 			                                onClick='javascript:__displayTooltip();'
-			                                tooltipText='<?php echo $l['Tooltip']['Date']; ?> <br/>'
+			                                tooltipText='<?php echo t('Tooltip','Date'); ?> <br/>'
 					value="<?php if (isset($billinvoice_startdate)) echo $billinvoice_startdate;
 									else echo date("Y-m-01"); ?>">
 				<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'startdate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
@@ -89,7 +89,7 @@
 			
 				<input name="enddate" type="text" id="enddate" 
 			                                onClick='javascript:__displayTooltip();'
-			                                tooltipText='<?php echo $l['Tooltip']['Date']; ?> <br/>'
+			                                tooltipText='<?php echo t('Tooltip','Date'); ?> <br/>'
 					value="<?php if (isset($billinvoice_enddate)) echo $billinvoice_enddate;
 									else echo date("Y-m-t"); ?>">
 				<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'enddate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
@@ -105,12 +105,12 @@
 				
 				<input name="username" type="text" id="usernameEdit" <?php if ($autoComplete) echo "autocomplete='off'"; ?>
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['Username']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','Username'); ?> <br/>'
                                 value="<?php if (isset($billinvoice_username) && $billinvoice_username != '%') echo $billinvoice_username; ?>" tabindex=1>
 				
 				
 					<br/>
-				<input class="sidebutton" type="submit" name="submit" value="<?php echo $l['button']['GenerateReport'] ?>" tabindex=3 />
+				<input class="sidebutton" type="submit" name="submit" value="<?php echo t('button','GenerateReport') ?>" tabindex=3 />
 				
 			</form></li>
 					

--- a/menu-bill-merchant.php
+++ b/menu-bill-merchant.php
@@ -37,10 +37,10 @@
 
         <form name="billpaypaltransactions" action="bill-merchant-transactions.php" method="get" class="sidebar">
 
-        <input class="sidebutton" type="submit" name="submit" value="<?php echo $l['button']['ProcessQuery'] ?>" tabindex=3 />
+        <input class="sidebutton" type="submit" name="submit" value="<?php echo t('button','ProcessQuery') ?>" tabindex=3 />
 	<br/><br/>
 
-		<h109><?php echo $l['button']['BetweenDates']; ?></h109> <br/>
+		<h109><?php echo t('button','BetweenDates'); ?></h109> <br/>
 
                         <input name="startdate" type="text" id="startdate"
                                 value="<?php if (isset($billing_date_startdate)) echo $billing_date_startdate;
@@ -61,7 +61,7 @@
                                 style="display: none; visibility: hidden; width: 160px;"></div>
 			<br/><br/>
 
-		<h109><?php echo $l['all']['VendorType']; ?></h109> <br/>
+		<h109><?php echo t('all','VendorType'); ?></h109> <br/>
                         <select name="vendor_type" size="1">
                                 <option value="<?php if (isset($billing_paypal_vendor_type)) echo $billing_paypal_vendor_type; else echo "%"; ?>">
                                         <?php if (isset($billing_paypal_vendor_type)) echo $billing_paypal_vendor_type; else echo "Any"; ?>
@@ -73,12 +73,12 @@
                         </select>
 			<br/><br/>
 
-		<h109><?php echo $l['all']['PayerEmail']; ?></h109> <br/>
+		<h109><?php echo t('all','PayerEmail'); ?></h109> <br/>
                         <input name="payer_email" type="text"
                                 value="<?php if (isset($billing_paypal_payeremail)) echo $billing_paypal_payeremail; else echo "*"; ?>">
 			<br/>
 
-		<h109><?php echo $l['all']['PaymentStatus']; ?></h109> <br/>
+		<h109><?php echo t('all','PaymentStatus'); ?></h109> <br/>
                         <select name="payment_status" size="1">
                                 <option value="<?php if (isset($billing_paypal_paymentstatus)) echo $billing_paypal_paymentstatus; else echo "%"; ?>">
                                         <?php if (isset($billing_paypal_paymentstatus)) echo $billing_paypal_paymentstatus; else echo "Any"; ?>
@@ -100,42 +100,42 @@
 
 
                 <br/><br/><br/>
-                <h109><?php echo $l['button']['AccountingFieldsinQuery']; ?></h109><br/>
-                <input type="checkbox" name="sqlfields[]" value="id" /> <h109> <?php echo $l['all']['ID']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="username" checked /> <h109><?php echo $l['all']['Username']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="password"  /> <h109><?php echo $l['all']['Password']; ?></h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="txnId"  /> <h109><?php echo $l['all']['TxnId']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="planId"  /> <h109><?php echo $l['all']['PlanId']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="quantity"  /> <h109><?php echo $l['all']['Quantity']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="business_email"  /> <h109><?php echo $l['all']['ReceiverEmail']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="business_id"  /> <h109><?php echo $l['all']['Business']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payment_tax" /> <h109><?php echo $l['all']['Tax']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payment_cost" checked /> <h109><?php echo $l['all']['Cost']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payment_fee" checked /> <h109><?php echo $l['all']['TransactionFee']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payment_total"  /> <h109><?php echo $l['all']['TotalCost']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payment_currency" checked /> <h109><?php echo $l['all']['PaymentCurrency']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="first_name" checked /> <h109><?php echo $l['all']['FirstName']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="last_name" checked /> <h109><?php echo $l['all']['LastName']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payer_email" checked /> <h109><?php echo $l['all']['PayerEmail']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payer_address_name"  /> <h109><?php echo $l['all']['AddressRecipient']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payer_address_street"  /> <h109><?php echo $l['all']['Street']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payer_address_country" checked /> <h109><?php echo $l['all']['Country']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payer_address_country_code"  /> <h109><?php echo $l['all']['CountryCode']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payer_address_city" checked /> <h109><?php echo $l['all']['City']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payer_address_state" checked /> <h109><?php echo $l['all']['State']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payer_address_zip"  /> <h109><?php echo $l['all']['Zip']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payment_date" checked /> <h109><?php echo $l['all']['PaymentDate']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payment_status" checked /> <h109><?php echo $l['all']['PaymentStatus']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payer_status" /> <h109><?php echo $l['all']['PayerStatus']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payment_address_status" /> <h109><?php echo $l['all']['PaymentAddressStatus']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="vendor_type" checked /> <h109><?php echo $l['all']['VendorType']; ?> </h109> <br/>
+                <h109><?php echo t('button','AccountingFieldsinQuery'); ?></h109><br/>
+                <input type="checkbox" name="sqlfields[]" value="id" /> <h109> <?php echo t('all','ID'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="username" checked /> <h109><?php echo t('all','Username'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="password"  /> <h109><?php echo t('all','Password'); ?></h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="txnId"  /> <h109><?php echo t('all','TxnId'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="planId"  /> <h109><?php echo t('all','PlanId'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="quantity"  /> <h109><?php echo t('all','Quantity'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="business_email"  /> <h109><?php echo t('all','ReceiverEmail'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="business_id"  /> <h109><?php echo t('all','Business'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payment_tax" /> <h109><?php echo t('all','Tax'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payment_cost" checked /> <h109><?php echo t('all','Cost'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payment_fee" checked /> <h109><?php echo t('all','TransactionFee'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payment_total"  /> <h109><?php echo t('all','TotalCost'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payment_currency" checked /> <h109><?php echo t('all','PaymentCurrency'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="first_name" checked /> <h109><?php echo t('all','FirstName'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="last_name" checked /> <h109><?php echo t('all','LastName'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payer_email" checked /> <h109><?php echo t('all','PayerEmail'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payer_address_name"  /> <h109><?php echo t('all','AddressRecipient'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payer_address_street"  /> <h109><?php echo t('all','Street'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payer_address_country" checked /> <h109><?php echo t('all','Country'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payer_address_country_code"  /> <h109><?php echo t('all','CountryCode'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payer_address_city" checked /> <h109><?php echo t('all','City'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payer_address_state" checked /> <h109><?php echo t('all','State'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payer_address_zip"  /> <h109><?php echo t('all','Zip'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payment_date" checked /> <h109><?php echo t('all','PaymentDate'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payment_status" checked /> <h109><?php echo t('all','PaymentStatus'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payer_status" /> <h109><?php echo t('all','PayerStatus'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payment_address_status" /> <h109><?php echo t('all','PaymentAddressStatus'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="vendor_type" checked /> <h109><?php echo t('all','VendorType'); ?> </h109> <br/>
                 Select:
                 <a class="table" href="javascript:SetChecked(1,'sqlfields[]','billpaypaltransactions')">All</a>
                 <a class="table" href="javascript:SetChecked(0,'sqlfields[]','billpaypaltransactions')">None</a>
 
 
                 <br/><br/>
-                <h109><?php echo $l['button']['OrderBy'] ?><h109> <br/>
+                <h109><?php echo t('button','OrderBy') ?><h109> <br/>
                         <center>
                         <select name="orderBy" size="1">
                                 <option value="id"> Id </option>
@@ -150,7 +150,7 @@
                         </center>
 
         <br/>
-        <input class="sidebutton" type="submit" name="submit" value="<?php echo $l['button']['ProcessQuery'] ?>" tabindex=3 />
+        <input class="sidebutton" type="submit" name="submit" value="<?php echo t('button','ProcessQuery') ?>" tabindex=3 />
 
 
 

--- a/menu-bill-payments.php
+++ b/menu-bill-payments.php
@@ -30,48 +30,48 @@
                                 <h3>Payments Management</h3>
                                 <ul class="subnav">
 
-                                                <li><a href="javascript:document.paymentslist.submit();"><b>&raquo;</b><?php echo $l['button']['ListPayments'] ?></a>
+                                                <li><a href="javascript:document.paymentslist.submit();"><b>&raquo;</b><?php echo t('button','ListPayments') ?></a>
                                                 
 													<form name="paymentslist" action="bill-payments-list.php" method="get" class="sidebar">
                                                         <input name="username" type="text" id="username" 
                                                         autocomplete='off'
                                 						onClick='javascript:__displayTooltip();'
-														tooltipText='<?php echo $l['Tooltip']['Username']; ?> <br/>'
+														tooltipText='<?php echo t('Tooltip','Username'); ?> <br/>'
                                                     	value="<?php if (isset($edit_username)) echo $edit_username; ?>" tabindex=3>
                                                     	
                                                         <input name="invoice_id" type="text" id="invoice_id" 
                                 						onClick='javascript:__displayTooltip();'
-														tooltipText='<?php echo $l['Tooltip']['invoiceID']; ?> <br/>'
+														tooltipText='<?php echo t('Tooltip','invoiceID'); ?> <br/>'
                                                     	value="<?php if (isset($edit_invoice_id)) echo $edit_invoice_id; ?>" tabindex=3>
 													</form>
                                                 
                                                 </li>
-                                                <li><a href="bill-payments-new.php"><b>&raquo;</b><?php echo $l['button']['NewPayment'] ?></a></li>
-                                                <li><a href="javascript:document.paymentsedit.submit();"><b>&raquo;</b><?php echo $l['button']['EditPayment'] ?></a>
+                                                <li><a href="bill-payments-new.php"><b>&raquo;</b><?php echo t('button','NewPayment') ?></a></li>
+                                                <li><a href="javascript:document.paymentsedit.submit();"><b>&raquo;</b><?php echo t('button','EditPayment') ?></a>
                                                         <form name="paymentsedit" action="bill-payments-edit.php" method="get" class="sidebar">
                                                         <input name="payment_id" type="text" id="payment_id" 
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['PaymentId']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','PaymentId'); ?> <br/>'
                                                                 value="<?php if (isset($edit_payment_id)) echo $edit_payment_id; ?>" tabindex=3>
                                                         </form></li>
 
-                                                <li><a href="bill-payments-del.php"><b>&raquo;</b><?php echo $l['button']['RemovePayment'] ?></a></li>
+                                                <li><a href="bill-payments-del.php"><b>&raquo;</b><?php echo t('button','RemovePayment') ?></a></li>
                                 </ul>
 
 
                                 <h3>Payment Types Management</h3>
                                 <ul class="subnav">
 
-                                                <li><a href="bill-payment-types-list.php"><b>&raquo;</b><?php echo $l['button']['ListPayTypes'] ?></a></li>
-                                                <li><a href="bill-payment-types-new.php"><b>&raquo;</b><?php echo $l['button']['NewPayType'] ?></a></li>
-                                                <li><a href="javascript:document.paymenttypesedit.submit();""><b>&raquo;</b><?php echo $l['button']['EditPayType'] ?></a>
+                                                <li><a href="bill-payment-types-list.php"><b>&raquo;</b><?php echo t('button','ListPayTypes') ?></a></li>
+                                                <li><a href="bill-payment-types-new.php"><b>&raquo;</b><?php echo t('button','NewPayType') ?></a></li>
+                                                <li><a href="javascript:document.paymenttypesedit.submit();""><b>&raquo;</b><?php echo t('button','EditPayType') ?></a>
                                                         <form name="paymenttypesedit" action="bill-payment-types-edit.php" method="get" class="sidebar">
                                                         <input name="paymentname" type="text" id="paymentname" <?php if ($autoComplete) echo "autocomplete='off'"; ?>
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['PayTypeName']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','PayTypeName'); ?> <br/>'
                                                                 value="<?php if (isset($edit_paymentName)) echo $edit_paymentName; ?>" tabindex=3>
                                                         </form></li>
-                                                <li><a href="bill-payment-types-del.php"><b>&raquo;</b><?php echo $l['button']['RemovePayType'] ?></a></li>
+                                                <li><a href="bill-payment-types-del.php"><b>&raquo;</b><?php echo t('button','RemovePayType') ?></a></li>
                                 </ul>
 
 

--- a/menu-bill-paypal.php
+++ b/menu-bill-paypal.php
@@ -37,10 +37,10 @@
 
         <form name="billpaypaltransactions" action="bill-merchant-transactions.php" method="get" class="sidebar">
 
-        <input class="sidebutton" type="submit" name="submit" value="<?php echo $l['button']['ProcessQuery'] ?>" tabindex=3 />
+        <input class="sidebutton" type="submit" name="submit" value="<?php echo t('button','ProcessQuery') ?>" tabindex=3 />
 	<br/><br/>
 
-		<h109><?php echo $l['button']['BetweenDates']; ?></h109> <br/>
+		<h109><?php echo t('button','BetweenDates'); ?></h109> <br/>
 
                         <input name="startdate" type="text" id="startdate"
                                 value="<?php if (isset($billing_date_startdate)) echo $billing_date_startdate;
@@ -61,7 +61,7 @@
                                 style="display: none; visibility: hidden; width: 160px;"></div>
 			<br/><br/>
 
-		<h109><?php echo $l['all']['VendorType']; ?></h109> <br/>
+		<h109><?php echo t('all','VendorType'); ?></h109> <br/>
                         <select name="vendor_type" size="1">
                                 <option value="<?php if (isset($billing_paypal_vendor_type)) echo $billing_paypal_vendor_type; else echo "%"; ?>">
                                         <?php if (isset($billing_paypal_vendor_type)) echo $billing_paypal_vendor_type; else echo "Any"; ?>
@@ -73,12 +73,12 @@
                         </select>
 			<br/><br/>
 
-		<h109><?php echo $l['all']['PayerEmail']; ?></h109> <br/>
+		<h109><?php echo t('all','PayerEmail'); ?></h109> <br/>
                         <input name="payer_email" type="text"
                                 value="<?php if (isset($billing_paypal_payeremail)) echo $billing_paypal_payeremail; else echo "*"; ?>">
 			<br/>
 
-		<h109><?php echo $l['all']['PaymentStatus']; ?></h109> <br/>
+		<h109><?php echo t('all','PaymentStatus'); ?></h109> <br/>
                         <select name="payment_status" size="1">
                                 <option value="<?php if (isset($billing_paypal_paymentstatus)) echo $billing_paypal_paymentstatus; else echo "%"; ?>">
                                         <?php if (isset($billing_paypal_paymentstatus)) echo $billing_paypal_paymentstatus; else echo "Any"; ?>
@@ -100,43 +100,43 @@
 
 
                 <br/><br/><br/>
-                <h109><?php echo $l['button']['AccountingFieldsinQuery']; ?></h109><br/>
-                <input type="checkbox" name="sqlfields[]" value="id" /> <h109> <?php echo $l['all']['ID']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="username" checked /> <h109><?php echo $l['all']['Username']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="password"  /> <h109><?php echo $l['all']['Password']; ?></h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="txnId"  /> <h109><?php echo $l['all']['TxnId']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="planName" checked /> <h109><?php echo $l['all']['PlanName']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="planId"  /> <h109><?php echo $l['all']['PlanId']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="quantity"  /> <h109><?php echo $l['all']['Quantity']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="business_email"  /> <h109><?php echo $l['all']['ReceiverEmail']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="business_id"  /> <h109><?php echo $l['all']['Business']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payment_tax" /> <h109><?php echo $l['all']['Tax']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payment_cost"  /> <h109><?php echo $l['all']['Cost']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payment_fee" checked /> <h109><?php echo $l['all']['TransactionFee']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payment_total" checked /> <h109><?php echo $l['all']['TotalCost']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payment_currency" checked /> <h109><?php echo $l['all']['PaymentCurrency']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="first_name" checked /> <h109><?php echo $l['all']['FirstName']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="last_name" checked /> <h109><?php echo $l['all']['LastName']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payer_email" checked /> <h109><?php echo $l['all']['PayerEmail']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payer_address_name"  /> <h109><?php echo $l['all']['AddressRecipient']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payer_address_street"  /> <h109><?php echo $l['all']['Street']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payer_address_country" checked /> <h109><?php echo $l['all']['Country']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payer_address_country_code"  /> <h109><?php echo $l['all']['CountryCode']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payer_address_city" checked /> <h109><?php echo $l['all']['City']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payer_address_state" checked /> <h109><?php echo $l['all']['State']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payer_address_zip"  /> <h109><?php echo $l['all']['Zip']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payment_date" checked /> <h109><?php echo $l['all']['PaymentDate']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payment_status" checked /> <h109><?php echo $l['all']['PaymentStatus']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payer_status" /> <h109><?php echo $l['all']['PayerStatus']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="payment_address_status" /> <h109><?php echo $l['all']['PaymentAddressStatus']; ?> </h109> <br/>
-                <input type="checkbox" name="sqlfields[]" value="vendor_type" checked /> <h109><?php echo $l['all']['VendorType']; ?> </h109> <br/>
+                <h109><?php echo t('button','AccountingFieldsinQuery'); ?></h109><br/>
+                <input type="checkbox" name="sqlfields[]" value="id" /> <h109> <?php echo t('all','ID'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="username" checked /> <h109><?php echo t('all','Username'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="password"  /> <h109><?php echo t('all','Password'); ?></h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="txnId"  /> <h109><?php echo t('all','TxnId'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="planName" checked /> <h109><?php echo t('all','PlanName'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="planId"  /> <h109><?php echo t('all','PlanId'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="quantity"  /> <h109><?php echo t('all','Quantity'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="business_email"  /> <h109><?php echo t('all','ReceiverEmail'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="business_id"  /> <h109><?php echo t('all','Business'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payment_tax" /> <h109><?php echo t('all','Tax'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payment_cost"  /> <h109><?php echo t('all','Cost'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payment_fee" checked /> <h109><?php echo t('all','TransactionFee'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payment_total" checked /> <h109><?php echo t('all','TotalCost'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payment_currency" checked /> <h109><?php echo t('all','PaymentCurrency'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="first_name" checked /> <h109><?php echo t('all','FirstName'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="last_name" checked /> <h109><?php echo t('all','LastName'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payer_email" checked /> <h109><?php echo t('all','PayerEmail'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payer_address_name"  /> <h109><?php echo t('all','AddressRecipient'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payer_address_street"  /> <h109><?php echo t('all','Street'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payer_address_country" checked /> <h109><?php echo t('all','Country'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payer_address_country_code"  /> <h109><?php echo t('all','CountryCode'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payer_address_city" checked /> <h109><?php echo t('all','City'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payer_address_state" checked /> <h109><?php echo t('all','State'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payer_address_zip"  /> <h109><?php echo t('all','Zip'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payment_date" checked /> <h109><?php echo t('all','PaymentDate'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payment_status" checked /> <h109><?php echo t('all','PaymentStatus'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payer_status" /> <h109><?php echo t('all','PayerStatus'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="payment_address_status" /> <h109><?php echo t('all','PaymentAddressStatus'); ?> </h109> <br/>
+                <input type="checkbox" name="sqlfields[]" value="vendor_type" checked /> <h109><?php echo t('all','VendorType'); ?> </h109> <br/>
                 Select:
                 <a class="table" href="javascript:SetChecked(1,'sqlfields[]','billpaypaltransactions')">All</a>
                 <a class="table" href="javascript:SetChecked(0,'sqlfields[]','billpaypaltransactions')">None</a>
 
 
                 <br/><br/>
-                <h109><?php echo $l['button']['OrderBy'] ?><h109> <br/>
+                <h109><?php echo t('button','OrderBy') ?><h109> <br/>
                         <center>
                         <select name="orderBy" size="1">
                                 <option value="id"> Id </option>
@@ -151,7 +151,7 @@
                         </center>
 
         <br/>
-        <input class="sidebutton" type="submit" name="submit" value="<?php echo $l['button']['ProcessQuery'] ?>" tabindex=3 />
+        <input class="sidebutton" type="submit" name="submit" value="<?php echo t('button','ProcessQuery') ?>" tabindex=3 />
 
 
 

--- a/menu-bill-plans.php
+++ b/menu-bill-plans.php
@@ -23,17 +23,17 @@
 	<h3>Plans Management</h3>
 	<ul class="subnav">
 	
-		<li><a href="bill-plans-list.php"><b>&raquo;</b><?php echo $l['button']['ListPlans'] ?></a></li>
-		<li><a href="bill-plans-new.php"><b>&raquo;</b><?php echo $l['button']['NewPlan'] ?></a></li>
-		<li><a href="javascript:document.billplansedit.submit();""><b>&raquo;</b><?php echo $l['button']['EditPlan'] ?><a>
+		<li><a href="bill-plans-list.php"><b>&raquo;</b><?php echo t('button','ListPlans') ?></a></li>
+		<li><a href="bill-plans-new.php"><b>&raquo;</b><?php echo t('button','NewPlan') ?></a></li>
+		<li><a href="javascript:document.billplansedit.submit();""><b>&raquo;</b><?php echo t('button','EditPlan') ?><a>
 			<form name="billplansedit" action="bill-plans-edit.php" method="get" class="sidebar">
 			<input name="planName" type="text" id="planNameEdit" <?php if ($autoComplete) echo "autocomplete='off'"; ?>
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['BillingPlanName']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','BillingPlanName'); ?> <br/>'
 				value="<?php if (isset($edit_planname)) echo $edit_planname; ?>" tabindex=3>
 			</form></li>
 			
-		<li><a href="bill-plans-del.php"><b>&raquo;</b><?php echo $l['button']['RemovePlan'] ?></a></li>
+		<li><a href="bill-plans-del.php"><b>&raquo;</b><?php echo t('button','RemovePlan') ?></a></li>
 		
 	</ul>
 	

--- a/menu-bill-pos.php
+++ b/menu-bill-pos.php
@@ -24,7 +24,7 @@
 	<ul class="subnav">
 	
 		<li>
-		<a href="javascript:document.billposlist.submit();"><b>&raquo;</b><?php echo $l['button']['ListUsers'] ?></a>
+		<a href="javascript:document.billposlist.submit();"><b>&raquo;</b><?php echo t('button','ListUsers') ?></a>
 		<form name="billposlist" action="bill-pos-list.php" method="get" class="sidebar">
 		<br/>
 			<?php   
@@ -33,16 +33,16 @@
 			?>
 		</form>
 		</li>
-		<li><a href="bill-pos-new.php"><b>&raquo;</b><?php echo $l['button']['NewUser'] ?></a></li>
-		<li><a href="javascript:document.billposedit.submit();"><b>&raquo;</b><?php echo $l['button']['EditUser'] ?><a>
+		<li><a href="bill-pos-new.php"><b>&raquo;</b><?php echo t('button','NewUser') ?></a></li>
+		<li><a href="javascript:document.billposedit.submit();"><b>&raquo;</b><?php echo t('button','EditUser') ?><a>
 			<form name="billposedit" action="bill-pos-edit.php" method="get" class="sidebar">
 			<input name="username" type="text" id="usernameEdit" <?php if ($autoComplete) echo "autocomplete='off'"; ?>
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['Username']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','Username'); ?> <br/>'
                                 value="<?php if (isset($edit_username)) echo $edit_username; ?>" tabindex=1>
 			</form></li>
 			
-		<li><a href="bill-pos-del.php"><b>&raquo;</b><?php echo $l['button']['RemoveUsers'] ?></a></li>
+		<li><a href="bill-pos-del.php"><b>&raquo;</b><?php echo t('button','RemoveUsers') ?></a></li>
 		
 	</ul>
 	

--- a/menu-bill-rates.php
+++ b/menu-bill-rates.php
@@ -30,7 +30,7 @@
                                 <h3>Track Rates</h3>
 	<ul class="subnav">
 
-                <li><a href="javascript:document.billrates.submit();"><b>&raquo;</b><?php echo $l['button']['DateAccounting'] ?></a>
+                <li><a href="javascript:document.billrates.submit();"><b>&raquo;</b><?php echo t('button','DateAccounting') ?></a>
                         <form name="billrates" action="bill-rates-date.php" method="get" class="sidebar">
 			<select name="ratename" size="1">
 				<option value="<?php if (isset($billing_date_ratename)) echo $billing_date_ratename; else echo ""; ?>">
@@ -50,11 +50,11 @@
 
                         <input name="username" type="text" id="username" <?php if ($autoComplete) echo "autocomplete='off'"; ?>
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['Username']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','Username'); ?> <br/>'
                                 value="<?php if (isset($billing_date_username)) echo $billing_date_username; ?>">
                         <input name="startdate" type="text" id="startdate"
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['Date']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','Date'); ?> <br/>'
                                 value="<?php if (isset($billing_date_startdate)) echo $billing_date_startdate;
                         else echo date("Y-m-01"); ?>">
 
@@ -65,7 +65,7 @@
 
                         <input name="enddate" type="text" id="enddate"
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['Date']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','Date'); ?> <br/>'
                                 value="<?php if (isset($billing_date_enddate)) echo $billing_date_enddate;
                                 else echo date("Y-m-t"); ?>">
 
@@ -81,16 +81,16 @@
                                 <h3>Rates Management</h3>
                                 <ul class="subnav">
 
-                                                <li><a href="bill-rates-list.php"><b>&raquo;</b><?php echo $l['button']['ListRates'] ?></a></li>
-                                                <li><a href="bill-rates-new.php"><b>&raquo;</b><?php echo $l['button']['NewRate'] ?></a></li>
-                                                <li><a href="javascript:document.billratesedit.submit();""><b>&raquo;</b><?php echo $l['button']['EditRate'] ?></a>
+                                                <li><a href="bill-rates-list.php"><b>&raquo;</b><?php echo t('button','ListRates') ?></a></li>
+                                                <li><a href="bill-rates-new.php"><b>&raquo;</b><?php echo t('button','NewRate') ?></a></li>
+                                                <li><a href="javascript:document.billratesedit.submit();""><b>&raquo;</b><?php echo t('button','EditRate') ?></a>
                                                         <form name="billratesedit" action="bill-rates-edit.php" method="get" class="sidebar">
                                                         <input name="ratename" type="text" id="ratename" <?php if ($autoComplete) echo "autocomplete='off'"; ?>
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['RateName']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','RateName'); ?> <br/>'
 								value="<?php if (isset($edit_rateName)) echo $edit_rateName; ?>" tabindex=3>
                                                         </form></li>
-                                                <li><a href="bill-rates-del.php"><b>&raquo;</b><?php echo $l['button']['RemoveRate'] ?></a></li>
+                                                <li><a href="bill-rates-del.php"><b>&raquo;</b><?php echo t('button','RemoveRate') ?></a></li>
                                 </ul>
 
                                 <br/><br/>

--- a/menu-config-backup.php
+++ b/menu-config-backup.php
@@ -31,11 +31,11 @@
 
 		<li><a href="config-backup-managebackups.php"><b>&raquo;</b>
 			<img src='images/icons/configMaintenance.png' border='0'>
-			<?php echo $l['button']['ManageBackups'] ?></a>
+			<?php echo t('button','ManageBackups') ?></a>
 		</li>
 		<li><a href="config-backup-createbackups.php"><b>&raquo;</b>
 			<img src='images/icons/configMaintenance.png' border='0'>
-			<?php echo $l['button']['CreateBackups'] ?></a>
+			<?php echo t('button','CreateBackups') ?></a>
 		</li>
 		
 	</ul>

--- a/menu-config-maint.php
+++ b/menu-config-maint.php
@@ -31,11 +31,11 @@
 
 		<li><a href="config-maint-test-user.php"><b>&raquo;</b>
 			<img src='images/icons/configMaintenance.png' border='0'>
-			<?php echo $l['button']['TestUserConnectivity'] ?></a>
+			<?php echo t('button','TestUserConnectivity') ?></a>
 		</li>
 		<li><a href="config-maint-disconnect-user.php"><b>&raquo;</b>
 			<img src='images/icons/configMaintenance.png' border='0'>
-			<?php echo $l['button']['DisconnectUser'] ?></a>
+			<?php echo t('button','DisconnectUser') ?></a>
 		</li>
 		
 	</ul>

--- a/menu-config-operators.php
+++ b/menu-config-operators.php
@@ -31,18 +31,18 @@
 	
 	<ul class="subnav">
 	
-		<li><a href="config-operators-list.php"><b>&raquo;</b><?php echo $l['button']['ListOperators'] ?></a></li>
-		<li><a href="config-operators-new.php"><b>&raquo;</b><?php echo $l['button']['NewOperator'] ?></a></li>
-		<li><a href="javascript:document.mngedit.submit();""><b>&raquo;</b><?php echo $l['button']['EditOperator'] ?></a>
+		<li><a href="config-operators-list.php"><b>&raquo;</b><?php echo t('button','ListOperators') ?></a></li>
+		<li><a href="config-operators-new.php"><b>&raquo;</b><?php echo t('button','NewOperator') ?></a></li>
+		<li><a href="javascript:document.mngedit.submit();""><b>&raquo;</b><?php echo t('button','EditOperator') ?></a>
 			<form name="mngedit" action="config-operators-edit.php" method="get" class="sidebar">
 			<input name="operator_username" type="text"
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['OperatorName']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','OperatorName'); ?> <br/>'
 				/>
 			</form>
 		</li>
 
-		<li><a href="config-operators-del.php"><b>&raquo;</b><?php echo $l['button']['RemoveOperator'] ?></a></li>
+		<li><a href="config-operators-del.php"><b>&raquo;</b><?php echo t('button','RemoveOperator') ?></a></li>
 	
 	</ul>
 

--- a/menu-config-reports.php
+++ b/menu-config-reports.php
@@ -30,7 +30,7 @@
 	<ul class="subnav">
 
 		<li><a href="config-reports-dashboard.php"><b>&raquo;</b>
-			<?php echo $l['button']['DashboardSettings'] ?></a>
+			<?php echo t('button','DashboardSettings') ?></a>
 		</li>
 
 		

--- a/menu-config.php
+++ b/menu-config.php
@@ -28,12 +28,12 @@
 	
 	<ul class="subnav">
 
-		<li><a href="config-user.php"><b>&raquo;</b><?php echo $l['button']['UserSettings'] ?></a></li>
-		<li><a href="config-db.php"><b>&raquo;</b><?php echo $l['button']['DatabaseSettings'] ?></a></li>
-		<li><a href="config-lang.php"><b>&raquo;</b><?php echo $l['button']['LanguageSettings'] ?></a></li>
-		<li><a href="config-logging.php"><b>&raquo;</b><?php echo $l['button']['LoggingSettings'] ?></a></li>
-		<li><a href="config-interface.php"><b>&raquo;</b><?php echo $l['button']['InterfaceSettings'] ?></a></li>
-		<li><a href="config-mail.php"><b>&raquo;</b><?php echo $l['button']['MailSettings'] ?></a></li>
+		<li><a href="config-user.php"><b>&raquo;</b><?php echo t('button','UserSettings') ?></a></li>
+		<li><a href="config-db.php"><b>&raquo;</b><?php echo t('button','DatabaseSettings') ?></a></li>
+		<li><a href="config-lang.php"><b>&raquo;</b><?php echo t('button','LanguageSettings') ?></a></li>
+		<li><a href="config-logging.php"><b>&raquo;</b><?php echo t('button','LoggingSettings') ?></a></li>
+		<li><a href="config-interface.php"><b>&raquo;</b><?php echo t('button','InterfaceSettings') ?></a></li>
+		<li><a href="config-mail.php"><b>&raquo;</b><?php echo t('button','MailSettings') ?></a></li>
 
 	</ul>
 	

--- a/menu-gis.php
+++ b/menu-gis.php
@@ -32,14 +32,14 @@
 	
 	<h3>GIS Mapping</h3>
 	<ul class="subnav">
-		<li><a href="gis-viewmap.php"><b>&raquo;</b><?php echo $l['button']['ViewMAP'] ?></a></li>
-		<li><a href="gis-editmap.php"><b>&raquo;</b><?php echo $l['button']['EditMAP'] ?></a></li>		
+		<li><a href="gis-viewmap.php"><b>&raquo;</b><?php echo t('button','ViewMAP') ?></a></li>
+		<li><a href="gis-editmap.php"><b>&raquo;</b><?php echo t('button','EditMAP') ?></a></li>		
 	</ul>
 
 	<h3>Settings</h3>
 	<ul class="subnav">
 	
-		<li><a href="javascript:document.gisregister.submit();"/><b>&raquo;</b><?php echo $l['button']['RegisterGoogleMapsAPI']?>
+		<li><a href="javascript:document.gisregister.submit();"/><b>&raquo;</b><?php echo t('button','RegisterGoogleMapsAPI')?>
 			</a>
 			<form name="gisregister" action="gis-main.php" method="get" class="sidebar">
 			<input name="code" type="text">

--- a/menu-graphs.php
+++ b/menu-graphs.php
@@ -36,16 +36,16 @@
 
 		<li><a href="javascript:document.overall_logins.submit();"><b>&raquo;</b>
 			<img src='images/icons/graphsGeneral.gif' border='0'>
-			<?php echo $l['button']['UserLogins'] ?></a>
+			<?php echo t('button','UserLogins') ?></a>
 			<form name="overall_logins" action="graphs-overall_logins.php" method="post" class="sidebar">
 			<input name="username" type="text" id="usernameLogins" <?php if ($autoComplete) echo "autocomplete='off'"; ?>
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['Username']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','Username'); ?> <br/>'
 				value="<?php if (isset($overall_logins_username)) echo $overall_logins_username; ?>">
 			<select class="generic" name="type" type="text">
-				<option value="daily"> <?php echo $l['all']['Daily'] ?>
-				<option value="monthly"> <?php echo $l['all']['Monthly'] ?>
-				<option value="yearly"> <?php echo $l['all']['Yearly'] ?>
+				<option value="daily"> <?php echo t('all','Daily') ?>
+				<option value="monthly"> <?php echo t('all','Monthly') ?>
+				<option value="yearly"> <?php echo t('all','Yearly') ?>
 			</select>
 			</form>
 		</li>
@@ -53,20 +53,20 @@
 
 		<li><a href="javascript:document.overall_download.submit();"><b>&raquo;</b>
 			<img src='images/icons/graphsGeneral.gif' border='0'>
-			<?php echo $l['button']['UserDownloads'] ?></a>
+			<?php echo t('button','UserDownloads') ?></a>
 			<form name="overall_download" action="graphs-overall_download.php" method="post" class="sidebar">
 			<input name="username" type="text" id="usernameDownloads" <?php if ($autoComplete) echo "autocomplete='off'"; ?>
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['Username']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','Username'); ?> <br/>'
 				value="<?php if (isset($overall_download_username)) echo $overall_download_username; ?>">
 			<select class="generic" name="type" type="text">
-				<option value="daily"> <?php echo $l['all']['Daily'] ?>
-				<option value="monthly"> <?php echo $l['all']['Monthly'] ?>
-				<option value="yearly"> <?php echo $l['all']['Yearly'] ?>
+				<option value="daily"> <?php echo t('all','Daily') ?>
+				<option value="monthly"> <?php echo t('all','Monthly') ?>
+				<option value="yearly"> <?php echo t('all','Yearly') ?>
 			</select>
 			<select class="generic" name="size" type="text">
-				<option value="megabytes"> <?php echo $l['all']['Megabytes'] ?>
-				<option value="gigabytes"> <?php echo $l['all']['Gigabytes'] ?>
+				<option value="megabytes"> <?php echo t('all','Megabytes') ?>
+				<option value="gigabytes"> <?php echo t('all','Gigabytes') ?>
 			</select>
 			</form>
 		</li>
@@ -74,20 +74,20 @@
 
 		<li><a href="javascript:document.overall_upload.submit();"><b>&raquo;</b>
 			<img src='images/icons/graphsGeneral.gif' border='0'>
-			<?php echo $l['button']['UserUploads'] ?></a>
+			<?php echo t('button','UserUploads') ?></a>
 			<form name="overall_upload" action="graphs-overall_upload.php" method="post" class="sidebar">
 			<input name="username" type="text" id="usernameUploads" <?php if ($autoComplete) echo "autocomplete='off'"; ?>
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['Username']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','Username'); ?> <br/>'
 				value="<?php if (isset($overall_upload_username)) echo $overall_upload_username; ?>">
 			<select class="generic" name="type" type="text">
-				<option value="daily"> <?php echo $l['all']['Daily'] ?>
-				<option value="monthly"> <?php echo $l['all']['Monthly'] ?>
-				<option value="yearly"> <?php echo $l['all']['Yearly'] ?>
+				<option value="daily"> <?php echo t('all','Daily') ?>
+				<option value="monthly"> <?php echo t('all','Monthly') ?>
+				<option value="yearly"> <?php echo t('all','Yearly') ?>
 			</select>
 			<select class="generic" name="size" type="text">
-				<option value="megabytes"> <?php echo $l['all']['Megabytes'] ?>
-				<option value="gigabytes"> <?php echo $l['all']['Gigabytes'] ?>
+				<option value="megabytes"> <?php echo t('all','Megabytes') ?>
+				<option value="gigabytes"> <?php echo t('all','Gigabytes') ?>
 			</select>
 			</form>
 		</li>
@@ -100,12 +100,12 @@
 
 		<li><a href="javascript:document.alltime_logins.submit();"><b>&raquo;</b>
 			<img src='images/icons/graphsGeneral.gif' border='0'>
-			<?php echo $l['button']['TotalLogins'] ?></a>
+			<?php echo t('button','TotalLogins') ?></a>
 			<form name="alltime_logins" action="graphs-alltime_logins.php" method="post" class="sidebar">
 			<select class="generic" name="type" type="text">
-				<option value="daily"> <?php echo $l['all']['Daily'] ?>
-				<option value="monthly"> <?php echo $l['all']['Monthly'] ?>
-				<option value="yearly"> <?php echo $l['all']['Yearly'] ?>
+				<option value="daily"> <?php echo t('all','Daily') ?>
+				<option value="monthly"> <?php echo t('all','Monthly') ?>
+				<option value="yearly"> <?php echo t('all','Yearly') ?>
 			</select>
 			</form></li>
 
@@ -113,26 +113,26 @@
 
 		<li><a href="javascript:document.alltime_traffic_compare.submit();"><b>&raquo;</b>
 			<img src='images/icons/graphsGeneral.gif' border='0'>
-			<?php echo $l['button']['TotalTraffic'] ?></a>
+			<?php echo t('button','TotalTraffic') ?></a>
 			<form name="alltime_traffic_compare" action="graphs-alltime_traffic_compare.php" method="post" 
 				class="sidebar">
 			<select class="generic" name="type" type="text">
-				<option value="daily"> <?php echo $l['all']['Daily'] ?>
-				<option value="monthly"> <?php echo $l['all']['Monthly'] ?>
-				<option value="yearly"> <?php echo $l['all']['Yearly'] ?>
+				<option value="daily"> <?php echo t('all','Daily') ?>
+				<option value="monthly"> <?php echo t('all','Monthly') ?>
+				<option value="yearly"> <?php echo t('all','Yearly') ?>
 			</select>
 			<select class="generic" name="size" type="text">
-				<option value="megabytes"> <?php echo $l['all']['Megabytes'] ?>
-				<option value="gigabytes"> <?php echo $l['all']['Gigabytes'] ?>
+				<option value="megabytes"> <?php echo t('all','Megabytes') ?>
+				<option value="gigabytes"> <?php echo t('all','Gigabytes') ?>
 			</select>
 			</form></li>
 			
 			
 		<li><a href="javascript:document.logged_users.submit();"><b>&raquo;</b>
 			<img src='images/icons/graphsGeneral.gif' border='0'>
-			<?php echo $l['button']['LoggedUsers'] ?></a>
+			<?php echo t('button','LoggedUsers') ?></a>
 			<form name="logged_users" action="graphs-logged_users.php" method="post" class="sidebar">
-			<?php echo $l['graphs']['Day']; ?>:</br>
+			<?php echo t('graphs','Day'); ?>:</br>
 			<?php $d = date("j"); ?>
 			<select class="generic" name="day" type="text">
 				<?php 
@@ -143,23 +143,23 @@
 				<?php $i++; 	?>
 				<?php endwhile; ?>
 			</select>
-			<?php echo $l['graphs']['Month']; ?>:</br>
+			<?php echo t('graphs','Month'); ?>:</br>
 			<?php $m = date("M"); ?>
 			<select class="generic" name="month" type="text">
-				<option value="jan" <?php if ($m == 'Jan') echo "selected" ?>> <?php echo $l['graphs']['Jan']?> </option>
-				<option value="feb" <?php if ($m == 'Feb') echo "selected" ?>> <?php echo $l['graphs']['Feb']?> </option>
-				<option value="mar" <?php if ($m == 'Mar') echo "selected" ?>> <?php echo $l['graphs']['Mar']?> </option>
-				<option value="apr" <?php if ($m == 'Apr') echo "selected" ?>> <?php echo $l['graphs']['Apr']?> </option>
-				<option value="may" <?php if ($m == 'May') echo "selected" ?>> <?php echo $l['graphs']['May']?> </option>
-				<option value="jun" <?php if ($m == 'Jun') echo "selected" ?>> <?php echo $l['graphs']['Jun']?> </option>
-				<option value="jul" <?php if ($m == 'Jul') echo "selected" ?>> <?php echo $l['graphs']['Jul']?> </option>
-				<option value="aug" <?php if ($m == 'Aug') echo "selected" ?>> <?php echo $l['graphs']['Aug']?> </option>
-				<option value="sep" <?php if ($m == 'Sep') echo "selected" ?>> <?php echo $l['graphs']['Sep']?> </option>
-				<option value="oct" <?php if ($m == 'Oct') echo "selected" ?>> <?php echo $l['graphs']['Oct']?> </option>
-				<option value="nov" <?php if ($m == 'Nov') echo "selected" ?>> <?php echo $l['graphs']['Nov']?> </option>
-				<option value="dec" <?php if ($m == 'Dec') echo "selected" ?>> <?php echo $l['graphs']['Dec']?> </option>
+				<option value="jan" <?php if ($m == 'Jan') echo "selected" ?>> <?php echo t('graphs','Jan')?> </option>
+				<option value="feb" <?php if ($m == 'Feb') echo "selected" ?>> <?php echo t('graphs','Feb')?> </option>
+				<option value="mar" <?php if ($m == 'Mar') echo "selected" ?>> <?php echo t('graphs','Mar')?> </option>
+				<option value="apr" <?php if ($m == 'Apr') echo "selected" ?>> <?php echo t('graphs','Apr')?> </option>
+				<option value="may" <?php if ($m == 'May') echo "selected" ?>> <?php echo t('graphs','May')?> </option>
+				<option value="jun" <?php if ($m == 'Jun') echo "selected" ?>> <?php echo t('graphs','Jun')?> </option>
+				<option value="jul" <?php if ($m == 'Jul') echo "selected" ?>> <?php echo t('graphs','Jul')?> </option>
+				<option value="aug" <?php if ($m == 'Aug') echo "selected" ?>> <?php echo t('graphs','Aug')?> </option>
+				<option value="sep" <?php if ($m == 'Sep') echo "selected" ?>> <?php echo t('graphs','Sep')?> </option>
+				<option value="oct" <?php if ($m == 'Oct') echo "selected" ?>> <?php echo t('graphs','Oct')?> </option>
+				<option value="nov" <?php if ($m == 'Nov') echo "selected" ?>> <?php echo t('graphs','Nov')?> </option>
+				<option value="dec" <?php if ($m == 'Dec') echo "selected" ?>> <?php echo t('graphs','Dec')?> </option>
 			</select>
-			<?php echo $l['graphs']['Year']; ?>:</br>
+			<?php echo t('graphs','Year'); ?>:</br>
 			<select class="generic" name="year" type="text">
 				<?php
 					for($i = 0; $i <= 10; $i++) {

--- a/menu-home.php
+++ b/menu-home.php
@@ -31,14 +31,14 @@
 
 	<ul class="subnav">
 
-		<li><a href="rep-stat-server.php"><b>&raquo;</b><?php echo $l['button']['ServerStatus'] ?></a></li>
-		<li><a href="rep-stat-services.php"><b>&raquo;</b><?php echo $l['button']['ServicesStatus'] ?></a></li>
-		<li><a href="rep-lastconnect.php"><b>&raquo;</b><?php echo $l['button']['LastConnectionAttempts'] ?></a></li>
+		<li><a href="rep-stat-server.php"><b>&raquo;</b><?php echo t('button','ServerStatus') ?></a></li>
+		<li><a href="rep-stat-services.php"><b>&raquo;</b><?php echo t('button','ServicesStatus') ?></a></li>
+		<li><a href="rep-lastconnect.php"><b>&raquo;</b><?php echo t('button','LastConnectionAttempts') ?></a></li>
 
 	<h3>Logs</h3>
 
-	        <li><a href="rep-logs-radius.php"><b>&raquo;</b><?php echo $l['button']['RadiusLog'] ?></a></li>
-	        <li><a href="rep-logs-system.php"><b>&raquo;</b><?php echo $l['button']['SystemLog'] ?></a></li>
+	        <li><a href="rep-logs-radius.php"><b>&raquo;</b><?php echo t('button','RadiusLog') ?></a></li>
+	        <li><a href="rep-logs-system.php"><b>&raquo;</b><?php echo t('button','SystemLog') ?></a></li>
 
 	</ul>
 	

--- a/menu-mng-batch.php
+++ b/menu-mng-batch.php
@@ -24,15 +24,15 @@
 	
 		<li><a href="mng-batch-list.php"><b>&raquo;</b>
 			<img src='images/icons/userList.gif' border='0'>
-			<?php echo $l['button']['ListBatches'] ?></a>
+			<?php echo t('button','ListBatches') ?></a>
 		</li>
 		<li><a href="mng-batch-add.php"><b>&raquo;</b>
 			<img src='images/icons/userNew.gif' border='0'>
-			<?php echo $l['button']['BatchAddUsers'] ?></a>
+			<?php echo t('button','BatchAddUsers') ?></a>
 		</li>
 		<li><a href="mng-batch-del.php"><b>&raquo;</b>
 			<img src='images/icons/userRemove.gif' border='0'>
-			<?php echo $l['button']['RemoveBatch'] ?>
+			<?php echo t('button','RemoveBatch') ?>
 			</a>
 		</li>
 		

--- a/menu-mng-hs.php
+++ b/menu-mng-hs.php
@@ -22,17 +22,17 @@
 	<h3>Hotspots Management</h3>
 	<ul class="subnav">
 	
-		<li><a href="mng-hs-list.php"><b>&raquo;</b><?php echo $l['button']['ListHotspots'] ?></a></li>
-		<li><a href="mng-hs-new.php"><b>&raquo;</b><?php echo $l['button']['NewHotspot'] ?></a></li>
-		<li><a href="javascript:document.mnghsedit.submit();""><b>&raquo;</b><?php echo $l['button']['EditHotspot'] ?><a>
+		<li><a href="mng-hs-list.php"><b>&raquo;</b><?php echo t('button','ListHotspots') ?></a></li>
+		<li><a href="mng-hs-new.php"><b>&raquo;</b><?php echo t('button','NewHotspot') ?></a></li>
+		<li><a href="javascript:document.mnghsedit.submit();""><b>&raquo;</b><?php echo t('button','EditHotspot') ?><a>
 			<form name="mnghsedit" action="mng-hs-edit.php" method="get" class="sidebar">
 			<input name="name" type="text"  id="hotspotEdit" autocomplete="off"
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['HotspotName']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','HotspotName'); ?> <br/>'
 				value="<?php if (isset($edit_hotspotname)) echo $edit_hotspotname; ?>" tabindex=3>
 			</form></li>
 			
-		<li><a href="mng-hs-del.php"><b>&raquo;</b><?php echo $l['button']['RemoveHotspot'] ?></a></li>
+		<li><a href="mng-hs-del.php"><b>&raquo;</b><?php echo t('button','RemoveHotspot') ?></a></li>
 		
 	</ul>
 	

--- a/menu-mng-rad-attributes.php
+++ b/menu-mng-rad-attributes.php
@@ -23,7 +23,7 @@
 	<h3>Attributes Management</h3>
 	<ul class="subnav">
 	
-		<li><a href="javascript:document.mngradattributeslist.submit();"><b>&raquo;</b><?php echo $l['button']['ListAttributesforVendor'] ?>
+		<li><a href="javascript:document.mngradattributeslist.submit();"><b>&raquo;</b><?php echo t('button','ListAttributesforVendor') ?>
 			</a>
                         <form name="mngradattributeslist" action="mng-rad-attributes-list.php" method="get" class="sidebar">
                         <?php
@@ -33,27 +33,27 @@
 			</form>
 		</li>
 
-		<li><a href="mng-rad-attributes-new.php" tabindex=2><b>&raquo;</b><?php echo $l['button']['NewVendorAttribute'] ?></a></li>
-		<li><a href="javascript:document.mngradattributesedit.submit();" tabindex=3 ><b>&raquo;</b><?php echo $l['button']['EditVendorAttribute'] ?></a>
+		<li><a href="mng-rad-attributes-new.php" tabindex=2><b>&raquo;</b><?php echo t('button','NewVendorAttribute') ?></a></li>
+		<li><a href="javascript:document.mngradattributesedit.submit();" tabindex=3 ><b>&raquo;</b><?php echo t('button','EditVendorAttribute') ?></a>
 			<form name="mngradattributesedit" action="mng-rad-attributes-edit.php" method="get" class="sidebar">
 			<input name="vendor" type="text" id="vendornameEdit" <?php if ($autoComplete) echo "autocomplete='off'"; ?>
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['VendorName']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','VendorName'); ?> <br/>'
 				value="<?php if (isset($vendor)) echo $vendor ?>" tabindex=4>
 			<input name="attribute" type="text" id="attributenameEdit" <?php if ($autoComplete) echo "autocomplete='off'"; ?>
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['AttributeName']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','AttributeName'); ?> <br/>'
 				value="<?php if (isset($attribute)) echo $attribute  ?>" tabindex=5>
 			</form></li>
-		<li><a href="javascript:document.mngradattributessearch.submit();" tabindex=6 ><b>&raquo;</b><?php echo $l['button']['SearchVendorAttribute'] ?></a>
+		<li><a href="javascript:document.mngradattributessearch.submit();" tabindex=6 ><b>&raquo;</b><?php echo t('button','SearchVendorAttribute') ?></a>
 			<form name="mngradattributessearch" action="mng-rad-attributes-search.php" method="get" class="sidebar">
 			<input name="attribute" type="text" id="attributenameSearch" <?php if ($autoComplete) echo "autocomplete='off'"; ?>
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['AttributeName']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','AttributeName'); ?> <br/>'
 				value="<?php if (isset($attribute)) echo $attribute ?>" tabindex=7>
 			</form></li>
-		<li><a href="mng-rad-attributes-del.php" tabindex=8><b>&raquo;</b><?php echo $l['button']['RemoveVendorAttribute'] ?></a></li>
-		<li><a href="mng-rad-attributes-import.php" tabindex=8><b>&raquo;</b><?php echo $l['button']['ImportVendorDictionary'] ?></a></li>
+		<li><a href="mng-rad-attributes-del.php" tabindex=8><b>&raquo;</b><?php echo t('button','RemoveVendorAttribute') ?></a></li>
+		<li><a href="mng-rad-attributes-import.php" tabindex=8><b>&raquo;</b><?php echo t('button','ImportVendorDictionary') ?></a></li>
 		
 	</ul>
 

--- a/menu-mng-rad-groups.php
+++ b/menu-mng-rad-groups.php
@@ -24,37 +24,37 @@
 
 		<li><a href="mng-rad-groupreply-list.php"><b>&raquo;</b>
 			<img src='images/icons/groupsList.png' border='0'>
-			<?php echo $l['button']['ListGroupReply'] ?></a></li>
+			<?php echo t('button','ListGroupReply') ?></a></li>
 		<li><a href="javascript:document.mngradgroupreplysearch.submit();""><b>&raquo;</b>
 			<img src='images/icons/groupsList.png' border='0'>
-			<?php echo $l['button']['SearchGroupReply'] ?><a>
+			<?php echo t('button','SearchGroupReply') ?><a>
 			<form name="mngradgroupreplysearch" action="mng-rad-groupreply-search.php" method="get" 
 				class="sidebar">
 			<input name="groupname" type="text" 
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['GroupName']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','GroupName'); ?> <br/>'
 				value="<?php if (isset($search_groupname)) echo $search_groupname; ?>" tabindex=2>
 			</form></li>
 
 		<li><a href="mng-rad-groupreply-new.php"><b>&raquo;</b>
 			<img src='images/icons/groupsAdd.png' border='0'>
-			<?php echo $l['button']['NewGroupReply'] ?></a></li>
+			<?php echo t('button','NewGroupReply') ?></a></li>
 		<li><a href="javascript:document.mngradgrprplyedit.submit();""><b>&raquo;</b>
 			<img src='images/icons/groupsEdit.png' border='0'>
-			<?php echo $l['button']['EditGroupReply'] ?><a>
+			<?php echo t('button','EditGroupReply') ?><a>
 			<form name="mngradgrprplyedit" action="mng-rad-groupreply-edit.php" method="get" class="sidebar">
 			<input name="groupname" type="text" value=""
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['GroupName']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','GroupName'); ?> <br/>'
 				/>
 			<input name="attribute" type="text" value=""
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['AttributeName']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','AttributeName'); ?> <br/>'
 				/>
 			</form></li>
 		<li><a href="mng-rad-groupreply-del.php"><b>&raquo;</b>
 			<img src='images/icons/groupsRemove.png' border='0'>
-			<?php echo $l['button']['RemoveGroupReply'] ?></a></li>
+			<?php echo t('button','RemoveGroupReply') ?></a></li>
 		
 	</ul>
 
@@ -63,37 +63,37 @@
 
 		<li><a href="mng-rad-groupcheck-list.php"><b>&raquo;</b>
 			<img src='images/icons/groupsList.png' border='0'>
-			<?php echo $l['button']['ListGroupCheck'] ?></a></li>
+			<?php echo t('button','ListGroupCheck') ?></a></li>
 		<li><a href="javascript:document.mngradgroupchecksearch.submit();""><b>&raquo;</b>
 			<img src='images/icons/groupsList.png' border='0'>
-			<?php echo $l['button']['SearchGroupCheck'] ?><a>
+			<?php echo t('button','SearchGroupCheck') ?><a>
 			<form name="mngradgroupchecksearch" action="mng-rad-groupcheck-search.php" method="get" 
 				class="sidebar">
 			<input name="groupname" type="text" 
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['GroupName']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','GroupName'); ?> <br/>'
 				value="<?php if (isset($search_groupname)) echo $search_groupname; ?>" tabindex=2>
 			</form></li>
 
 		<li><a href="mng-rad-groupcheck-new.php"><b>&raquo;</b>
 			<img src='images/icons/groupsAdd.png' border='0'>
-			<?php echo $l['button']['NewGroupCheck'] ?></a></li>
+			<?php echo t('button','NewGroupCheck') ?></a></li>
 		<li><a href="javascript:document.mngradgrpchkedit.submit();""><b>&raquo;</b>
 			<img src='images/icons/groupsEdit.png' border='0'>
-			<?php echo $l['button']['EditGroupCheck'] ?><a>
+			<?php echo t('button','EditGroupCheck') ?><a>
 			<form name="mngradgrpchkedit" action="mng-rad-groupcheck-edit.php" method="get" class="sidebar">
 			<input name="groupname" type="text" value=""
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['GroupName']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','GroupName'); ?> <br/>'
 				/>
 			<input name="attribute" type="text" value=""
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['AttributeName']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','AttributeName'); ?> <br/>'
 				/>
 			</form></li>
 		<li><a href="mng-rad-groupcheck-del.php"><b>&raquo;</b>
 			<img src='images/icons/groupsRemove.png' border='0'>
-			<?php echo $l['button']['RemoveGroupCheck'] ?></a></li>
+			<?php echo t('button','RemoveGroupCheck') ?></a></li>
 		
 	</ul>
 

--- a/menu-mng-rad-hunt.php
+++ b/menu-mng-rad-hunt.php
@@ -23,21 +23,21 @@
 	<h3>HuntGroup Management</h3>
 	<ul class="subnav">
 	
-		<li><a href="mng-rad-hunt-list.php" tabindex=1><b>&raquo;</b><?php echo $l['button']['ListHG'] ?></a></li>
-		<li><a href="mng-rad-hunt-new.php" tabindex=2><b>&raquo;</b><?php echo $l['button']['NewHG'] ?></a></li>
-		<li><a href="javascript:document.mngradhuntedit.submit();" tabindex=3 ><b>&raquo;</b><?php echo $l['button']['EditHG'] ?></a>
+		<li><a href="mng-rad-hunt-list.php" tabindex=1><b>&raquo;</b><?php echo t('button','ListHG') ?></a></li>
+		<li><a href="mng-rad-hunt-new.php" tabindex=2><b>&raquo;</b><?php echo t('button','NewHG') ?></a></li>
+		<li><a href="javascript:document.mngradhuntedit.submit();" tabindex=3 ><b>&raquo;</b><?php echo t('button','EditHG') ?></a>
 			<form name="mngradhuntedit" action="mng-rad-hunt-edit.php" method="get" class="sidebar">
 			<input name="nasipaddress" type="text" id="nashostEdit" <?php if ($autoComplete) echo "autocomplete='off'"; ?>
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['hgNasIpAddress']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','hgNasIpAddress'); ?> <br/>'
 			tabindex=4 />
                         <input name="groupname" type="text" value=""
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['hgGroupName']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','hgGroupName'); ?> <br/>'
             tabindex=5 />
 
 			</form></li>
-		<li><a href="mng-rad-hunt-del.php" tabindex=5><b>&raquo;</b><?php echo $l['button']['RemoveHG'] ?></a></li>
+		<li><a href="mng-rad-hunt-del.php" tabindex=5><b>&raquo;</b><?php echo t('button','RemoveHG') ?></a></li>
 		
 	</ul>
 

--- a/menu-mng-rad-ippool.php
+++ b/menu-mng-rad-ippool.php
@@ -22,20 +22,20 @@
 	<h3>IP Pools</h3>
 	<ul class="subnav">
 	
-		<li><a href="mng-rad-ippool-list.php" tabindex=1><b>&raquo;</b><?php echo $l['button']['ListIPPools'] ?></a></li>
-		<li><a href="mng-rad-ippool-new.php" tabindex=2><b>&raquo;</b><?php echo $l['button']['NewIPPool'] ?></a></li>
-		<li><a href="javascript:document.mngradippooledit.submit();" tabindex=3 ><b>&raquo;</b><?php echo $l['button']['EditIPPool'] ?></a>
+		<li><a href="mng-rad-ippool-list.php" tabindex=1><b>&raquo;</b><?php echo t('button','ListIPPools') ?></a></li>
+		<li><a href="mng-rad-ippool-new.php" tabindex=2><b>&raquo;</b><?php echo t('button','NewIPPool') ?></a></li>
+		<li><a href="javascript:document.mngradippooledit.submit();" tabindex=3 ><b>&raquo;</b><?php echo t('button','EditIPPool') ?></a>
 			<form name="mngradippooledit" action="mng-rad-ippool-edit.php" method="get" class="sidebar">
 			<input name="poolname" type="text" 
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['PoolName']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','PoolName'); ?> <br/>'
 				value="<?php if (isset($poolname)) echo $poolname ?>" tabindex=4>
 			<input name="ipaddressold" type="text" 
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['IPAddress']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','IPAddress'); ?> <br/>'
 				value="<?php if (isset($ipaddressold)) echo $ipaddressold  ?>" tabindex=4>
 			</form></li>
-		<li><a href="mng-rad-ippool-del.php" tabindex=5><b>&raquo;</b><?php echo $l['button']['RemoveIPPool'] ?></a></li>
+		<li><a href="mng-rad-ippool-del.php" tabindex=5><b>&raquo;</b><?php echo t('button','RemoveIPPool') ?></a></li>
 		
 	</ul>
 

--- a/menu-mng-rad-nas.php
+++ b/menu-mng-rad-nas.php
@@ -23,16 +23,16 @@
 	<h3>NAS Management</h3>
 	<ul class="subnav">
 	
-		<li><a href="mng-rad-nas-list.php" tabindex=1><b>&raquo;</b><?php echo $l['button']['ListNAS'] ?></a></li>
-		<li><a href="mng-rad-nas-new.php" tabindex=2><b>&raquo;</b><?php echo $l['button']['NewNAS'] ?></a></li>
-		<li><a href="javascript:document.mngradnasedit.submit();" tabindex=3 ><b>&raquo;</b><?php echo $l['button']['EditNAS'] ?></a>
+		<li><a href="mng-rad-nas-list.php" tabindex=1><b>&raquo;</b><?php echo t('button','ListNAS') ?></a></li>
+		<li><a href="mng-rad-nas-new.php" tabindex=2><b>&raquo;</b><?php echo t('button','NewNAS') ?></a></li>
+		<li><a href="javascript:document.mngradnasedit.submit();" tabindex=3 ><b>&raquo;</b><?php echo t('button','EditNAS') ?></a>
 			<form name="mngradnasedit" action="mng-rad-nas-edit.php" method="get" class="sidebar">
 			<input name="nashost" type="text" id="nashostEdit" <?php if ($autoComplete) echo "autocomplete='off'"; ?>
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['NasName']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','NasName'); ?> <br/>'
 			tabindex=4>
 			</form></li>
-		<li><a href="mng-rad-nas-del.php" tabindex=5><b>&raquo;</b><?php echo $l['button']['RemoveNAS'] ?></a></li>
+		<li><a href="mng-rad-nas-del.php" tabindex=5><b>&raquo;</b><?php echo t('button','RemoveNAS') ?></a></li>
 		
 	</ul>
 

--- a/menu-mng-rad-profiles.php
+++ b/menu-mng-rad-profiles.php
@@ -22,13 +22,13 @@
 
 		<li><a href="mng-rad-profiles-list.php"><b>&raquo;</b>
 			<img src='images/icons/groupsList.png' border='0'>
-			<?php echo $l['button']['ListProfiles'] ?></a></li>
+			<?php echo t('button','ListProfiles') ?></a></li>
 		<li><a href="mng-rad-profiles-new.php"><b>&raquo;</b>
 			<img src='images/icons/groupsAdd.png' border='0'>
-			<?php echo $l['button']['NewProfile'] ?></a></li>
+			<?php echo t('button','NewProfile') ?></a></li>
 		<li><a href="javascript:document.mngradprofileedit.submit();""><b>&raquo;</b>
 			<img src='images/icons/groupsEdit.png' border='0'>
-			<?php echo $l['button']['EditProfile'] ?><a>
+			<?php echo t('button','EditProfile') ?><a>
 			<form name="mngradprofileedit" action="mng-rad-profiles-edit.php" method="get" class="sidebar">
 			<?php   
 				include 'include/management/populate_selectbox.php';
@@ -38,11 +38,11 @@
 
 		<li><a href="mng-rad-profiles-duplicate.php"><b>&raquo;</b>
 			<img src='images/icons/groupsEdit.png' border='0'>
-			<?php echo $l['button']['DuplicateProfile'] ?></a></li>
+			<?php echo t('button','DuplicateProfile') ?></a></li>
 
 		<li><a href="mng-rad-profiles-del.php"><b>&raquo;</b>
 			<img src='images/icons/groupsRemove.png' border='0'>
-			<?php echo $l['button']['RemoveProfile'] ?></a></li>
+			<?php echo t('button','RemoveProfile') ?></a></li>
 	</ul>
 
 </div>

--- a/menu-mng-rad-realms.php
+++ b/menu-mng-rad-realms.php
@@ -20,9 +20,9 @@
 	<h3>Realms Management</h3>
 	<ul class="subnav">
 
-		<li><a href="mng-rad-realms-list.php"><b>&raquo;</b><?php echo $l['button']['ListRealms'] ?></a></li>
-		<li><a href="mng-rad-realms-new.php"><b>&raquo;</b><?php echo $l['button']['NewRealm'] ?></a></li>
-		<li><a href="javascript:document.mngradrealmedit.submit();""><b>&raquo;</b><?php echo $l['button']['EditRealm'] ?><a>
+		<li><a href="mng-rad-realms-list.php"><b>&raquo;</b><?php echo t('button','ListRealms') ?></a></li>
+		<li><a href="mng-rad-realms-new.php"><b>&raquo;</b><?php echo t('button','NewRealm') ?></a></li>
+		<li><a href="javascript:document.mngradrealmedit.submit();""><b>&raquo;</b><?php echo t('button','EditRealm') ?><a>
 			<form name="mngradrealmedit" action="mng-rad-realms-edit.php" method="get" class="sidebar">
 			<?php   
 				include_once('include/management/populate_selectbox.php');
@@ -30,23 +30,23 @@
 			?>
 			</form></li>
 
-		<li><a href="mng-rad-realms-del.php"><b>&raquo;</b><?php echo $l['button']['RemoveRealm'] ?></a></li>
+		<li><a href="mng-rad-realms-del.php"><b>&raquo;</b><?php echo t('button','RemoveRealm') ?></a></li>
 	</ul>
 
 
 	<h3>Proxys Management</h3>
 	<ul class="subnav">
 
-		<li><a href="mng-rad-proxys-list.php"><b>&raquo;</b><?php echo $l['button']['ListProxys'] ?></a></li>
-		<li><a href="mng-rad-proxys-new.php"><b>&raquo;</b><?php echo $l['button']['NewProxy'] ?></a></li>
-		<li><a href="javascript:document.mngradproxyedit.submit();""><b>&raquo;</b><?php echo $l['button']['EditProxy'] ?><a>
+		<li><a href="mng-rad-proxys-list.php"><b>&raquo;</b><?php echo t('button','ListProxys') ?></a></li>
+		<li><a href="mng-rad-proxys-new.php"><b>&raquo;</b><?php echo t('button','NewProxy') ?></a></li>
+		<li><a href="javascript:document.mngradproxyedit.submit();""><b>&raquo;</b><?php echo t('button','EditProxy') ?><a>
 			<form name="mngradproxyedit" action="mng-rad-proxys-edit.php" method="get" class="sidebar">
 			<?php   
 				populate_proxys("Select Proxy","proxyname","generic");
 			?>
 			</form></li>
 
-		<li><a href="mng-rad-proxys-del.php"><b>&raquo;</b><?php echo $l['button']['RemoveProxy'] ?></a></li>
+		<li><a href="mng-rad-proxys-del.php"><b>&raquo;</b><?php echo t('button','RemoveProxy') ?></a></li>
 	</ul>
 
 </div>

--- a/menu-mng-rad-usergroup.php
+++ b/menu-mng-rad-usergroup.php
@@ -24,31 +24,31 @@
 	<h3>User-Group Management</h3>
 	<ul class="subnav">
 
-		<li><a href="mng-rad-usergroup-list.php"><b>&raquo;</b><?php echo $l['button']['ListUserGroup'] ?></a></li>
-		<li><a href="javascript:document.mngradusrgrplist.submit();""><b>&raquo;</b><?php echo $l['button']['ListUsersGroup'] ?><a>
+		<li><a href="mng-rad-usergroup-list.php"><b>&raquo;</b><?php echo t('button','ListUserGroup') ?></a></li>
+		<li><a href="javascript:document.mngradusrgrplist.submit();""><b>&raquo;</b><?php echo t('button','ListUsersGroup') ?><a>
 			<form name="mngradusrgrplist" action="mng-rad-usergroup-list-user.php" method="get" 
 				class="sidebar">
 			<input name="username" type="text" id="usernameList" <?php if ($autoComplete) echo "autocomplete='off'"; ?>
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['Username']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','Username'); ?> <br/>'
 				/>
 			</form></li>
 
-		<li><a href="mng-rad-usergroup-new.php"><b>&raquo;</b><?php echo $l['button']['NewUserGroup'] ?></a></li>
-		<li><a href="javascript:document.mngradusrgrpedit.submit();""><b>&raquo;</b><?php echo $l['button']['EditUserGroup'] ?><a>
+		<li><a href="mng-rad-usergroup-new.php"><b>&raquo;</b><?php echo t('button','NewUserGroup') ?></a></li>
+		<li><a href="javascript:document.mngradusrgrpedit.submit();""><b>&raquo;</b><?php echo t('button','EditUserGroup') ?><a>
 			<form name="mngradusrgrpedit" action="mng-rad-usergroup-edit.php" method="get" class="sidebar">
 			<input name="username" type="text" value="" id="usernameEdit" <?php if ($autoComplete) echo "autocomplete='off'"; ?>
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['Username']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','Username'); ?> <br/>'
 				/>
 			<input name="group" type="text" value="" id="groupnameEdit" <?php if ($autoComplete) echo "autocomplete='off'"; ?>
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['GroupName']; ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','GroupName'); ?> <br/>'
 				/>
 			</form></li>
 
 
-		<li><a href="mng-rad-usergroup-del.php"><b>&raquo;</b><?php echo $l['button']['RemoveUserGroup'] ?></a></li>
+		<li><a href="mng-rad-usergroup-del.php"><b>&raquo;</b><?php echo t('button','RemoveUserGroup') ?></a></li>
 	</ul>
 
 </div>

--- a/menu-mng-users.php
+++ b/menu-mng-users.php
@@ -24,38 +24,38 @@
 	
 		<li><a href="mng-list-all.php"><b>&raquo;</b>
 			<img src='images/icons/userList.gif' border='0'>
-			<?php echo $l['button']['ListUsers'] ?></a>
+			<?php echo t('button','ListUsers') ?></a>
 		</li>
 		<li><a href="mng-new.php"><b>&raquo;</b>
 			<img src='images/icons/userNew.gif' border='0'>
-			<?php echo $l['button']['NewUser'] ?></a>
+			<?php echo t('button','NewUser') ?></a>
 		</li>
 		<li><a href="mng-new-quick.php"><b>&raquo;</b>
 			<img src='images/icons/userNew.gif' border='0'>
-			<?php echo $l['button']['NewUserQuick'] ?></a>
+			<?php echo t('button','NewUserQuick') ?></a>
 		</li>
 		<li><a href="javascript:document.mngedit.submit();""><b>&raquo;</b>
 			<img src='images/icons/userEdit.gif' border='0'>
-			<?php echo $l['button']['EditUser'] ?></a>
+			<?php echo t('button','EditUser') ?></a>
 			<form name="mngedit" action="mng-edit.php" method="get" class="sidebar">
 			<input name="username" type="text" id="usernameEdit" autocomplete="off"
 				onClick='javascript:__displayTooltip();' 
-				tooltipText='<?php echo $l['Tooltip']['Username']; ?> <br/>'
+				tooltipText='<?php echo t('Tooltip','Username'); ?> <br/>'
 				value="<?php if (isset($edit_username)) echo $edit_username; ?>" tabindex=1>
 			</form></li>
 		<li><a href="javascript:document.mngsearch.submit();""><b>&raquo;</b>
 			<img src='images/icons/userSearch.gif' border='0'>
-			<?php echo $l['button']['SearchUsers'] ?></a>
+			<?php echo t('button','SearchUsers') ?></a>
 			<form name="mngsearch" action="mng-search.php" method="get" class="sidebar">
 			<input name="username" type="text" id="usernameSearch" autocomplete="off"
 				onClick='javascript:__displayTooltip();' 
-				tooltipText='<?php echo $l['Tooltip']['Username']; ?> <br/> <?php echo $l['Tooltip']['UsernameWildcard']; ?>'
+				tooltipText='<?php echo t('Tooltip','Username'); ?> <br/> <?php echo t('Tooltip','UsernameWildcard'); ?>'
 				value="<?php if (isset($search_username)) echo $search_username; ?>" tabindex=2>
 			</form></li>
 		
 		<li><a href="mng-del.php"><b>&raquo;</b>
 			<img src='images/icons/userRemove.gif' border='0'>
-			<?php echo $l['button']['RemoveUsers'] ?>
+			<?php echo t('button','RemoveUsers') ?>
 			</a>
 		</li>
 		
@@ -67,7 +67,7 @@
 	
 		<li><a href="mng-import-users.php"><b>&raquo;</b>
 			<img src='images/icons/userNew.gif' border='0'>
-			<?php echo $l['button']['ImportUsers'] ?></a>
+			<?php echo t('button','ImportUsers') ?></a>
 		</li>
 		
 	</ul>

--- a/menu-reports-batch.php
+++ b/menu-reports-batch.php
@@ -35,18 +35,18 @@ include_once ("lang/main.php");
 		<h3>List</h3>
 
 			<li>
-				<a href="rep-batch-list.php"><b>&raquo;</b><?php echo $l['button']['BatchHistory'] ?></a>
+				<a href="rep-batch-list.php"><b>&raquo;</b><?php echo t('button','BatchHistory') ?></a>
 
 			</li>
 			
 			
 			
 			<li>
-				<a href="javascript:document.batch_name_details.submit();"><b>&raquo;</b><?php echo $l['button']['BatchDetails'] ?></a>
+				<a href="javascript:document.batch_name_details.submit();"><b>&raquo;</b><?php echo t('button','BatchDetails') ?></a>
 				<form name="batch_name_details" action="rep-batch-details.php" method="get" class="sidebar">
 				<input name="batch_name" type="text" id="batchNameDetails" <?php if ($autoComplete) echo "autocomplete='off'"; ?>
 									onClick='javascript:__displayTooltip();'
-									tooltipText='<?php echo $l['Tooltip']['BatchName']; ?>'
+									tooltipText='<?php echo t('Tooltip','BatchName'); ?>'
 					value="<?php if (isset($batch_name_details)) echo $batch_name_details; ?>">
 				</form>
 			</li>

--- a/menu-reports-hb.php
+++ b/menu-reports-hb.php
@@ -32,7 +32,7 @@ include_once ("lang/main.php");
 
 		<h3>Dashboard</h3>
 
-			<li><a href="rep-hb-dashboard.php"><b>&raquo;</b><?php echo $l['button']['Dashboard'] ?></a></li>
+			<li><a href="rep-hb-dashboard.php"><b>&raquo;</b><?php echo t('button','Dashboard') ?></a></li>
 
 		</ul>
 

--- a/menu-reports-logs.php
+++ b/menu-reports-logs.php
@@ -33,7 +33,7 @@ include_once ("lang/main.php");
 		<h3>Log Files</h3>
 
 			<li><a href="javascript:document.daloradius_log.submit();"><b>&raquo;</b>
-			<img src='images/icons/reportsLogs.png' border='0'>&nbsp;<?php echo $l['button']['daloRADIUSLog'] ?></a>
+			<img src='images/icons/reportsLogs.png' border='0'>&nbsp;<?php echo t('button','daloRADIUSLog') ?></a>
                         <form name="daloradius_log" action="rep-logs-daloradius.php" method="get" class="sidebar">
 	                        <select class="generic" name="daloradiusLineCount" type="text">
 					<?php if (isset($daloradiusLineCount)) {
@@ -68,7 +68,7 @@ include_once ("lang/main.php");
                         </form></li>
 
 			<li><a href="javascript:document.radius_log.submit();"><b>&raquo;</b>
-			<img src='images/icons/reportsLogs.png' border='0'>&nbsp;<?php echo $l['button']['RadiusLog'] ?></a>
+			<img src='images/icons/reportsLogs.png' border='0'>&nbsp;<?php echo t('button','RadiusLog') ?></a>
                         <form name="radius_log" action="rep-logs-radius.php" method="get" class="sidebar">
 	                        <select class="generic" name="radiusLineCount" type="text">
 					<?php if (isset($radiusLineCount)) {
@@ -102,7 +102,7 @@ include_once ("lang/main.php");
                         </form></li>
 
 			<li><a href="javascript:document.system_log.submit();"><b>&raquo;</b>
-			<img src='images/icons/reportsLogs.png' border='0'>&nbsp;<?php echo $l['button']['SystemLog'] ?></a>
+			<img src='images/icons/reportsLogs.png' border='0'>&nbsp;<?php echo t('button','SystemLog') ?></a>
                         <form name="system_log" action="rep-logs-system.php" method="get" class="sidebar">
 	                        <select class="generic" name="systemLineCount" type="text">
 					<?php if (isset($systemLineCount)) {
@@ -120,13 +120,13 @@ include_once ("lang/main.php");
                                 </select>
 	                        <input type="text" name="systemFilter" 
 	                                onClick='javascript:__displayTooltip();'
-	                                tooltipText='<?php echo $l['Tooltip']['Filter']; ?> <br/>'
+	                                tooltipText='<?php echo t('Tooltip','Filter'); ?> <br/>'
 					value="<?php if (isset($systemFilter)) echo $systemFilter; ?>" />
                         </form></li>
 
 
 			<li><a href="javascript:document.boot_log.submit();"><b>&raquo;</b>
-			<img src='images/icons/reportsLogs.png' border='0'>&nbsp;<?php echo $l['button']['BootLog'] ?></a>
+			<img src='images/icons/reportsLogs.png' border='0'>&nbsp;<?php echo t('button','BootLog') ?></a>
                         <form name="boot_log" action="rep-logs-boot.php" method="get" class="sidebar">
 	                        <select class="generic" name="bootLineCount" type="text">
 					<?php if (isset($bootLineCount)) {
@@ -144,7 +144,7 @@ include_once ("lang/main.php");
                                 </select>
 	                        <input type="text" name="bootFilter" 
 	                                onClick='javascript:__displayTooltip();'
-	                                tooltipText='<?php echo $l['Tooltip']['Filter']; ?> <br/>'
+	                                tooltipText='<?php echo t('Tooltip','Filter'); ?> <br/>'
 					value="<?php if (isset($bootFilter)) echo $bootFilter; ?>" />
                         </form></li>
 

--- a/menu-reports-status.php
+++ b/menu-reports-status.php
@@ -29,9 +29,9 @@ include_once ("lang/main.php");
 		<h3>Status</h3>
 
 			<li><a href="rep-stat-server.php"><b>&raquo;</b>
-				<img src='images/icons/reportsStatus.png' border='0'>&nbsp;<?php echo $l['button']['ServerStatus'] ?></a></li>
+				<img src='images/icons/reportsStatus.png' border='0'>&nbsp;<?php echo t('button','ServerStatus') ?></a></li>
 			<li><a href="rep-stat-services.php"><b>&raquo;</b>
-				<img src='images/icons/reportsStatus.png' border='0'>&nbsp;<?php echo $l['button']['ServicesStatus'] ?></a></li>
+				<img src='images/icons/reportsStatus.png' border='0'>&nbsp;<?php echo t('button','ServicesStatus') ?></a></li>
 
 		</ul>
 

--- a/menu-reports.php
+++ b/menu-reports.php
@@ -37,27 +37,27 @@ include_once ("lang/main.php");
 				
 						<li><a href="javascript:document.reponline.submit();"><b>&raquo;</b>
 							<img src='images/icons/reportsOnlineUsers.gif' border='0'>
-							<?php echo $l['button']['OnlineUsers'] ?></a>
+							<?php echo t('button','OnlineUsers') ?></a>
 							
 							<form name="reponline" action="rep-online.php" method="get" class="sidebar">
 								<input name="usernameOnline" type="text" id="usernameOnline"
 				<?php if ($autoComplete) echo "autocomplete='off'"; ?>
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['Username']; ?> <br/> <?php echo $l['Tooltip']['UsernameWildcard'] ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','Username'); ?> <br/> <?php echo t('Tooltip','UsernameWildcard') ?> <br/>'
 								value="<?php if (isset($usernameOnline)) echo $usernameOnline ?>" tabindex=1>
 							</form>
 							</li>							
 
                                                 <li><a href="javascript:document.replastconnect.submit();"><b>&raquo;</b>
 							<img src='images/icons/reportsLastConnection.png' border='0'>
-							<?php echo $l['button']['LastConnectionAttempts'] ?></a>
+							<?php echo t('button','LastConnectionAttempts') ?></a>
 
 
 							<form name="replastconnect" action="rep-lastconnect.php" method="get" class="sidebar">
 								<input name="usernameLastConnect" type="text" id="usernameLastConnect"
 				<?php if ($autoComplete) echo "autocomplete='off'"; ?>
                                 onClick='javascript:__displayTooltip();'
-                                tooltipText='<?php echo $l['Tooltip']['Username']; ?> <br/> <?php echo $l['Tooltip']['UsernameWildcard'] ?> <br/>'
+                                tooltipText='<?php echo t('Tooltip','Username'); ?> <br/> <?php echo t('Tooltip','UsernameWildcard') ?> <br/>'
 								value="<?php if (isset($usernameLastConnect)) echo $usernameLastConnect ?>" tabindex=2>
 								<select class="generic" name="radiusreply" tabindex=3>
 									<option value="Any">Any</option>
@@ -68,7 +68,7 @@ include_once ("lang/main.php");
 							<img src="library/js_date/calendar.gif" 
 								onclick="showChooser(this, 'startdate_lastconnect', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
 							<input name="startdate" type="text" id="startdate_lastconnect" onClick='javascript:__displayTooltip();'
-								tooltipText='<?php echo $l['Tooltip']['Date']; ?>'
+								tooltipText='<?php echo t('Tooltip','Date'); ?>'
 							value="<?php if (isset($startdate)) echo $startdate;
 							else echo date("Y-m-01"); ?>">
 							<div id="chooserSpan" class="dateChooser select-free" 
@@ -79,7 +79,7 @@ include_once ("lang/main.php");
 							<img src="library/js_date/calendar.gif" 
 								onclick="showChooser(this, 'enddate_lastconnect', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
 							<input name="enddate" type="text" id="enddate_lastconnect" onClick='javascript:__displayTooltip();'
-								tooltipText='<?php echo $l['Tooltip']['Date']; ?>'
+								tooltipText='<?php echo t('Tooltip','Date'); ?>'
 								value="<?php if (isset($enddate)) echo $enddate;
 							else echo date("Y-m-t"); ?>">
 							<div id="chooserSpan" class="dateChooser select-free" 
@@ -93,14 +93,14 @@ include_once ("lang/main.php");
 
 						<li><a href="javascript:document.repnewusers.submit();"><b>&raquo;</b>
 						<img src='images/icons/userList.gif' border='0'>
-						<?php echo $l['button']['NewUsers'] ?></a>
+						<?php echo t('button','NewUsers') ?></a>
 
 						<form name="repnewusers" action="rep-newusers.php" method="get" class="sidebar">
 							<h4>Start Date</h4>
 							<img src="library/js_date/calendar.gif" 
 								onclick="showChooser(this, 'startdate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
 							<input name="startdate" type="text" id="startdate" onClick='javascript:__displayTooltip();'
-								tooltipText='<?php echo $l['Tooltip']['Date']; ?>'
+								tooltipText='<?php echo t('Tooltip','Date'); ?>'
 							value="<?php if (isset($startdate)) echo $startdate;
 							else echo date("Y-01-01"); ?>">
 							<div id="chooserSpan" class="dateChooser select-free" 
@@ -110,7 +110,7 @@ include_once ("lang/main.php");
 							<img src="library/js_date/calendar.gif" 
 								onclick="showChooser(this, 'enddate', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
 							<input name="enddate" type="text" id="enddate" onClick='javascript:__displayTooltip();'
-								tooltipText='<?php echo $l['Tooltip']['Date']; ?>'
+								tooltipText='<?php echo t('Tooltip','Date'); ?>'
 								value="<?php if (isset($enddate)) echo $enddate;
 							else echo date("Y-m-t"); ?>">
 							<div id="chooserSpan" class="dateChooser select-free" 
@@ -123,7 +123,7 @@ include_once ("lang/main.php");
 							
 						<li><a href="javascript:document.topusers.submit();"><b>&raquo;</b>
 							<img src='images/icons/reportsTopUsers.png' border='0'>
-							<?php echo $l['button']['TopUser'] ?></a>
+							<?php echo t('button','TopUser') ?></a>
 							<form name="topusers" action="rep-topusers.php" method="get" class="sidebar">
 							<select class="generic" name="limit" type="text" tabindex=3>
 								<option value="5"> 5 </option>
@@ -141,7 +141,7 @@ include_once ("lang/main.php");
 			<img src="library/js_date/calendar.gif" 
 				onclick="showChooser(this, 'startdate_topuser', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
 			<input name="startdate" type="text" id="startdate_topuser" onClick='javascript:__displayTooltip();'
-                     tooltipText='<?php echo $l['Tooltip']['Date']; ?>'
+                     tooltipText='<?php echo t('Tooltip','Date'); ?>'
 			value="<?php if (isset($startdate)) echo $startdate;
 			else echo date("Y-m-01"); ?>">
 			<div id="chooserSpan" class="dateChooser select-free" 
@@ -152,7 +152,7 @@ include_once ("lang/main.php");
 			<img src="library/js_date/calendar.gif" 
 				onclick="showChooser(this, 'enddate_topuser', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'Y-m-d', false);">
 			<input name="enddate" type="text" id="enddate_topuser" onClick='javascript:__displayTooltip();'
-                     tooltipText='<?php echo $l['Tooltip']['Date']; ?>'
+                     tooltipText='<?php echo t('Tooltip','Date'); ?>'
 			value="<?php if (isset($enddate)) echo $enddate;
 			else echo date("Y-m-t"); ?>">
 			<div id="chooserSpan" class="dateChooser select-free" 
@@ -167,7 +167,7 @@ include_once ("lang/main.php");
 							</form></li>
                                                 <li><a href="rep-history.php"><b>&raquo;</b>
 							<img src='images/icons/reportsHistory.png' border='0'>
-							<?php echo $l['button']['History'] ?></a></li>
+							<?php echo t('button','History') ?></a></li>
 				</ul>
 		
 				

--- a/mng-batch-add.php
+++ b/mng-batch-add.php
@@ -552,11 +552,11 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngbatch.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngbatch.php') ?>
 				<h144>+</h144></a></h2>
 
 				<div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['mngbatch'] ?>
+					<?php echo t('helpPage','mngbatch') ?>
 					<br/>
 				</div>
                 <?php
@@ -567,40 +567,40 @@
 
 <div class="tabber">
 
-     <div class="tabbertab" title="<?php echo $l['title']['AccountInfo']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','AccountInfo'); ?>">
 
 	<fieldset>
 
-                <h302> <?php echo $l['title']['AccountInfo']; ?> </h302>
+                <h302> <?php echo t('title','AccountInfo'); ?> </h302>
 		<br/>
 
 		<ul>
 
 
 		<li class='fieldset'>
-		<label for='batchName' class='form'><?php echo $l['all']['batchName'] ?></label>
+		<label for='batchName' class='form'><?php echo t('all','batchName') ?></label>
 		<input name='batch_name' type='text' id='batch_name' value='' tabindex='100' />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('batchNameTooltip')" />
 		
 		<div id='batchNameTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['batchNameTooltip'] ?>
+			<?php echo t('Tooltip','batchNameTooltip') ?>
 		</div>
 		</li>
 		
 		<li class='fieldset'>
-		<label for='batchDescription' class='form'><?php echo $l['all']['batchDescription'] ?></label>
+		<label for='batchDescription' class='form'><?php echo t('all','batchDescription') ?></label>
 		<input name='batch_description' type='text' id='batch_description' value='' tabindex='101' />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('batchDescriptionTooltip')" />
 		
 		<div id='batchDescriptionTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['batchDescriptionTooltip'] ?>
+			<?php echo t('Tooltip','batchDescriptionTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='hotspot' class='form'><?php echo $l['all']['HotSpot']?></label>
+		<label for='hotspot' class='form'><?php echo t('all','HotSpot')?></label>
 		<?php
 		        include_once('include/management/populate_selectbox.php');
 		        populate_hotspots("Select Hotspot", "hotspot_id");
@@ -608,7 +608,7 @@
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('hotspot')" />
 		<div id='hotspotTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['hotspotTooltip'] ?>
+			<?php echo t('Tooltip','hotspotTooltip') ?>
 		</div>
 		</li>
 
@@ -622,13 +622,13 @@
 		<br/>
 		
 		<li class='fieldset'>
-		<label for='usernamePrefix' class='form'><?php echo $l['all']['UsernamePrefix'] ?></label>
+		<label for='usernamePrefix' class='form'><?php echo t('all','UsernamePrefix') ?></label>
 		<input name='username_prefix' type='text' id='username_prefix' value='' tabindex='102' />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('usernamePrefixTooltip')" />
 		
 		<div id='usernamePrefixTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['usernamePrefixTooltip'] ?>
+			<?php echo t('Tooltip','usernamePrefixTooltip') ?>
 		</div>
 		</li>
 		
@@ -637,12 +637,12 @@
 		<li class='fieldset'>
 		<input checked type='radio' value="createRandomUsers" name="createBatchUsersType" 
 			onclick="javascript:toggleRandomUsers()"/>
-		<b> <?php echo $l['all']['CreateRandomUsers'] ?> </b>
+		<b> <?php echo t('all','CreateRandomUsers') ?> </b>
 		<br/>
 		</li>
 
 		<li class='fieldset'>
-		<label for='usernameLength' class='form'><?php echo $l['all']['UsernameLength'] ?></label>
+		<label for='usernameLength' class='form'><?php echo t('all','UsernameLength') ?></label>
 		<input class="integer" name='length_user' type='text' id='length_user' value='8' tabindex='103' />
 		<img src="images/icons/bullet_arrow_up.png" alt="+" onclick="javascript:changeInteger('length_user','increment')" />
 		<img src="images/icons/bullet_arrow_down.png" alt="-" onclick="javascript:changeInteger('length_user','decrement')"/>
@@ -650,7 +650,7 @@
 		
 		<div id='lengthOfUsernameTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['lengthOfUsernameTooltip'] ?>
+			<?php echo t('Tooltip','lengthOfUsernameTooltip') ?>
 		</div>
 		</li>
 
@@ -660,12 +660,12 @@
 		<li class='fieldset'>
 		<input type='radio' value="createIncrementUsers" name="createBatchUsersType" 
 			onclick="javascript:toggleIncrementUsers()"/>
-		<b> <?php echo $l['all']['CreateIncrementingUsers'] ?> </b>
+		<b> <?php echo t('all','CreateIncrementingUsers') ?> </b>
 		<br/>
 		</li>
 
 		<li class='fieldset'>
-		<label for='startingIndex' class='form'><?php echo $l['all']['StartingIndex'] ?></label>
+		<label for='startingIndex' class='form'><?php echo t('all','StartingIndex') ?></label>
 		<input class="integerLarge" name='startingIndex' type='text' id='startingIndex' value='1' disabled tabindex='104' />
 		<img src="images/icons/bullet_arrow_up.png" alt="+" onclick="javascript:changeInteger('startingIndex','increment')" />
 		<img src="images/icons/bullet_arrow_down.png" alt="-" onclick="javascript:changeInteger('startingIndex','decrement')"/>
@@ -673,7 +673,7 @@
 
 		<div id='startingIndexTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['startingIndexTooltip'] ?>
+			<?php echo t('Tooltip','startingIndexTooltip') ?>
 		</div>
 		<li>
 
@@ -681,7 +681,7 @@
 		<br/>
 		
 		<li class='fieldset'>
-		<label for='passwordLength' class='form'><?php echo $l['all']['PasswordLength'] ?></label>
+		<label for='passwordLength' class='form'><?php echo t('all','PasswordLength') ?></label>
 		<input class="integer" name='length_pass' type='text' id='length_pass' value='8' tabindex='105' />
 		<img src="images/icons/bullet_arrow_up.png" alt="+" onclick="javascript:changeInteger('length_pass','increment')" />
 		<img src="images/icons/bullet_arrow_down.png" alt="-" onclick="javascript:changeInteger('length_pass','decrement')"/>
@@ -689,12 +689,12 @@
 
 		<div id='lengthOfPasswordTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['lengthOfPasswordTooltip'] ?>
+			<?php echo t('Tooltip','lengthOfPasswordTooltip') ?>
 		</div>
 		</li>		
 
 		<li class='fieldset'>
-		<label for='numberInstances' class='form'><?php echo $l['all']['NumberInstances'] ?></label>
+		<label for='numberInstances' class='form'><?php echo t('all','NumberInstances') ?></label>
 		<input class="integer" name='number' type='text' id='number' value='1' tabindex='106' />
 		<img src="images/icons/bullet_arrow_up.png" alt="+" onclick="javascript:changeInteger('number','increment')" />
 		<img src="images/icons/bullet_arrow_down.png" alt="-" onclick="javascript:changeInteger('number','decrement')"/>
@@ -702,12 +702,12 @@
 
 		<div id='instancesToCreateTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['instancesToCreateTooltip'] ?>
+			<?php echo t('Tooltip','instancesToCreateTooltip') ?>
 		</div>
 		<li>
 		
 		<li class='fieldset'>
-		<label for='group' class='form'><?php echo $l['all']['Group']?></label>
+		<label for='group' class='form'><?php echo t('all','Group')?></label>
 		<?php
 		        include_once('include/management/populate_selectbox.php');
 		        populate_groups("Select Groups","group");
@@ -715,19 +715,19 @@
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('group')" />
 		<div id='groupTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['groupTooltip'] ?>
+			<?php echo t('Tooltip','groupTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='groupPriority' class='form'><?php echo $l['all']['GroupPriority'] ?></label>
+		<label for='groupPriority' class='form'><?php echo t('all','GroupPriority') ?></label>
 		<input class="integer" name='group_priority' type='text' id='group_priority' value='0' tabindex='107' />
 		<img src="images/icons/bullet_arrow_up.png" alt="+" onclick="javascript:changeInteger('group_priority','increment')" />
 		<img src="images/icons/bullet_arrow_down.png" alt="-" onclick="javascript:changeInteger('group_priority','decrement')"/>
 		</li>
 
 		<li class='fieldset'>
-		<label for='plan' class='form'><?php echo $l['all']['PlanName']?></label>
+		<label for='plan' class='form'><?php echo t('all','PlanName')?></label>
 		<?php
 		        include_once('include/management/populate_selectbox.php');
 		        populate_plans("Select Plan","plan");
@@ -735,14 +735,14 @@
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('plan')" />
 		<div id='planTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['planTooltip'] ?>
+			<?php echo t('Tooltip','planTooltip') ?>
 		</div>
 		</li>
 		
 		<li class='fieldset'>
 		<br/><br/>
 		<hr><br/>
-		<input type="submit" name="submit" value="<?php echo $l['buttons']['apply'] ?> " tabindex=1000 
+		<input type="submit" name="submit" value="<?php echo t('buttons','apply') ?> " tabindex=1000 
 			class='button' />
 		</li>
 		</ul>
@@ -751,21 +751,21 @@
 
      </div>
 
-	<div class="tabbertab" title="<?php echo $l['title']['UserInfo']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','UserInfo'); ?>">
 	<?php
-		$customApplyButton = "<input type='submit' name='submit' value=".$l['buttons']['apply']." class='button' />";
+		$customApplyButton = "<input type='submit' name='submit' value=".t('buttons','apply')." class='button' />";
 		include_once('include/management/userinfo.php');
 	?>
 	</div>
 
-	<div class="tabbertab" title="<?php echo $l['title']['BillingInfo']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','BillingInfo'); ?>">
 	<?php
-		$customApplyButton = "<input type='submit' name='submit' value=".$l['buttons']['apply']." class='button' />";
+		$customApplyButton = "<input type='submit' name='submit' value=".t('buttons','apply')." class='button' />";
 		include_once('include/management/userbillinfo.php');
 	?>
 	</div>
 
-     <div class="tabbertab" title="<?php echo $l['title']['Attributes']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','Attributes'); ?>">
 	<?php
 		include_once('include/management/attributes.php');
 	?>

--- a/mng-batch-del.php
+++ b/mng-batch-del.php
@@ -184,11 +184,11 @@
 
 <div id="contentnorightbar">
 	
-	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngbatchdel.php'] ?>
+	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngbatchdel.php') ?>
 	:: <?php if (isset($username)) { echo $username; } ?><h144>+</h144></a></h2>
 
 	<div id="helpPage" style="display:none;visibility:visible" >
-		<?php echo $l['helpPage']['mngbatchdel'] ?>
+		<?php echo t('helpPage','mngbatchdel') ?>
 		<br/>
 	</div>
 	<?php
@@ -200,15 +200,15 @@
 	
 	<fieldset>
 
-		<h302> <?php echo $l['title']['BatchRemoval'] ?> </h302>
+		<h302> <?php echo t('title','BatchRemoval') ?> </h302>
 		<br/>
 
-		<label for='batch_name' class='form'><?php echo $l['all']['BatchName']?></label>
+		<label for='batch_name' class='form'><?php echo t('all','BatchName')?></label>
 		<input name='batch_name' type='text' id='batch_name' value='' tabindex=100 />
 
 		<br/><br/>
 		<hr><br/>
-		<input type="submit" name="submit" value="<?php echo $l['buttons']['apply'] ?>" tabindex=1000 
+		<input type="submit" name="submit" value="<?php echo t('buttons','apply') ?>" tabindex=1000 
 			class='button' />
 
 	</fieldset>

--- a/mng-batch-list.php
+++ b/mng-batch-list.php
@@ -70,11 +70,11 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngbatchlist.php']; ?>
+		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngbatchlist.php'); ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngbatchlist'] ?>
+			<?php echo t('helpPage','mngbatchlist') ?>
 			<br/>
 		</div>
 
@@ -217,41 +217,41 @@
 	echo "<thread> <tr>
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=id&orderType=$orderType\">
-		".$l['all']['BatchName']."</a>
+		".t('all','BatchName')."</a>
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['HotSpot']."
+		".t('all','HotSpot')."
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['BatchStatus']."
+		".t('all','BatchStatus')."
 		</th>
 		
 		<th scope='col'> 
-		".$l['all']['TotalUsers']."
+		".t('all','TotalUsers')."
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['PlanName']."
+		".t('all','PlanName')."
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['PlanCost']."
+		".t('all','PlanCost')."
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['BatchCost']."
+		".t('all','BatchCost')."
 		</th>
 
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=creationdate&orderType=$orderType\">
-		".$l['all']['CreationDate']."</a>
+		".t('all','CreationDate')."</a>
 		</th>
 
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=creationby&orderType=$orderType\">
-		".$l['all']['CreationBy']."</a>
+		".t('all','CreationBy')."</a>
 		</th>
 
 		</tr> </thread>";
@@ -280,10 +280,10 @@
 					onClick='javascript:__displayTooltip();'
 					tooltipText='
 					<a class=\"toolTip\" href=\"rep-batch-details.php?batch_name={$row['batch_name']}\">
-						{$l['Tooltip']['BatchDetails']}</a>
+						{t('Tooltip','BatchDetails')}</a>
 						<br/><br/>
 								<div id=\"divContainerUserInfo\">
-									<b>{$l['all']['batchDescription']}</b>:<br/><br/>
+									<b>{t('all','batchDescription')}</b>:<br/><br/>
 									{$row['batch_description']}
 								</div>
 								<br/>

--- a/mng-batch.php
+++ b/mng-batch.php
@@ -43,7 +43,7 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#"><?php echo $l['Intro']['mngbatch.php'] ?></a></h2>
+		<h2 id="Intro"><a href="#"><?php echo t('Intro','mngbatch.php') ?></a></h2>
 		<p>
 		</p>
 

--- a/mng-del.php
+++ b/mng-del.php
@@ -205,11 +205,11 @@
 
 <div id="contentnorightbar">
 
-	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngdel.php'] ?>
+	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngdel.php') ?>
 	:: <?php if (isset($username)) { echo $username; } ?><h144>+</h144></a></h2>
 
 	<div id="helpPage" style="display:none;visibility:visible" >
-		<?php echo $l['helpPage']['mngdel'] ?>
+		<?php echo t('helpPage','mngdel') ?>
 		<br/>
 	</div>
 	<?php
@@ -221,14 +221,14 @@
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['AccountRemoval'] ?> </h302>
+		<h302> <?php echo t('title','AccountRemoval') ?> </h302>
 		<br/>
 
-		<label for='username' class='form'><?php echo $l['all']['Username']?></label>
+		<label for='username' class='form'><?php echo t('all','Username')?></label>
 		<input name='username[]' type='text' id='username' value='<?php echo $username ?>' tabindex=100 />
 		<br />
 
-		<label for='delradacct' class='form'><?php echo $l['all']['RemoveRadacctRecords']?></label>
+		<label for='delradacct' class='form'><?php echo t('all','RemoveRadacctRecords')?></label>
 		<select class='form' tabindex=102 name='delradacct' tabindex=101>
 			<option value='no'>no</option>
 			<option value='yes'>yes</option>
@@ -237,7 +237,7 @@
 
 		<br/><br/>
 		<hr><br/>
-		<input type="submit" name="submit" value="<?php echo $l['buttons']['apply'] ?>" tabindex=1000
+		<input type="submit" name="submit" value="<?php echo t('buttons','apply') ?>" tabindex=1000
 			class='button' />
 
 	</fieldset>

--- a/mng-edit.php
+++ b/mng-edit.php
@@ -720,11 +720,11 @@ function enableUser() {
 
 <div id="contentnorightbar">
 
-	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngedit.php'] ?>
+	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngedit.php') ?>
 	:: <?php if (isset($username)) { echo $username; } ?><h144>+</h144></a></h2>
 
 	<div id="helpPage" style="display:none;visibility:visible" >
-		<?php echo $l['helpPage']['mngedit'] ?>
+		<?php echo t('helpPage','mngedit') ?>
 		<br/>
 	</div>
 	<?php
@@ -741,36 +741,36 @@ function enableUser() {
 	<input type="hidden" value="<?php echo $username ?>" name="username" />
 
 	<div class="tabber">
- <div class="tabbertab" title="<?php echo $l['title']['AccountInfo']; ?>">
+ <div class="tabbertab" title="<?php echo t('title','AccountInfo'); ?>">
 
 	<fieldset>
 
-                <h302> <?php echo $l['title']['AccountInfo']; ?> </h302>
+                <h302> <?php echo t('title','AccountInfo'); ?> </h302>
 
                 <ul>
 
                 <div id='UserContainer'>
                 <li class='fieldset'>
-                <label for='username' class='form'><?php echo $l['all']['Username']?></label>
+                <label for='username' class='form'><?php echo t('all','Username')?></label>
 		<input name='username' type='hidden' value='<?php if (isset($username)) echo $username ?>' />
                 <input name='username' type='text' id='username' value='<?php if (isset($username)) echo $username ?>' disabled tabindex=100 />
                 <img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('usernameTooltip')" />
 
                 <div id='usernameTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['usernameTooltip'] ?>
+                        <?php echo t('Tooltip','usernameTooltip') ?>
                 </div>
                 </li>
 
                 <li class='fieldset'>
-                <label for='password' class='form'><?php echo $l['all']['Password']?></label>
+                <label for='password' class='form'><?php echo t('all','Password')?></label>
                 <input name='password' type='text' id='password' value='<?php if (isset($user_password)) echo $user_password ?>'
                         <?php if (isset($hiddenPassword)) echo $hiddenPassword ?> disabled tabindex=101 />
                 <img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('passwordTooltip')" />
 
                 <div id='passwordTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['passwordTooltip'] ?>
+                        <?php echo t('Tooltip','passwordTooltip') ?>
                 </div>
                 </li>
                 </div>
@@ -778,7 +778,7 @@ function enableUser() {
 
 
 		<li class='fieldset'>
-		<label for='planName' class='form'><?php echo $l['all']['PlanName'] ?></label>
+		<label for='planName' class='form'><?php echo t('all','PlanName') ?></label>
 		<input name='oldplanName' type='hidden' value='<?php if (isset($bi_planname)) echo $bi_planname ?>' />
                 <?php
  	               include 'include/management/populate_selectbox.php';
@@ -788,7 +788,7 @@ function enableUser() {
 
 		<div id='planNameTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['planNameTooltip'] ?>
+			<?php echo t('Tooltip','planNameTooltip') ?>
 		</div>
 		</li>
 
@@ -810,7 +810,7 @@ function enableUser() {
 				onClick='javascript:disableUser()' />
 
 		<br/><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' />
 
 		<div style="float: right; text-align: right;">
 				<a href="<?php echo $_SESSION['PREV_LIST_PAGE']; ?>">Back to Listing Page</a>
@@ -825,11 +825,11 @@ function enableUser() {
 	</div>
 
 
-		<div class="tabbertab" title="<?php echo $l['title']['RADIUSCheck']; ?>">
+		<div class="tabbertab" title="<?php echo t('title','RADIUSCheck'); ?>">
 
 		<fieldset>
 
-			<h302> <?php echo $l['title']['RADIUSCheck']; ?> </h302>
+			<h302> <?php echo t('title','RADIUSCheck'); ?> </h302>
 			<br/>
 
 			<ul>
@@ -859,7 +859,7 @@ function enableUser() {
 
 	if ($numrows = $res->numRows() == 0) {
 		echo "<center>";
-		echo $l['messages']['noCheckAttributesForUser'];
+		echo t('messages','noCheckAttributesForUser');
 		echo "</center>";
 	}
 
@@ -919,7 +919,7 @@ function enableUser() {
 			<hr><br/>
 
 			<br/>
-			<input type='submit' name='submit' value='<?php echo $l['buttons']['apply']?>' class='button' />
+			<input type='submit' name='submit' value='<?php echo t('buttons','apply')?>' class='button' />
 			<br/>
 
 			</ul>
@@ -927,11 +927,11 @@ function enableUser() {
 		</fieldset>
 	</div>
 
-	<div class='tabbertab' title='<?php echo $l['title']['RADIUSReply']?>' >
+	<div class='tabbertab' title='<?php echo t('title','RADIUSReply')?>' >
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['RADIUSReply']; ?> </h302>
+		<h302> <?php echo t('title','RADIUSReply'); ?> </h302>
 		<br/>
 
 		<ul>
@@ -957,7 +957,7 @@ function enableUser() {
 
 	if ($numrows = $res->numRows() == 0) {
 		echo "<center>";
-		echo $l['messages']['noReplyAttributesForUser'];
+		echo t('messages','noReplyAttributesForUser');
 		echo "</center>";
 	}
 
@@ -1014,7 +1014,7 @@ function enableUser() {
         <hr><br/>
 
         <br/>
-        <input type='submit' name='submit' value='<?php echo $l['buttons']['apply']?>' class='button' />
+        <input type='submit' name='submit' value='<?php echo t('buttons','apply')?>' class='button' />
         <br/>
 
 	</ul>
@@ -1027,27 +1027,27 @@ function enableUser() {
 ?>
 
 
-     <div class="tabbertab" title="<?php echo $l['title']['UserInfo']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','UserInfo'); ?>">
         <?php
-                $customApplyButton = "<input type='submit' name='submit' value=".$l['buttons']['apply']." class='button' />";
+                $customApplyButton = "<input type='submit' name='submit' value=".t('buttons','apply')." class='button' />";
                 include_once('include/management/userinfo.php');
         ?>
      </div>
 
-        <div class="tabbertab" title="<?php echo $l['title']['BillingInfo']; ?>">
+        <div class="tabbertab" title="<?php echo t('title','BillingInfo'); ?>">
         <?php
-                $customApplyButton = "<input type='submit' name='submit' value=".$l['buttons']['apply']." class='button' />";
+                $customApplyButton = "<input type='submit' name='submit' value=".t('buttons','apply')." class='button' />";
                 include_once('include/management/userbillinfo.php');
         ?>
         </div>
 
-     <div class="tabbertab" title="<?php echo $l['title']['Attributes']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','Attributes'); ?>">
         <?php
                 include_once('include/management/attributes.php');
         ?>
      </div>
 
-     <div class="tabbertab" title="<?php echo $l['title']['Groups']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','Groups'); ?>">
 
 <?php
         include 'library/opendb.php';
@@ -1065,7 +1065,7 @@ function enableUser() {
         <li class='fieldset'>
 
                 <li class='fieldset'>
-                <label for='group' class='form'><?php echo $l['all']['Group']?></label>
+                <label for='group' class='form'><?php echo t('all','Group')?></label>
                 <?php
                         include_once 'include/management/populate_selectbox.php';
                         populate_groups("Select Groups","newgroups[]");
@@ -1082,7 +1082,7 @@ function enableUser() {
 
                 <div id='groupTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['groupTooltip'] ?>
+                        <?php echo t('Tooltip','groupTooltip') ?>
                 </div>
                 </li>
 
@@ -1092,7 +1092,7 @@ function enableUser() {
 
         <br/>
         <hr><br/>
-        <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+        <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
         </li>
 
         </ul>

--- a/mng-hs-del.php
+++ b/mng-hs-del.php
@@ -91,11 +91,11 @@
 
 <div id="contentnorightbar">
 
-	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mnghsdel.php'] ?>
+	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mnghsdel.php') ?>
 	:: <?php if (isset($name)) { echo $name; } ?><h144>+</h144></a></h2>
 
 	<div id="helpPage" style="display:none;visibility:visible" >
-		<?php echo $l['helpPage']['mnghsdel'] ?>
+		<?php echo t('helpPage','mnghsdel') ?>
 		<br/>
 	</div>
 	<?php
@@ -107,17 +107,17 @@
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['HotspotRemoval'] ?> </h302>
+		<h302> <?php echo t('title','HotspotRemoval') ?> </h302>
 		<br/>
 
-		<label for='name' class='form'><?php echo $l['all']['HotSpotName'] ?></label>
+		<label for='name' class='form'><?php echo t('all','HotSpotName') ?></label>
 		<input name='name[]' type='text' id='name' value='<?php echo $name ?>' tabindex=100 autocomplete="off" />
 		<br/>
 
 		<br/><br/>
 		<hr><br/>
 
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=1000 
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=1000 
 			class='button' />
 
 	</fieldset>

--- a/mng-hs-edit.php
+++ b/mng-hs-edit.php
@@ -153,11 +153,11 @@
 ?>		
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mnghsedit.php'] ?>
+		<h2 id="Intro" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mnghsedit.php') ?>
 		:: <?php if (isset($name)) { echo $name; } ?><h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mnghsedit'] ?>
+			<?php echo t('helpPage','mnghsedit') ?>
 			<br/>
 		</div>
 		<?php
@@ -168,47 +168,47 @@
 
 <div class="tabber">
 
-	<div class="tabbertab" title="<?php echo $l['title']['HotspotInfo']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','HotspotInfo'); ?>">
 
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['HotspotInfo']; ?> </h302>
+		<h302> <?php echo t('title','HotspotInfo'); ?> </h302>
 		<br/>
 
 		<ul>
 
 			<li class='fieldset'>
-			<label for='name' class='form'><?php echo $l['all']['HotSpotName'] ?></label>
+			<label for='name' class='form'><?php echo t('all','HotSpotName') ?></label>
 			<input disabled name='name' type='text' id='name' value='<?php echo $name ?>' tabindex=100 />
 			</li>
 
 			<li class='fieldset'>
-			<label for='macaddress' class='form'><?php echo $l['all']['MACAddress'] ?></label>
+			<label for='macaddress' class='form'><?php echo t('all','MACAddress') ?></label>
 			<input name='macaddress' type='text' id='macaddress' value='<?php echo $macaddress ?>' tabindex=101 />
 			<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('hotspotMacaddressTooltip')" /> 
 			
 			<div id='hotspotMacaddressTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 				<img src='images/icons/comment.png' alt='Tip' border='0' />
-				<?php echo $l['Tooltip']['hotspotMacaddressTooltip'] ?>
+				<?php echo t('Tooltip','hotspotMacaddressTooltip') ?>
 			</div>
 			</li>
 
 			<li class='fieldset'>
-			<label for='geocode' class='form'><?php echo $l['all']['Geocode'] ?></label>
+			<label for='geocode' class='form'><?php echo t('all','Geocode') ?></label>
 			<input name='geocode' type='text' id='geocode' value='<?php echo $geocode ?>' tabindex=102 />
 			<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('geocodeTooltip')" /> 
 			
 			<div id='geocodeTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 				<img src='images/icons/comment.png' alt='Tip' border='0' />
-				<?php echo $l['Tooltip']['geocodeTooltip'] ?>
+				<?php echo t('Tooltip','geocodeTooltip') ?>
 			</div>
 			</li>
 
 			<li class='fieldset'>
 			<br/>
 			<hr><br/>
-			<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000
+			<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000
 				class='button' />
 			</li>
 
@@ -220,7 +220,7 @@
 
 </div>
 
-<div class="tabbertab" title="<?php echo $l['title']['ContactInfo']; ?>">
+<div class="tabbertab" title="<?php echo t('title','ContactInfo'); ?>">
 
 <?php
 	include_once('include/management/contactinfo.php');

--- a/mng-hs-list.php
+++ b/mng-hs-list.php
@@ -60,11 +60,11 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mnghslist.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mnghslist.php') ?>
 				<h144>+</h144></a></h2>
 				
 				<div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['mnghslist'] ?>
+					<?php echo t('helpPage','mnghslist') ?>
 					<br/>
 				</div>
 				<br/>
@@ -126,27 +126,27 @@
 	echo "<thread> <tr>
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=id&orderType=$orderTypeNextPage\">
-		".$l['all']['ID']."</a>
+		".t('all','ID')."</a>
 		</th>
 
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=name&orderType=$orderTypeNextPage\">
-		".$l['all']['HotSpot']."</a>
+		".t('all','HotSpot')."</a>
 		</th>
 
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=mac&orderType=$orderTypeNextPage\">
-		".$l['ContactInfo']['OwnerName']."</a>
+		".t('ContactInfo','OwnerName')."</a>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=geocode&orderType=$orderTypeNextPage\">
-		".$l['ContactInfo']['Company']."</a>
+		".t('ContactInfo','Company')."</a>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=geocode&orderType=$orderTypeNextPage\">
-		 ".$l['ContactInfo']['HotspotType']."</a>
+		 ".t('ContactInfo','HotspotType')."</a>
 		</th>
 
 	</tr> </thread>";
@@ -159,10 +159,10 @@
                                         javascript:__displayTooltip();'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-hs-edit.php?name=$row[1]\">
-                                                {$l['Tooltip']['HotspotEdit']}</a>
+                                                {t('Tooltip','HotspotEdit')}</a>
                                         &nbsp;
                                         <a class=\"toolTip\" href=\"acct-hotspot-compare.php?\">
-                                                {$l['all']['Compare']}</a>
+                                                {t('all','Compare')}</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerHotspotInfo\">

--- a/mng-hs-new.php
+++ b/mng-hs-new.php
@@ -125,11 +125,11 @@
 
 <div id="contentnorightbar">
 
-	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mnghsnew.php'] ?>
+	<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mnghsnew.php') ?>
 	<h144>+</h144></a></h2>
 	
 	<div id="helpPage" style="display:none;visibility:visible" >
-		<?php echo $l['helpPage']['mnghsnew'] ?>
+		<?php echo t('helpPage','mnghsnew') ?>
 		<br/>
 	</div>
 	<?php
@@ -140,52 +140,52 @@
 
 <div class="tabber">
 
-	<div class="tabbertab" title="<?php echo $l['title']['HotspotInfo']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','HotspotInfo'); ?>">
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['HotspotInfo']; ?> </h302>
+		<h302> <?php echo t('title','HotspotInfo'); ?> </h302>
 		<br/>
 
 		<ul>
 
 		<li class='fieldset'>
-		<label for='name' class='form'><?php echo $l['all']['HotSpotName'] ?></label>
+		<label for='name' class='form'><?php echo t('all','HotSpotName') ?></label>
 		<input name='name' type='text' id='name' value='' tabindex=100 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('hotspotNameTooltip')" /> 
 		
 		<div id='hotspotNameTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['hotspotNameTooltip'] ?>
+			<?php echo t('Tooltip','hotspotNameTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='macaddress' class='form'><?php echo $l['all']['MACAddress'] ?></label>
+		<label for='macaddress' class='form'><?php echo t('all','MACAddress') ?></label>
 		<input name='macaddress' type='text' id='macaddress' value='' tabindex=101 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('hotspotMacaddressTooltip')" /> 
 		
 		<div id='hotspotMacaddressTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['hotspotMacaddressTooltip'] ?>
+			<?php echo t('Tooltip','hotspotMacaddressTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='geocode' class='form'><?php echo $l['all']['Geocode'] ?></label>
+		<label for='geocode' class='form'><?php echo t('all','Geocode') ?></label>
 		<input name='geocode' type='text' id='geocode' value='' tabindex=102 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('geocodeTooltip')" /> 
 		
 		<div id='geocodeTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['geocodeTooltip'] ?>
+			<?php echo t('Tooltip','geocodeTooltip') ?>
 		</div>
 		</li>
 	
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' />
 		</li>
 
 		</ul>
@@ -194,7 +194,7 @@
 	</div>
 
 
-	<div class="tabbertab" title="<?php echo $l['title']['ContactInfo']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','ContactInfo'); ?>">
 
 <?php
 	include_once('include/management/contactinfo.php');

--- a/mng-hs.php
+++ b/mng-hs.php
@@ -24,7 +24,7 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#"><?php echo $l['Intro']['mngmain.php'] ?></a></h2>
+				<h2 id="Intro"><a href="#"><?php echo t('Intro','mngmain.php') ?></a></h2>
 
 
 <?php

--- a/mng-import-users.php
+++ b/mng-import-users.php
@@ -169,11 +169,11 @@
 
 	<div id="contentnorightbar">
 	
-			<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngimportusers.php'] ?>
+			<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngimportusers.php') ?>
 			<h144>+</h144></a></h2>
 			
 			<div id="helpPage" style="display:none;visibility:visible" >
-				<?php echo $l['helpPage']['mngimportusers'] ?>
+				<?php echo t('helpPage','mngimportusers') ?>
 				<br/>
 			</div>
 			<?php
@@ -184,7 +184,7 @@
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['ImportUsers']; ?> </h302>
+		<h302> <?php echo t('title','ImportUsers'); ?> </h302>
 		<br/>
 
 		<ul>
@@ -195,7 +195,7 @@
 		
 		
 		<li class='fieldset'>
-		<label for='passwordType' class='form'><?php echo $l['all']['PasswordType']?> </label>
+		<label for='passwordType' class='form'><?php echo t('all','PasswordType')?> </label>
 		<select class='form' tabindex=102 name='passwordType' >
 			<option value='Cleartext-Password'>Cleartext-Password</option>
 			<option value='User-Password'>User-Password</option>
@@ -207,7 +207,7 @@
 		</li>
 		
 		<li class='fieldset'>
-		<label for='group' class='form'><?php echo $l['all']['Group']?></label>
+		<label for='group' class='form'><?php echo t('all','Group')?></label>
 		<?php   
 			include_once 'include/management/populate_selectbox.php';
 			populate_groups("Select Groups","groups[]");
@@ -221,7 +221,7 @@
 
 
 		<li class='fieldset'>
-		<label for='planName' class='form'><?php echo $l['all']['PlanName'] ?></label>
+		<label for='planName' class='form'><?php echo t('all','PlanName') ?></label>
                 <?php
                        populate_plans("Select Plan","planName","form");
                 ?>
@@ -229,12 +229,12 @@
 		
 		<div id='planNameTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['planNameTooltip'] ?>
+			<?php echo t('Tooltip','planNameTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='userType' class='form'><?php echo $l['all']['UserType'] ?></label>
+		<label for='userType' class='form'><?php echo t('all','UserType') ?></label>
 		<input type='checkbox' name='userType' value='userType' /> If users are MAC or PIN based authentication, check this box
 		</li>
 
@@ -244,7 +244,7 @@
 
 		
 		<li class='fieldset'>
-		<label for='csvdata' class='form'><?php echo $l['all']['CSVData'] ?></label>
+		<label for='csvdata' class='form'><?php echo t('all','CSVData') ?></label>
 		<textarea class='form_fileimport' name='csvdata' tabindex=101></textarea>
 		</li>
 
@@ -252,7 +252,7 @@
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' />
 		</li>
 
 		</ul>

--- a/mng-list-all.php
+++ b/mng-list-all.php
@@ -66,11 +66,11 @@
 
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mnglistall.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mnglistall.php') ?>
 				<h144>+</h144></a></h2>
 				
                 <div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['mnglistall'] ?>
+					<?php echo t('helpPage','mnglistall') ?>
 					<br/>
 				</div>
 					<div id="returnMessages">
@@ -167,26 +167,26 @@
 	echo "<thread> <tr>
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=id&orderType=$orderType\">
-		".$l['all']['ID']."</a>
+		".t('all','ID')."</a>
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['Name']."</a>
+		".t('all','Name')."</a>
 		</th>
 		
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=Username&orderType=$orderType\">
-		".$l['all']['Username']."</a>
+		".t('all','Username')."</a>
 		</th>
 
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=Value&orderType=$orderType\">
-		".$l['all']['Password']."</a>
+		".t('all','Password')."</a>
 		</th>
 
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=Groupname&orderType=$orderType\">
-		".$l['title']['Groups']."</a>
+		".t('title','Groups')."</a>
 		</th>
 		</tr> </thread>";
 
@@ -206,7 +206,7 @@
 
 
 		$js = "javascript:ajaxGeneric('include/management/retUserInfo.php','retBandwidthInfo','divContainerUserInfo','username=".urlencode($row[0])."');";
-		$content =  '<a class="toolTip" href="mng-edit.php?username='.urlencode($row[0]).'">'.$l['Tooltip']['UserEdit'].'</a>';
+		$content =  '<a class="toolTip" href="mng-edit.php?username='.urlencode($row[0]).'">'.t('Tooltip','UserEdit').'</a>';
 		$str = addToolTipBalloon(array(
 									'content' => $content,
 									'onClick' => $js,

--- a/mng-main.php
+++ b/mng-main.php
@@ -24,7 +24,7 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#"><?php echo $l['Intro']['mngmain.php'] ?></a></h2>
+				<h2 id="Intro"><a href="#"><?php echo t('Intro','mngmain.php') ?></a></h2>
 				
 				<p>
 	<table><center><br/>

--- a/mng-new-quick.php
+++ b/mng-new-quick.php
@@ -306,11 +306,11 @@
 
 	<div id="contentnorightbar">
 
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngnewquick.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngnewquick.php') ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngnewquick'] ?>
+			<?php echo t('helpPage','mngnewquick') ?>
 			<br/>
 		</div>
 		<?php
@@ -320,17 +320,17 @@
 		<form name="newuser" action="mng-new-quick.php" method="post" >
 <div class="tabber">
 
-     <div class="tabbertab" title="<?php echo $l['title']['AccountInfo']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','AccountInfo'); ?>">
 
         <fieldset>
 
-			<h302> <?php echo $l['title']['AccountInfo']; ?> </h302>
+			<h302> <?php echo t('title','AccountInfo'); ?> </h302>
 			<br/>
 		
 		<ul>
 
 		<li class='fieldset'>
-		<label for='username' class='form'><?php echo $l['all']['Username']?></label>
+		<label for='username' class='form'><?php echo t('all','Username')?></label>
 		<input name='username' type='text' id='username' value='' tabindex=100  />
 		<input type='button' value='Random' class='button' onclick="javascript:randomAlphanumeric('username',8,<?php
 		echo "'".$configValues['CONFIG_USER_ALLOWEDRANDOMCHARS']."'" ?>)" />
@@ -338,12 +338,12 @@
 
 		<div id='usernameTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['usernameTooltip'] ?>
+			<?php echo t('Tooltip','usernameTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='password' class='form'><?php echo $l['all']['Password']?></label>
+		<label for='password' class='form'><?php echo t('all','Password')?></label>
 		<input name='password' type='text' id='password' value='' <?php if (isset($hiddenPassword)) 
 			echo $hiddenPassword ?> tabindex=101 />
 		<input type='button' value='Random' class='button' onclick="javascript:randomAlphanumeric('password',8,<?php
@@ -352,12 +352,12 @@
 
 		<div id='passwordTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['passwordTooltip'] ?>
+			<?php echo t('Tooltip','passwordTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='passwordType' class='form'><?php echo $l['all']['PasswordType']?> </label>
+		<label for='passwordType' class='form'><?php echo t('all','PasswordType')?> </label>
 		<select class='form' tabindex=102 name='passwordType' >
 			<option value='Cleartext-Password'>Cleartext-Password</option>
 			<option value='User-Password'>User-Password</option>
@@ -370,7 +370,7 @@
 		</li>
 
 		<li class='fieldset'>
-		<label for='group' class='form'><?php echo $l['all']['Group']?></label>
+		<label for='group' class='form'><?php echo t('all','Group')?></label>
 		<?php   
 			include_once 'include/management/populate_selectbox.php';
 			populate_groups("Select Groups","groups[]");
@@ -387,14 +387,14 @@
 
 		<div id='groupTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['groupTooltip'] ?>
+			<?php echo t('Tooltip','groupTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
 		<br/>
                 <hr><br/>
-		<input type="submit" name="submit" value="<?php echo $l['buttons']['apply']?>" 
+		<input type="submit" name="submit" value="<?php echo t('buttons','apply')?>" 
 			onclick = "javascript:small_window(document.newuser.username.value, 
 			document.newuser.password.value, document.newuser.maxallsession.value);" tabindex=10000 class='button' />
 		</li>
@@ -405,23 +405,23 @@
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['Attributes']; ?> </h302>
+		<h302> <?php echo t('title','Attributes'); ?> </h302>
 	<br/>
 
-		<label for='simultaneoususe' class='form'><?php echo $l['all']['SimultaneousUse']?></label>
+		<label for='simultaneoususe' class='form'><?php echo t('all','SimultaneousUse')?></label>
 		<input name='simultaneoususe' type='text' value='' tabindex=106 />
 		<br/>
 
-		<label for='framedipaddress' class='form'><?php echo $l['all']['FramedIPAddress']?></label>
+		<label for='framedipaddress' class='form'><?php echo t('all','FramedIPAddress')?></label>
 		<input name='framedipaddress' type='text' value='' tabindex=107 />
 		<br/>
 
-		<label for='expiration' class='form'><?php echo $l['all']['Expiration']?></label>		
+		<label for='expiration' class='form'><?php echo t('all','Expiration')?></label>		
 		<input value='' id='expiration' name='expiration'  tabindex=108 />
 		<img src="library/js_date/calendar.gif" onclick="showChooser(this, 'expiration', 'chooserSpan', 1950, <?php echo date('Y', time());?>, 'd M Y', false);">
 		<br/>
 
-		<label for='sessiontimeout' class='form'><?php echo $l['all']['SessionTimeout']?></label>
+		<label for='sessiontimeout' class='form'><?php echo t('all','SessionTimeout')?></label>
 		<input value='' id='sessiontimeout' name='sessiontimeout'  tabindex=109 />
 		<select onChange="javascript:setText(this.id,'sessiontimeout')" id="option0" class='form' >
 			<option value="1">calculate time</option>
@@ -434,7 +434,7 @@
 		</select>
 		<br/>
 
-		<label for='idletimeout' class='form'><?php echo $l['all']['IdleTimeout']?></label>
+		<label for='idletimeout' class='form'><?php echo t('all','IdleTimeout')?></label>
 		<input value='' id='idletimeout' name='idletimeout'  tabindex=110 />
 		<select onChange="javascript:setText(this.id,'idletimeout')" id="option1" class='form' >
 			<option value="1">calculate time</option>
@@ -448,7 +448,7 @@
 		<br/>
 
 		<label for='maxallsession' class='form'><?php 
-			echo $l['all']['MaxAllSession'] ?></label>
+			echo t('all','MaxAllSession') ?></label>
 		<input value='' id='maxallsession' name='maxallsession'  tabindex=111 />
 		<select onChange="javascript:setText(this.id,'maxallsession')" id="option2" class='form' >
 			<option value="1">calculate time</option>
@@ -469,10 +469,10 @@
         </div>
 
 
-     <div class="tabbertab" title="<?php echo $l['title']['UserInfo']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','UserInfo'); ?>">
 
         <?php
-		$customApplyButton = "<input type=\"submit\" name=\"submit\" value=\"".$l['buttons']['apply']."\"
+		$customApplyButton = "<input type=\"submit\" name=\"submit\" value=\"".t('buttons','apply')."\"
 		                        onclick = \"javascript:small_window(document.newuser.username.value,
 		                        document.newuser.password.value, document.newuser.maxallsession.value);\" tabindex=10000
 		                        class='button' />";
@@ -484,9 +484,9 @@
 
 
 
-        <div class="tabbertab" title="<?php echo $l['title']['BillingInfo']; ?>">
+        <div class="tabbertab" title="<?php echo t('title','BillingInfo'); ?>">
         <?php
-                $customApplyButton = "<input type='submit' name='submit' value=".$l['buttons']['apply']." class='button' />";
+                $customApplyButton = "<input type='submit' name='submit' value=".t('buttons','apply')." class='button' />";
                 include_once('include/management/userbillinfo.php');
         ?>
         </div>

--- a/mng-new.php
+++ b/mng-new.php
@@ -550,11 +550,11 @@
 ?>
 	<div id="contentnorightbar">
 
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngnew.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngnew.php') ?>
 		<h144>+</h144></a></h2>
 		
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngnew'] ?>
+			<?php echo t('helpPage','mngnew') ?>
 			<br/>
 		</div>
 		<?php
@@ -565,11 +565,11 @@
 
 <div class="tabber">
 
-     <div class="tabbertab" title="<?php echo $l['title']['AccountInfo']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','AccountInfo'); ?>">
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['AccountInfo']; ?> </h302>
+		<h302> <?php echo t('title','AccountInfo'); ?> </h302>
 
 		<input checked type='radio' value="userAuth" name="authType" onclick="javascript:toggleUserAuth()"/>
 		<b> Username Authentication </b>
@@ -579,7 +579,7 @@
 
 		<div id='UserContainer'>
 		<li class='fieldset'>
-		<label for='username' class='form'><?php echo $l['all']['Username']?></label>
+		<label for='username' class='form'><?php echo t('all','Username')?></label>
 		<input name='username' type='text' id='username' value='' tabindex=100 />
 		<input type='button' value='Random' class='button' onclick="javascript:randomAlphanumeric('username',8,<?php
 		echo "'".$configValues['CONFIG_USER_ALLOWEDRANDOMCHARS']."'" ?>)" />
@@ -587,12 +587,12 @@
 
 		<div id='usernameTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['usernameTooltip'] ?>
+			<?php echo t('Tooltip','usernameTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='password' class='form'><?php echo $l['all']['Password']?></label>
+		<label for='password' class='form'><?php echo t('all','Password')?></label>
 		<input name='password' type='text' id='password' value='' 
 			<?php if (isset($hiddenPassword)) echo $hiddenPassword ?> tabindex=101 />
 		<input type='button' value='Random' class='button' onclick="javascript:randomAlphanumeric('password',8,<?php
@@ -601,14 +601,14 @@
 
 		<div id='passwordTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' /> 
-			<?php echo $l['Tooltip']['passwordTooltip'] ?>
+			<?php echo t('Tooltip','passwordTooltip') ?>
 		</div>
 		</li>
 		</div>
 
 
 		<li class='fieldset'>
-		<label for='passwordType' class='form'><?php echo $l['all']['PasswordType']?> </label>
+		<label for='passwordType' class='form'><?php echo t('all','PasswordType')?> </label>
 		<select class='form' tabindex=102 name='passwordType' >
 			<option value='Cleartext-Password'>Cleartext-Password</option>
 			<option value='User-Password'>User-Password</option>
@@ -621,7 +621,7 @@
 
 
 		<li class='fieldset'>
-		<label for='group' class='form'><?php echo $l['all']['Group']?></label>
+		<label for='group' class='form'><?php echo t('all','Group')?></label>
 		<?php   
 			include_once 'include/management/populate_selectbox.php';
 			populate_groups("Select Groups","groups[]");
@@ -638,7 +638,7 @@
 
 		<div id='groupTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' /> 
-			<?php echo $l['Tooltip']['groupTooltip'] ?>
+			<?php echo t('Tooltip','groupTooltip') ?>
 		</div>
 		</li>
 
@@ -646,7 +646,7 @@
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 		</li>
 
 		</ul>
@@ -657,7 +657,7 @@
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['AccountInfo']; ?> </h302>
+		<h302> <?php echo t('title','AccountInfo'); ?> </h302>
 
 
 		<input type='radio' name="authType" value="macAuth"  onclick="javascript:toggleMacAuth()"/>
@@ -667,18 +667,18 @@
 		<ul>
 
 		<li class='fieldset'>
-		<label for='macaddress' class='form'><?php echo $l['all']['MACAddress']?></label>
+		<label for='macaddress' class='form'><?php echo t('all','MACAddress')?></label>
 		<input name='macaddress' type='text' id='macaddress' value='' tabindex=105 disabled />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('macaddressTooltip')"  />
 
 		<div id='macaddressTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['macaddressTooltip'] ?>
+			<?php echo t('Tooltip','macaddressTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='group' class='form'><?php echo $l['all']['Group']?></label>
+		<label for='group' class='form'><?php echo t('all','Group')?></label>
 		<?php   
 			include_once 'include/management/populate_selectbox.php';
 			populate_groups("Select Groups", "group_macaddress[]", "form", "disabled");
@@ -695,7 +695,7 @@
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 		</li>
 
 		</ul>
@@ -707,7 +707,7 @@
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['AccountInfo']; ?> </h302>
+		<h302> <?php echo t('title','AccountInfo'); ?> </h302>
 
 		<input type='radio' name="authType" value="pincodeAuth" onclick="javascript:togglePinCode()"/>
 		<b> PIN Code Authentication </b>
@@ -716,19 +716,19 @@
 		<ul>
 
 		<li class='fieldset'>
-		<label for='pincode' class='form'><?php echo $l['all']['PINCode']?></label>
+		<label for='pincode' class='form'><?php echo t('all','PINCode')?></label>
 		<input name='pincode' type='text' id='pincode' value='' tabindex=106 disabled />
 		<input type='button' value='Generate' class='button' onclick="javascript:randomAlphanumeric('pincode',10)" />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('pincodeTooltip')" />		
 		
 		<div id='pincodeTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['pincodeTooltip'] ?>
+			<?php echo t('Tooltip','pincodeTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='group' class='form'><?php echo $l['all']['Group']?></label>
+		<label for='group' class='form'><?php echo t('all','Group')?></label>
 		<?php   
 			include_once 'include/management/populate_selectbox.php';
 			populate_groups("Select Groups", "group_pincode[]", "form", "disabled");
@@ -745,7 +745,7 @@
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 		</li>
 
 		</ul>
@@ -756,21 +756,21 @@
 
 
 
-	<div class="tabbertab" title="<?php echo $l['title']['UserInfo']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','UserInfo'); ?>">
 	<?php
-		$customApplyButton = "<input type='submit' name='submit' value=".$l['buttons']['apply']." class='button' />";
+		$customApplyButton = "<input type='submit' name='submit' value=".t('buttons','apply')." class='button' />";
 		include_once('include/management/userinfo.php');
 	?>
 	</div>
 
-	<div class="tabbertab" title="<?php echo $l['title']['BillingInfo']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','BillingInfo'); ?>">
 	<?php
-		$customApplyButton = "<input type='submit' name='submit' value=".$l['buttons']['apply']." class='button' />";
+		$customApplyButton = "<input type='submit' name='submit' value=".t('buttons','apply')." class='button' />";
 		include_once('include/management/userbillinfo.php');
 	?>
 	</div>
 
-	<div class="tabbertab" title="<?php echo $l['title']['Attributes']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','Attributes'); ?>">
 	<?php
 		include_once('include/management/attributes.php');
 	?>

--- a/mng-rad-attributes-del.php
+++ b/mng-rad-attributes-del.php
@@ -111,11 +111,11 @@
 
 	<div id="contentnorightbar">
 
-			<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradattributesdel.php'] ?>
+			<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradattributesdel.php') ?>
 			<h144>+</h144></a></h2>
 
 			<div id="helpPage" style="display:none;visibility:visible" >
-				<?php echo $l['helpPage']['mngradattributesdel'] ?>
+				<?php echo t('helpPage','mngradattributesdel') ?>
 				<br/>
 			</div>
 			<?php
@@ -127,30 +127,30 @@
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['VendorAttribute']; ?> </h302>
+		<h302> <?php echo t('title','VendorAttribute'); ?> </h302>
 		<br/>
 
 		<ul>
 
 		<li class='fieldset'>
-		<label for='vendor' class='form'><?php echo $l['all']['VendorName'] ?></label>
+		<label for='vendor' class='form'><?php echo t('all','VendorName') ?></label>
 		<input name='vendor' type='text' id='vendor' value='<?php if (isset($vendor)) echo $vendor ?>' tabindex=100 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('vendorNameTooltip')" />
 
 		<div id='vendorNameTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['vendorNameTooltip'] ?>
+			<?php echo t('Tooltip','vendorNameTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='attribute' class='form'><?php echo $l['all']['Attribute'] ?></label>
+		<label for='attribute' class='form'><?php echo t('all','Attribute') ?></label>
 		<input name='attribute' type='text' id='attribute' value='<?php if (isset($attribute)) echo $attribute ?>' tabindex=101 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('attributeTooltip')" />
 
 		<div id='attributeTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['attributeTooltip'] ?>
+			<?php echo t('Tooltip','attributeTooltip') ?>
 		</div>
 		</li>
 
@@ -158,7 +158,7 @@
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' />
 		</li>
 
 		</ul>

--- a/mng-rad-attributes-edit.php
+++ b/mng-rad-attributes-edit.php
@@ -122,11 +122,11 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradattributesedit.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradattributesedit.php') ?>
 		:: <?php if (isset($vendor)) { echo $vendor; } ?><h144>+</h144></a></h2>
 		
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradattributesedit'] ?>
+			<?php echo t('helpPage','mngradattributesedit') ?>
 			<br/>
 		</div>
 		<?php
@@ -137,7 +137,7 @@
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['VendorAttribute']; ?> </h302>
+		<h302> <?php echo t('title','VendorAttribute'); ?> </h302>
 		<br/>
 
 		<ul>
@@ -145,31 +145,31 @@
 		<input type='hidden' name='vendor' value='<?php if (isset($vendor)) echo $vendor ?>' />
 
 		<li class='fieldset'>
-		<label for='vendor' class='form'><?php echo $l['all']['VendorName'] ?></label>
+		<label for='vendor' class='form'><?php echo t('all','VendorName') ?></label>
 		<input disabled name='vendor' type='text' id='vendor' value='<?php if (isset($vendor)) echo $vendor ?>' tabindex=100 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('vendorNameTooltip')" />
 		
 		<div id='vendorNameTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['vendorNameTooltip'] ?>
+			<?php echo t('Tooltip','vendorNameTooltip') ?>
 		</div>
 		</li>
 
 		<input type='hidden' name='attributeOld' value='<?php if (isset($attribute)) echo $attribute ?>' />
 
 		<li class='fieldset'>
-		<label for='attribute' class='form'><?php echo $l['all']['Attribute'] ?></label>
+		<label for='attribute' class='form'><?php echo t('all','Attribute') ?></label>
 		<input name='attribute' type='text' id='attribute' value='<?php if (isset($attribute)) echo $attribute ?>' tabindex=101 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('attributeTooltip')" />
 		
 		<div id='attributeTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['attributeTooltip'] ?>
+			<?php echo t('Tooltip','attributeTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='type' class='form'><?php echo $l['all']['Type'] ?></label>
+		<label for='type' class='form'><?php echo t('all','Type') ?></label>
 		<select name='type' type='text' id='type' class='form' tabindex=102 />
 		<option value='<?php echo $type; ?>'><?php echo $type; ?></option>
 		<?php
@@ -181,12 +181,12 @@
 		
 		<div id='typeTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['typeTooltip'] ?>
+			<?php echo t('Tooltip','typeTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='RecommendedOP' class='form'><?php echo $l['all']['RecommendedOP'] ?></label>
+		<label for='RecommendedOP' class='form'><?php echo t('all','RecommendedOP') ?></label>
 		<select name='RecommendedOP' type='text' id='RecommendedOP' class='form' tabindex=103 />
 		<option value='<?php echo $RecommendedOP; ?>'><?php echo $RecommendedOP; ?></option>
 		<?php
@@ -198,12 +198,12 @@
 		
 		<div id='RecommendedOPTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['RecommendedOPTooltip'] ?>
+			<?php echo t('Tooltip','RecommendedOPTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='RecommendedTable' class='form'><?php echo $l['all']['RecommendedTable'] ?></label>
+		<label for='RecommendedTable' class='form'><?php echo t('all','RecommendedTable') ?></label>
 		<select name='RecommendedTable' type='text' id='RecommendedTable' class='form' tabindex=104 />
 		<option value='<?php echo $RecommendedTable; ?>'><?php echo $RecommendedTable; ?></option>
 		<?php
@@ -215,24 +215,24 @@
 		
 		<div id='RecommendedTableTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['RecommendedTableTooltip'] ?>
+			<?php echo t('Tooltip','RecommendedTableTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='RecommendedTooltip' class='form'><?php echo $l['all']['RecommendedTooltip'] ?></label>
+		<label for='RecommendedTooltip' class='form'><?php echo t('all','RecommendedTooltip') ?></label>
 		<textarea class='form' name='RecommendedTooltip' type='text' id='RecommendedTooltip' tabindex=105 /><?php if (isset($RecommendedTooltip)) echo $RecommendedTooltip ?></textarea>
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('RecommendedTooltipTooltip')" />
 		
 		<div id='RecommendedTooltipTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['RecommendedTooltipTooltip'] ?>
+			<?php echo t('Tooltip','RecommendedTooltipTooltip') ?>
 		</div>
 		</li>
 
 
 		<li class='fieldset'>
-		<label for='RecommendedHelper' class='form'><?php echo $l['all']['RecommendedHelper'] ?></label>
+		<label for='RecommendedHelper' class='form'><?php echo t('all','RecommendedHelper') ?></label>
 		<select name='RecommendedHelper' type='text' id='RecommendedHelper' class='form' tabindex=104 />
 		<option value='<?php echo $RecommendedHelper; ?>'><?php echo $RecommendedHelper; ?></option>
 		<?php
@@ -244,14 +244,14 @@
 		
 		<div id='RecommendedHelperTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['RecommendedHelperTooltip'] ?>
+			<?php echo t('Tooltip','RecommendedHelperTooltip') ?>
 		</div>
 		</li>
 	
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' />
 		</li>
 
 		</ul>

--- a/mng-rad-attributes-import.php
+++ b/mng-rad-attributes-import.php
@@ -161,11 +161,11 @@
 
 	<div id="contentnorightbar">
 
-			<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradattributesimport.php'] ?>
+			<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradattributesimport.php') ?>
 			<h144>+</h144></a></h2>
 
 			<div id="helpPage" style="display:none;visibility:visible" >
-				<?php echo $l['helpPage']['mngradattributesimport'] ?>
+				<?php echo t('helpPage','mngradattributesimport') ?>
 				<br/>
 			</div>
 			<?php
@@ -176,24 +176,24 @@
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['VendorAttribute']; ?> </h302>
+		<h302> <?php echo t('title','VendorAttribute'); ?> </h302>
 		<br/>
 
 		<ul>
 
 		<li class='fieldset'>
-		<label for='vendor' class='form'><?php echo $l['all']['VendorName'] ?></label>
+		<label for='vendor' class='form'><?php echo t('all','VendorName') ?></label>
 		<input name='vendor' type='text' id='vendor' value='<?php if (isset($vendor)) echo $vendor ?>' tabindex=100 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('vendorNameTooltip')" />
 
 		<div id='vendorNameTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['vendorNameTooltip'] ?>
+			<?php echo t('Tooltip','vendorNameTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='dictionary' class='form'><?php echo $l['all']['Dictionary'] ?></label>
+		<label for='dictionary' class='form'><?php echo t('all','Dictionary') ?></label>
 		<textarea class='form_fileimport' name='dictionary' tabindex=102></textarea>
 		</li>
 
@@ -201,7 +201,7 @@
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' />
 		</li>
 
 		</ul>

--- a/mng-rad-attributes-list.php
+++ b/mng-rad-attributes-list.php
@@ -61,11 +61,11 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradattributeslist.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradattributeslist.php') ?>
 				<h144>+</h144></a></h2>
 				
 				<div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['mngradattributeslist'] ?>
+					<?php echo t('helpPage','mngradattributeslist') ?>
 					<br/>
 				</div>
 				<br/>
@@ -132,17 +132,17 @@
 	echo "<thread> <tr>
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=id&orderType=$orderTypeNextPage&vendor=$vendor\">
-		".$l['all']['VendorID']."</a>
+		".t('all','VendorID')."</a>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=vendor&orderType=$orderTypeNextPage&vendor=$vendor\">
-		".$l['all']['VendorName']."</a>
+		".t('all','VendorName')."</a>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=attribute&orderType=$orderTypeNextPage&vendor=$vendor\">
-		".$l['all']['VendorAttribute']."</a>
+		".t('all','VendorAttribute')."</a>
 		</th>
 
 		</tr> </thread>";
@@ -158,7 +158,7 @@
                                         javascript:__displayTooltip();'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-rad-attributes-edit.php?vendor=$row[1]&attribute=$row[2]\">
-                                                {$l['Tooltip']['AttributeEdit']}</a>
+                                                {t('Tooltip','AttributeEdit')}</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerAttributeInfo\">

--- a/mng-rad-attributes-new.php
+++ b/mng-rad-attributes-new.php
@@ -94,11 +94,11 @@
 
 	<div id="contentnorightbar">
 
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradattributesnew.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradattributesnew.php') ?>
 		<h144>+</h144></a></h2>
 		
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradattributesnew'] ?>
+			<?php echo t('helpPage','mngradattributesnew') ?>
 			<br/>
 		</div>
 		<?php
@@ -109,35 +109,35 @@
 	
 	<fieldset>
 
-		<h302> <?php echo $l['title']['VendorAttribute']; ?> </h302>
+		<h302> <?php echo t('title','VendorAttribute'); ?> </h302>
 		<br/>
 
 		<ul>
 
 		<li class='fieldset'>
-		<label for='vendor' class='form'><?php echo $l['all']['VendorName'] ?></label>
+		<label for='vendor' class='form'><?php echo t('all','VendorName') ?></label>
 		<input name='vendor' type='text' id='vendor' value='' tabindex=100 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('vendorNameTooltip')" />
 		
 		<div id='vendorNameTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['vendorNameTooltip'] ?>
+			<?php echo t('Tooltip','vendorNameTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='attribute' class='form'><?php echo $l['all']['Attribute'] ?></label>
+		<label for='attribute' class='form'><?php echo t('all','Attribute') ?></label>
 		<input name='attribute' type='text' id='attribute' value='' tabindex=101 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('attributeTooltip')" />
 
 		<div id='attributeTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['attributeTooltip'] ?>
+			<?php echo t('Tooltip','attributeTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='type' class='form'><?php echo $l['all']['Type'] ?></label>
+		<label for='type' class='form'><?php echo t('all','Type') ?></label>
 		<select name='type' type='text' id='type' class='form' tabindex=102 />
 			<option value=''>Select Type...</option>
 		<?php
@@ -149,12 +149,12 @@
 		
 		<div id='typeTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['typeTooltip'] ?>
+			<?php echo t('Tooltip','typeTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='RecommendedOP' class='form'><?php echo $l['all']['RecommendedOP'] ?></label>
+		<label for='RecommendedOP' class='form'><?php echo t('all','RecommendedOP') ?></label>
 		<select name='RecommendedOP' id='RecommendedOP' class='form' tabindex=103 />
 			<option value=''>Select OP...</option>
 		<?php
@@ -166,12 +166,12 @@
 		
 		<div id='RecommendedOPTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['RecommendedOPTooltip'] ?>
+			<?php echo t('Tooltip','RecommendedOPTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='RecommendedTable' class='form'><?php echo $l['all']['RecommendedTable'] ?></label>
+		<label for='RecommendedTable' class='form'><?php echo t('all','RecommendedTable') ?></label>
                 <select name='RecommendedTable' id='RecommendedTable' class='form' tabindex=104 />
 		<option value=''>Select Table...</option>
 		<?php
@@ -183,17 +183,17 @@
 		
 		<div id='RecommendedTableTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['RecommendedTableTooltip'] ?>
+			<?php echo t('Tooltip','RecommendedTableTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='RecommendedTooltip' class='form'><?php echo $l['all']['RecommendedTooltip'] ?></label>
+		<label for='RecommendedTooltip' class='form'><?php echo t('all','RecommendedTooltip') ?></label>
 		<textarea class='form' name='RecommendedTooltip' type='text' id='RecommendedTooltip' tabindex=105 /></textarea>
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('RecommendedTooltipTooltip')" />
 		<div id='RecommendedTooltipTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['RecommendedTooltipTooltip'] ?>
+			<?php echo t('Tooltip','RecommendedTooltipTooltip') ?>
 		</div>
 		</li>
 
@@ -201,7 +201,7 @@
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' />
 		</li>
 
 		</ul>

--- a/mng-rad-attributes-search.php
+++ b/mng-rad-attributes-search.php
@@ -59,11 +59,11 @@
 
 	<div id="contentnorightbar">
 	
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradattributessearch.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradattributessearch.php') ?>
 		:: <?php if (isset($attribute)) { echo $attribute; } ?><h144>+</h144></a></h2>
 		
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradattributessearch'] ?>
+			<?php echo t('helpPage','mngradattributessearch') ?>
 			<br/>
 		</div>
 		<br/>
@@ -126,17 +126,17 @@
 	echo "<thread> <tr>
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=id&orderType=$orderTypeNextPage&attribute=$attribute\">
-		".$l['all']['VendorID']."</a>
+		".t('all','VendorID')."</a>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=vendor&orderType=$orderTypeNextPage&attribute=$attribute\">
-		".$l['all']['VendorName']."</a>
+		".t('all','VendorName')."</a>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=attribute&orderType=$orderTypeNextPage&attribute=$attribute\">
-		".$l['all']['VendorAttribute']."</a>
+		".t('all','VendorAttribute')."</a>
 		</th>
 
 		</tr> </thread>";
@@ -149,7 +149,7 @@
                                         javascript:__displayTooltip();'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-rad-attributes-edit.php?vendor=$row[1]&attribute=$row[2]\">
-                                                {$l['Tooltip']['AttributeEdit']}</a>
+                                                {t('Tooltip','AttributeEdit')}</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerAttributeInfo\">

--- a/mng-rad-attributes.php
+++ b/mng-rad-attributes.php
@@ -41,11 +41,11 @@
 ?>
 	<div id="contentnorightbar">
 
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradattributes.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradattributes.php') ?>
 		<h144>+</h144></a></h2>
 		
 		<div id="helpPage" style="display:none;visibility:visible" >				
-			<?php echo $l['helpPage']['mngradattributes'] ?>
+			<?php echo t('helpPage','mngradattributes') ?>
 			<br/>
 		</div>
 		<br/>

--- a/mng-rad-groupcheck-del.php
+++ b/mng-rad-groupcheck-del.php
@@ -127,11 +127,11 @@ WHERE GroupName='".$dbSocket->escapeSimple($groupname)."'AND Value='$value' AND 
 
 	<div id="contentnorightbar">
 
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradgroupcheckdel.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradgroupcheckdel.php') ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradgroupcheckdel'] ?>
+			<?php echo t('helpPage','mngradgroupcheckdel') ?>
 			<br/>
 		</div>
 		<?php
@@ -143,25 +143,25 @@ WHERE GroupName='".$dbSocket->escapeSimple($groupname)."'AND Value='$value' AND 
 
         <fieldset>
 
-			<h302> <?php echo $l['title']['GroupInfo'] ?> </h302>
+			<h302> <?php echo t('title','GroupInfo') ?> </h302>
 			<br/>
 
-			<label for='groupname' class='form'><?php echo $l['all']['Groupname'] ?></label>
+			<label for='groupname' class='form'><?php echo t('all','Groupname') ?></label>
 			<input name='groupname' type='text' id='groupname' value='<?php echo $groupname ?>' tabindex=100 />
 			<br/>
 
-			<label for='value' class='form'><?php echo $l['all']['Value'] ?></label>
+			<label for='value' class='form'><?php echo t('all','Value') ?></label>
 			<input name='value' type='text' id='value' value='<?php echo $value ?>' tabindex=101 />
 			<br/>
 
-			<label for='attribute' class='form'><?php echo $l['all']['Attribute'] ?></label>
+			<label for='attribute' class='form'><?php echo t('all','Attribute') ?></label>
 			<input name='attribute' type='text' id='attribute' value='<?php echo $attribute ?>' tabindex=102 />
 			<br/>
 
 			<br/><br/>
 			<hr><br/>
 
-			<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+			<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 
         </fieldset>
 

--- a/mng-rad-groupcheck-edit.php
+++ b/mng-rad-groupcheck-edit.php
@@ -134,11 +134,11 @@
 
 	<div id="contentnorightbar">
 	
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradgroupcheckedit.php'] ?> 
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradgroupcheckedit.php') ?> 
 		<?php echo $groupname ?><h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradgroupcheckedit'] ?>
+			<?php echo t('helpPage','mngradgroupcheckedit') ?>
 			<br/>
 		</div>
 		<?php
@@ -152,14 +152,14 @@
 			
         <fieldset>
 
-			<h302> <?php echo $l['title']['GroupInfo'] ?> </h302>
+			<h302> <?php echo t('title','GroupInfo') ?> </h302>
 			<br/>
 
-			<label for='attribute' class='form'><?php echo $l['all']['Attribute'] ?></label>
+			<label for='attribute' class='form'><?php echo t('all','Attribute') ?></label>
 			<input name='attribute' type='text' id='attribute' value='<?php echo $attribute ?>' tabindex=100 />
 			<br/>
 
-			<label for='op' class='form'><?php echo $l['all']['Operator'] ?></label>
+			<label for='op' class='form'><?php echo t('all','Operator') ?></label>
 			<select name='op' id='op' class='form' tabindex=101 />
 					<option value='<?php echo $op ?>'><?php echo $op ?></option>
 					<?php
@@ -170,14 +170,14 @@
 			<br/>
 
 
-			<label for='newvalue' class='form'><?php echo $l['all']['NewValue'] ?></label>
+			<label for='newvalue' class='form'><?php echo t('all','NewValue') ?></label>
 			<input name='value' type='text' id='value' value='<?php echo $value ?>' tabindex=102 />
 			<br/>
 
 			<br/><br/>
 			<hr><br/>
 
-			<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+			<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 
         </fieldset>
 

--- a/mng-rad-groupcheck-list.php
+++ b/mng-rad-groupcheck-list.php
@@ -56,11 +56,11 @@
 
 	<div id="contentnorightbar">
 
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradgroupchecklist.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradgroupchecklist.php') ?>
 		<h144>+</h144></a></h2>
 		
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradgroupchecklist'] ?>
+			<?php echo t('helpPage','mngradgroupchecklist') ?>
 			<br/>
 		</div>
 		<br/>
@@ -117,22 +117,22 @@
 	echo "<thread> <tr>
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=groupname&orderType=$orderTypeNextPage\">
-		".$l['all']['Groupname']."</a>
+		".t('all','Groupname')."</a>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=attribute&orderType=$orderTypeNextPage\">
-		".$l['all']['Attribute']."</a>
+		".t('all','Attribute')."</a>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=op&orderType=$orderTypeNextPage\">
-		".$l['all']['Operator']."</a>
+		".t('all','Operator')."</a>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=value&orderType=$orderTypeNextPage\">
-		".$l['all']['Value']."</a>
+		".t('all','Value')."</a>
 		</th>
 
 	</tr> </thread>";
@@ -142,7 +142,7 @@
 				<a class='tablenovisit' href='javascript:return;'
                                 onclick=\"javascript:__displayTooltip();\"
                                 tooltipText=\"
-                                        <a class='toolTip' href='mng-rad-groupcheck-edit.php?groupname=$row[0]&value=$row[3]&attribute=$row[1]'>".$l['Tooltip']['EditGroup']."</a>
+                                        <a class='toolTip' href='mng-rad-groupcheck-edit.php?groupname=$row[0]&value=$row[3]&attribute=$row[1]'>".t('Tooltip','EditGroup')."</a>
                                         <br/>\"
 				>$row[0]</td>
 			<td> $row[1] </td>

--- a/mng-rad-groupcheck-new.php
+++ b/mng-rad-groupcheck-new.php
@@ -150,11 +150,11 @@
 
 	<div id="contentnorightbar">
 
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradgroupchecknew.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradgroupchecknew.php') ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradgroupchecknew'] ?>
+			<?php echo t('helpPage','mngradgroupchecknew') ?>
 			<br/>
 		</div>
 		<?php
@@ -165,17 +165,17 @@
 
         <fieldset>
 
-			<h302> <?php echo $l['title']['GroupInfo'] ?> </h302>
+			<h302> <?php echo t('title','GroupInfo') ?> </h302>
 			<br/>
 
-			<label for='groupname' class='form'><?php echo $l['all']['Groupname'] ?></label>
+			<label for='groupname' class='form'><?php echo t('all','Groupname') ?></label>
 			<input name='groupname' type='text' id='groupname' value='<?php echo $groupname ?>' tabindex=100 />
 			<br />
 
 			<br/><br/>
 			<hr><br/>
 
-			<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+			<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 
         </fieldset>
 

--- a/mng-rad-groupcheck-search.php
+++ b/mng-rad-groupcheck-search.php
@@ -61,11 +61,11 @@
 
 	<div id="contentnorightbar">
 
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradgroupchecksearch.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradgroupchecksearch.php') ?>
 		<h144>+</h144></a></h2>
 		
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradgroupchecksearch'] ?>
+			<?php echo t('helpPage','mngradgroupchecksearch') ?>
 			<br/>
 		</div>
 		<br/>
@@ -125,22 +125,22 @@
 	echo "<thread> <tr>
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=groupname&orderType=$orderTypeNextPage\">
-		".$l['all']['Groupname']."</a>
+		".t('all','Groupname')."</a>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=attribute&orderType=$orderTypeNextPage\">
-		".$l['all']['Attribute']."</a>
+		".t('all','Attribute')."</a>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=op&orderType=$orderTypeNextPage\">
-		".$l['all']['Operator']."</a>
+		".t('all','Operator')."</a>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=value&orderType=$orderTypeNextPage\">
-		".$l['all']['Value']."</a>
+		".t('all','Value')."</a>
 		</th>
 
 	</tr> </thread>";

--- a/mng-rad-groupreply-del.php
+++ b/mng-rad-groupreply-del.php
@@ -123,11 +123,11 @@
 
 	<div id="contentnorightbar">
 
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradgroupreplydel.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradgroupreplydel.php') ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradgroupreplydel'] ?>
+			<?php echo t('helpPage','mngradgroupreplydel') ?>
 			<br/>
 		</div>
 		<?php
@@ -140,25 +140,25 @@
 
         <fieldset>
 
-			<h302> <?php echo $l['title']['GroupInfo'] ?> </h302>
+			<h302> <?php echo t('title','GroupInfo') ?> </h302>
 			<br/>
 
-			<label for='groupname' class='form'><?php echo $l['all']['Groupname'] ?></label>
+			<label for='groupname' class='form'><?php echo t('all','Groupname') ?></label>
 			<input name='groupname' type='text' id='groupname' value='<?php echo $groupname ?>' tabindex=100 />
 			<br/>
 
-			<label for='value' class='form'><?php echo $l['all']['Value'] ?></label>
+			<label for='value' class='form'><?php echo t('all','Value') ?></label>
 			<input name='value' type='text' id='value' value='<?php echo $value ?>' tabindex=101 />
 			<br/>
 
-			<label for='attribute' class='form'><?php echo $l['all']['Attribute'] ?></label>
+			<label for='attribute' class='form'><?php echo t('all','Attribute') ?></label>
 			<input name='attribute' type='text' id='attribute' value='<?php echo $attribute ?>' tabindex=102 />
 			<br/>
 
 			<br/><br/>
 			<hr><br/>
 
-			<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+			<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 
         </fieldset>
 

--- a/mng-rad-groupreply-edit.php
+++ b/mng-rad-groupreply-edit.php
@@ -133,11 +133,11 @@
 
 	<div id="contentnorightbar">
 	
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradgroupreplyedit.php'] ?> 
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradgroupreplyedit.php') ?> 
 		<?php echo $groupname ?><h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradgroupreplyedit'] ?>
+			<?php echo t('helpPage','mngradgroupreplyedit') ?>
 			<br/>
 		</div>
 		<?php
@@ -151,14 +151,14 @@
 			
         <fieldset>
 
-			<h302> <?php echo $l['title']['GroupInfo'] ?> </h302>
+			<h302> <?php echo t('title','GroupInfo') ?> </h302>
 			<br/>
 
-			<label for='attribute' class='form'><?php echo $l['all']['Attribute'] ?></label>
+			<label for='attribute' class='form'><?php echo t('all','Attribute') ?></label>
 			<input name='attribute' type='text' id='attribute' value='<?php echo $attribute ?>' tabindex=100 />
 			<br/>
 
-			<label for='op' class='form'><?php echo $l['all']['Operator'] ?></label>
+			<label for='op' class='form'><?php echo t('all','Operator') ?></label>
 			<select name='op' id='op' class='form' tabindex=101 />
 				<option value='<?php echo $op ?>'><?php echo $op ?></option>
 					<?php
@@ -169,14 +169,14 @@
 			<br/>
 
 
-			<label for='newvalue' class='form'><?php echo $l['all']['NewValue'] ?></label>
+			<label for='newvalue' class='form'><?php echo t('all','NewValue') ?></label>
 			<input name='value' type='text' id='value' value='<?php echo $value ?>' tabindex=102 />
 			<br/>
 
 			<br/><br/>
 			<hr><br/>
 
-			<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+			<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 
         </fieldset>
 

--- a/mng-rad-groupreply-list.php
+++ b/mng-rad-groupreply-list.php
@@ -58,11 +58,11 @@
 
 	<div id="contentnorightbar">
 	
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradgroupreplylist.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradgroupreplylist.php') ?>
 		<h144>+</h144></a></h2>
 		
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradgroupreplylist'] ?>
+			<?php echo t('helpPage','mngradgroupreplylist') ?>
 			<br/>
 		</div>
 		<br/>
@@ -120,22 +120,22 @@
 	echo "<thread> <tr>
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=groupname&orderType=$orderTypeNextPage\">
-		".$l['all']['Groupname']."</a>
+		".t('all','Groupname')."</a>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=attribute&orderType=$orderTypeNextPage\">
-		".$l['all']['Attribute']."</a>
+		".t('all','Attribute')."</a>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=op&orderType=$orderTypeNextPage\">
-		".$l['all']['Operator']."</a>
+		".t('all','Operator')."</a>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=value&orderType=$orderTypeNextPage\">
-		".$l['all']['Value']."</a>
+		".t('all','Value')."</a>
 		</th>
 
 	</tr> </thread>";
@@ -145,7 +145,7 @@
 				<a class='tablenovisit' href='javascript:return;'
                                 onclick=\"javascript:__displayTooltip();\"
                                 tooltipText=\"
-                                        <a class='toolTip' href='mng-rad-groupreply-edit.php?groupname=$row[0]&value=$row[3]&attribute=$row[1]'>".$l['Tooltip']['EditGroup']."</a>
+                                        <a class='toolTip' href='mng-rad-groupreply-edit.php?groupname=$row[0]&value=$row[3]&attribute=$row[1]'>".t('Tooltip','EditGroup')."</a>
                                         <br/>\"
 				>$row[0]</a></td>
 			<td> $row[1] </td>

--- a/mng-rad-groupreply-new.php
+++ b/mng-rad-groupreply-new.php
@@ -149,11 +149,11 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradgroupreplynew.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradgroupreplynew.php') ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradgroupreplynew'] ?>
+			<?php echo t('helpPage','mngradgroupreplynew') ?>
 			<br/>
 		</div>
 		<?php
@@ -165,17 +165,17 @@
 
         <fieldset>
 
-			<h302> <?php echo $l['title']['GroupInfo'] ?> </h302>
+			<h302> <?php echo t('title','GroupInfo') ?> </h302>
 			<br/>
 
-			<label for='groupname' class='form'><?php echo $l['all']['Groupname'] ?></label>
+			<label for='groupname' class='form'><?php echo t('all','Groupname') ?></label>
 			<input name='groupname' type='text' id='groupname' value='<?php echo $groupname ?>' tabindex=100 />
 			<br />
 
 			<br/><br/>
 			<hr><br/>
 
-			<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+			<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 
         </fieldset>
 

--- a/mng-rad-groupreply-search.php
+++ b/mng-rad-groupreply-search.php
@@ -61,11 +61,11 @@
 
 	<div id="contentnorightbar">
 	
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradgroupreplysearch.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradgroupreplysearch.php') ?>
 		<h144>+</h144></a></h2>
 		
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradgroupreplysearch'] ?>
+			<?php echo t('helpPage','mngradgroupreplysearch') ?>
 			<br/>
 		</div>
 		<br/>
@@ -124,24 +124,24 @@
 	}
 
 	echo "<thread> <tr>
-		<th scope='col'>".$l['all']['Groupname']."
+		<th scope='col'>".t('all','Groupname')."
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=groupname&orderType=$orderTypeNextPage\">
-		".$l['all']['Groupname']."</a>
+		".t('all','Groupname')."</a>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=attribute&orderType=$orderTypeNextPage\">
-		".$l['all']['Attribute']."</a>
+		".t('all','Attribute')."</a>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=op&orderType=$orderTypeNextPage\">
-		".$l['all']['Operator']."</a>
+		".t('all','Operator')."</a>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=value&orderType=$orderTypeNextPage\">
-		".$l['all']['Value']."</a>
+		".t('all','Value')."</a>
 		</th>
 
 	</tr> </thread>";

--- a/mng-rad-groups.php
+++ b/mng-rad-groups.php
@@ -44,11 +44,11 @@
 
 	<div id="contentnorightbar">
 	
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradgroups.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradgroups.php') ?>
 		<h144>+</h144></a></h2>
 		
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradgroups'] ?>
+			<?php echo t('helpPage','mngradgroups') ?>
 			<br/>
 		</div>
 		<br/>

--- a/mng-rad-hunt-del.php
+++ b/mng-rad-hunt-del.php
@@ -124,11 +124,11 @@
 
 	<div id="contentnorightbar">
 
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradhuntdel.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradhuntdel.php') ?>
 		:: <?php if (isset($nasipaddress)) { echo $nasipaddress; } ?><h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradhuntdel'] ?>
+			<?php echo t('helpPage','mngradhuntdel') ?>
 			<br/>
 		</div>
 		<?php
@@ -140,21 +140,21 @@
 
         <fieldset>
 
-			<h302> <?php echo $l['title']['HGInfo'] ?> </h302>
+			<h302> <?php echo t('title','HGInfo') ?> </h302>
 			<br/>
 
-			<label for='nasipaddress' class='form'><?php echo $l['all']['HgIPHost'] ?></label>
+			<label for='nasipaddress' class='form'><?php echo t('all','HgIPHost') ?></label>
 			<input name='nasipaddress' type='text' id='nasipaddress' value='' tabindex=100 />
 			<br />
 
-                        <label for='nasportid' class='form'><?php echo $l['all']['HgPortId'] ?></label>
+                        <label for='nasportid' class='form'><?php echo t('all','HgPortId') ?></label>
                         <input name='nasportid' type='text' id='nasportid' value='<?php echo $nasportid ?>' tabindex=101 />
                         <br/>
 
 			<br/><br/>
 			<hr><br/>
 
-			<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+			<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 
         </fieldset>
 

--- a/mng-rad-hunt-edit.php
+++ b/mng-rad-hunt-edit.php
@@ -148,11 +148,11 @@
 
 	<div id="contentnorightbar">
 
-			<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradhuntedit.php'] ?>
+			<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradhuntedit.php') ?>
 			:: <?php if (isset($nasipaddress)) { echo $nasipaddress; } ?><h144>+</h144></a></h2>
 
 			<div id="helpPage" style="display:none;visibility:visible" >
-				<?php echo $l['helpPage']['mngradhuntedit'] ?>
+				<?php echo t('helpPage','mngradhuntedit') ?>
 				<br/>
 			</div>
 			<?php
@@ -163,26 +163,26 @@
 			
 <div class="tabber">
 
-     <div class="tabbertab" title="<?php echo $l['title']['HGInfo']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','HGInfo'); ?>">
 		<input type="hidden" value="<?php echo $nasipaddress ?>" name="nasipaddressold" />
 		<input type="hidden" value="<?php echo $nasportid ?>" name="nasportidold" />
 
 
         <fieldset>
 
-                <h302> <?php echo $l['title']['HGInfo'] ?> </h302>
+                <h302> <?php echo t('title','HGInfo') ?> </h302>
                 <br/>
 
-                <label for='nasipaddress' class='form'><?php echo $l['all']['HgIPHost'] ?></label>
+                <label for='nasipaddress' class='form'><?php echo t('all','HgIPHost') ?></label>
                 <input name='nasipaddress' type='text' id='nasipaddress' value='<?php echo $nasipaddress ?>' tabindex=100 />
                 <br />
 
-                <label for='groupname' class='form'><?php echo $l['all']['HgGroupName'] ?></label>
+                <label for='groupname' class='form'><?php echo t('all','HgGroupName') ?></label>
                 <input name='groupname' type='text' id='groupname' value='<?php echo $groupname ?>' tabindex=101 />
                 <br />
 
 
-                <label for='nasportid' class='form'><?php echo $l['all']['HgPortId'] ?></label>
+                <label for='nasportid' class='form'><?php echo t('all','HgPortId') ?></label>
                 <input name='nasportid' type='text' id='nasportid' value='<?php echo $nasportid ?>' tabindex=104 />
                 <br />
 
@@ -191,7 +191,7 @@
                 <br/><br/>
                 <hr><br/>
 
-                <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+                <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 
         </fieldset>
 

--- a/mng-rad-hunt-list.php
+++ b/mng-rad-hunt-list.php
@@ -56,11 +56,11 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradhuntlist.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradhuntlist.php') ?>
 				<h144>+</h144></a></h2>
 				
 				<div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['mngradhuntlist'] ?>
+					<?php echo t('helpPage','mngradhuntlist') ?>
 					<br/>
 				</div>
 				<br/>
@@ -125,25 +125,25 @@
 	echo "<thread> <tr>
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=id&orderType=$orderType\">
-		".$l['all']['HgID']."</a>
+		".t('all','HgID')."</a>
 		<br/>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=nasipaddress&orderType=$orderType\">
-		".$l['all']['HgIPHost']."</a>
+		".t('all','HgIPHost')."</a>
 		<br/>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=groupname&orderType=$orderType\">
-		".$l['all']['HgGroupName']."</a>
+		".t('all','HgGroupName')."</a>
 		<br/>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=nasportid&orderType=$orderType\">
-		".$l['all']['HgPortId']."</a>
+		".t('all','HgPortId')."</a>
 		<br/>
 		</th>
 
@@ -154,8 +154,8 @@
                                 <td> <a class='tablenovisit' href='javascript:return;'
                                 onclick=\"javascript:__displayTooltip();\"
                                 tooltipText=\"
-                                        <a class='toolTip' href='mng-rad-hunt-edit.php?nasipaddress=$row[2]&nasportid=$row[3]'>".$l['Tooltip']['EditHG']."</a>
-                                        <a class='toolTip' href='mng-rad-hunt-del.php?nasipaddress=$row[2]&nasportid=$row[3]'>".$l['Tooltip']['RemoveHG']."</a>
+                                        <a class='toolTip' href='mng-rad-hunt-edit.php?nasipaddress=$row[2]&nasportid=$row[3]'>".t('Tooltip','EditHG')."</a>
+                                        <a class='toolTip' href='mng-rad-hunt-del.php?nasipaddress=$row[2]&nasportid=$row[3]'>".t('Tooltip','RemoveHG')."</a>
                                         <br/>\"
                                         >$row[2]</a></td>
 				<td> $row[1] </td>

--- a/mng-rad-hunt-new.php
+++ b/mng-rad-hunt-new.php
@@ -107,11 +107,11 @@
 
 	<div id="contentnorightbar">
 	
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradhuntnew.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradhuntnew.php') ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >				
-			<?php echo $l['helpPage']['mngradhuntnew'] ?>
+			<?php echo t('helpPage','mngradhuntnew') ?>
 			<br/>
 		</div>
 		<?php
@@ -122,28 +122,28 @@
                 <form name="newhg" action="<?php echo $_SERVER['PHP_SELF']; ?>" method="post">
 <div class="tabber">
 
-     <div class="tabbertab" title="<?php echo $l['title']['HGInfo']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','HGInfo'); ?>">
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['HGInfo'] ?> </h302>
+		<h302> <?php echo t('title','HGInfo') ?> </h302>
 		<br/>
 
-                <label for='nasipaddress' class='form'><?php echo $l['all']['HgIPHost'] ?></label>
+                <label for='nasipaddress' class='form'><?php echo t('all','HgIPHost') ?></label>
                 <input name='nasipaddress' type='text' id='nasipaddress' value='' tabindex=100 />
                 <br />
 
 
-                <label for='groupname' class='form'><?php echo $l['all']['HgGroupName'] ?></label>
+                <label for='groupname' class='form'><?php echo t('all','HgGroupName') ?></label>
                 <input name='groupname' type='text' id='groupname' value='' tabindex=101 />
                 <br />
 
-                <label for='nasportid' class='form'><?php echo $l['all']['HgPortId'] ?></label>
+                <label for='nasportid' class='form'><?php echo t('all','HgPortId') ?></label>
                 <input name='nasportid' type='text' id='nasportid' value='0' tabindex=105 />
                 <br/><br/>
                 <hr><br/>
 
-                <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+                <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 
         </fieldset>
 

--- a/mng-rad-hunt.php
+++ b/mng-rad-hunt.php
@@ -41,11 +41,11 @@
 ?>
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradhunt.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradhunt.php') ?>
 				<h144>+</h144></a></h2>
 				
 				<div id="helpPage" style="display:none;visibility:visible" >				
-					<?php echo $l['helpPage']['mngradhunt'] ?>
+					<?php echo t('helpPage','mngradhunt') ?>
 					<br/>
 				</div>
 				<br/>

--- a/mng-rad-ippool-del.php
+++ b/mng-rad-ippool-del.php
@@ -106,11 +106,11 @@
 
 	<div id="contentnorightbar">
 
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradippooldel.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradippooldel.php') ?>
 		:: <?php if (isset($poolname)) { echo $poolname; } ?><h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradippooldel'] ?>
+			<?php echo t('helpPage','mngradippooldel') ?>
 			<br/>
 		</div>
 <?php
@@ -122,21 +122,21 @@
 
         <fieldset>
 
-			<h302> <?php echo $l['title']['IPPoolInfo'] ?> </h302>
+			<h302> <?php echo t('title','IPPoolInfo') ?> </h302>
 			<br/>
 
-			<label for='poolname' class='form'><?php echo $l['all']['PoolName'] ?></label>
+			<label for='poolname' class='form'><?php echo t('all','PoolName') ?></label>
 			<input name='poolname' type='text' id='poolname' value='<?php echo $poolname ?>' tabindex=100 />
 			<br />
 
-			<label for='ipaddress' class='form'><?php echo $l['all']['IPAddress'] ?></label>
+			<label for='ipaddress' class='form'><?php echo t('all','IPAddress') ?></label>
 			<input name='ipaddress' type='text' id='ipaddress' value='<?php echo $ipaddress ?>' tabindex=101 />
 			<br />
 
 			<br/><br/>
 			<hr><br/>
 
-			<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+			<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 
         </fieldset>
 

--- a/mng-rad-ippool-edit.php
+++ b/mng-rad-ippool-edit.php
@@ -104,11 +104,11 @@
 
 	<div id="contentnorightbar">
 	
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradippoolnew.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradippoolnew.php') ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >				
-			<?php echo $l['helpPage']['mngradippoolnew'] ?>
+			<?php echo t('helpPage','mngradippoolnew') ?>
 			<br/>
 		</div>
 <?php
@@ -117,29 +117,29 @@
 
 		<form name="newippool" action="<?php echo $_SERVER['PHP_SELF']; ?>" method="post">
 <div class="tabber">
-	<div class="tabbertab" title="<?php echo $l['title']['IPPoolInfo']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','IPPoolInfo'); ?>">
 	<fieldset>
 
-		<h302> <?php echo $l['title']['IPPoolInfo'] ?> </h302>
+		<h302> <?php echo t('title','IPPoolInfo') ?> </h302>
 		<br/>
 
-			<label for='poolname' class='form'><?php echo $l['all']['PoolName'] ?></label>
+			<label for='poolname' class='form'><?php echo t('all','PoolName') ?></label>
 			<input name='poolname' type='hidden' id='poolname' value='<?php echo $poolname ?>' tabindex=100 />
 			<input disabled name='poolname' type='text' id='poolname' value='<?php echo $poolname ?>' tabindex=100 />
 			<br />
 
-			<label for='ipaddressold' class='form'><?php echo $l['all']['IPAddress'] ?></label>
+			<label for='ipaddressold' class='form'><?php echo t('all','IPAddress') ?></label>
 			<input name='ipaddressold' type='text' id='ipaddressold' value='<?php echo $ipaddressold ?>' tabindex=101 />
 			<br />
 
-			<label for='ipaddress' class='form'>New <?php echo $l['all']['IPAddress'] ?></label>
+			<label for='ipaddress' class='form'>New <?php echo t('all','IPAddress') ?></label>
 			<input name='ipaddress' type='text' id='ipaddress' value='<?php echo $ipaddress ?>' tabindex=102 />
 			<br />
 
 			<br/><br/>
 			<hr><br/>
 
-			<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+			<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 
         </fieldset>
      </div>

--- a/mng-rad-ippool-list.php
+++ b/mng-rad-ippool-list.php
@@ -56,11 +56,11 @@
 
 	<div id="contentnorightbar">
 	
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradippoollist.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradippoollist.php') ?>
 		<h144>+</h144></a></h2>
 		
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradippoollist'] ?>
+			<?php echo t('helpPage','mngradippoollist') ?>
 			<br/>
 		</div>
 		<br/>
@@ -121,55 +121,55 @@
 	echo "<thread> <tr>
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=id&orderType=$orderType\">
-		".$l['all']['ID']."</a>
+		".t('all','ID')."</a>
 		<br/>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=pool_name&orderType=$orderType\">
-		".$l['all']['PoolName']."</a>
+		".t('all','PoolName')."</a>
 		<br/>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=framedipaddress&orderType=$orderType\">
-		".$l['all']['IPAddress']."</a>
+		".t('all','IPAddress')."</a>
 		<br/>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=nasipaddress&orderType=$orderType\">
-		".$l['all']['NASIPAddress']."</a>
+		".t('all','NASIPAddress')."</a>
 		<br/>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=CalledStationId&orderType=$orderType\">
-		".$l['all']['CalledStationId']."</a>
+		".t('all','CalledStationId')."</a>
 		<br/>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=CallingStationID&orderType=$orderType\">
-		".$l['all']['CallingStationID']."</a>
+		".t('all','CallingStationID')."</a>
 		<br/>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=expiry_time&orderType=$orderType\">
-		".$l['all']['ExpiryTime']."</a>
+		".t('all','ExpiryTime')."</a>
 		<br/>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=username&orderType=$orderType\">
-		".$l['all']['Username']."</a>
+		".t('all','Username')."</a>
 		<br/>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=pool_key&orderType=$orderType\">
-		".$l['all']['PoolKey']."</a>
+		".t('all','PoolKey')."</a>
 		<br/>
 		</th>
 	</tr> </thread>";
@@ -180,9 +180,9 @@
                                 <td> <a class='tablenovisit' href='javascript:return;'
                                 onclick=\"javascript:__displayTooltip();\"
                                 tooltipText=\"
-                                        <a class='toolTip' href='mng-rad-ippool-edit.php?poolname=$row[1]&ipaddressold=$row[2]'>".$l['Tooltip']['EditIPAddress']."</a>
+                                        <a class='toolTip' href='mng-rad-ippool-edit.php?poolname=$row[1]&ipaddressold=$row[2]'>".t('Tooltip','EditIPAddress')."</a>
 					<br/>
-                                        <a class='toolTip' href='mng-rad-ippool-del.php?poolname=$row[1]&ipaddress=$row[2]'>".$l['Tooltip']['RemoveIPAddress']."</a>
+                                        <a class='toolTip' href='mng-rad-ippool-del.php?poolname=$row[1]&ipaddress=$row[2]'>".t('Tooltip','RemoveIPAddress')."</a>
                                         <br/>\"
                                         >$row[2]</a></td>
 				<td> $row[3] </td>

--- a/mng-rad-ippool-new.php
+++ b/mng-rad-ippool-new.php
@@ -101,11 +101,11 @@
 
 	<div id="contentnorightbar">
 	
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradippoolnew.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradippoolnew.php') ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >				
-			<?php echo $l['helpPage']['mngradippoolnew'] ?>
+			<?php echo t('helpPage','mngradippoolnew') ?>
 			<br/>
 		</div>
 
@@ -116,25 +116,25 @@
 		<form name="newippool" action="<?php echo $_SERVER['PHP_SELF']; ?>" method="post">
 
 <div class="tabber">
-	<div class="tabbertab" title="<?php echo $l['title']['IPPoolInfo']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','IPPoolInfo'); ?>">
 	<fieldset>
 
-		<h302> <?php echo $l['title']['IPPoolInfo'] ?> </h302>
+		<h302> <?php echo t('title','IPPoolInfo') ?> </h302>
 		<br/>
 
-			<label for='poolname' class='form'><?php echo $l['all']['PoolName'] ?></label>
+			<label for='poolname' class='form'><?php echo t('all','PoolName') ?></label>
 			<input name='poolname' type='text' id='poolname' value='<?php echo $poolname ?>' tabindex=100 />
 			<br />
 
 
-			<label for='ipaddress' class='form'><?php echo $l['all']['IPAddress'] ?></label>
+			<label for='ipaddress' class='form'><?php echo t('all','IPAddress') ?></label>
 			<input name='ipaddress' type='text' id='ipaddress' value='<?php echo $ipaddress ?>' tabindex=101 />
 			<br />
 
 			<br/><br/>
 			<hr><br/>
 
-			<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+			<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 
         </fieldset>
      </div>

--- a/mng-rad-ippool.php
+++ b/mng-rad-ippool.php
@@ -42,11 +42,11 @@
 
 	<div id="contentnorightbar">
 	
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradippool.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradippool.php') ?>
 		<h144>+</h144></a></h2>
 		
 		<div id="helpPage" style="display:none;visibility:visible" >				
-			<?php echo $l['helpPage']['mngradippool'] ?>
+			<?php echo t('helpPage','mngradippool') ?>
 			<br/>
 		</div>
 		<br/>

--- a/mng-rad-nas-del.php
+++ b/mng-rad-nas-del.php
@@ -102,11 +102,11 @@
 
 	<div id="contentnorightbar">
 	
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradnasdel.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradnasdel.php') ?>
 		:: <?php if (isset($nashost)) { echo $nashost; } ?><h144>+</h144></a></h2>
 		
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradnasdel'] ?>
+			<?php echo t('helpPage','mngradnasdel') ?>
 			<br/>
 		</div>
 		<?php
@@ -118,17 +118,17 @@
 
         <fieldset>
 
-			<h302> <?php echo $l['title']['NASInfo'] ?> </h302>
+			<h302> <?php echo t('title','NASInfo') ?> </h302>
 			<br/>
 
-			<label for='nashost' class='form'><?php echo $l['all']['NasIPHost'] ?></label>
+			<label for='nashost' class='form'><?php echo t('all','NasIPHost') ?></label>
 			<input name='nashost' type='text' id='nashost' value='' tabindex=100 />
 			<br />
 
 			<br/><br/>
 			<hr><br/>
 
-			<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+			<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 
         </fieldset>
 

--- a/mng-rad-nas-edit.php
+++ b/mng-rad-nas-edit.php
@@ -164,11 +164,11 @@
 
 	<div id="contentnorightbar">
 
-			<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradnasedit.php'] ?>
+			<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradnasedit.php') ?>
 			:: <?php if (isset($nashost)) { echo $nashost; } ?><h144>+</h144></a></h2>
 
 			<div id="helpPage" style="display:none;visibility:visible" >
-				<?php echo $l['helpPage']['mngradnasedit'] ?>
+				<?php echo t('helpPage','mngradnasedit') ?>
 				<br/>
 			</div>
 			<?php
@@ -179,24 +179,24 @@
 			
 <div class="tabber">
 
-     <div class="tabbertab" title="<?php echo $l['title']['NASInfo']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','NASInfo'); ?>">
 		<input type="hidden" value="<?php echo $nashost ?>" name="nashostold" />
 
 
         <fieldset>
 
-                <h302> <?php echo $l['title']['NASInfo'] ?> </h302>
+                <h302> <?php echo t('title','NASInfo') ?> </h302>
                 <br/>
 
-                <label for='nashost' class='form'><?php echo $l['all']['NasIPHost'] ?></label>
+                <label for='nashost' class='form'><?php echo t('all','NasIPHost') ?></label>
                 <input name='nashost' type='text' id='nashost' value='<?php echo $nashost ?>' tabindex=100 />
                 <br />
 
-                <label for='nassecret' class='form'><?php echo $l['all']['NasSecret'] ?></label>
+                <label for='nassecret' class='form'><?php echo t('all','NasSecret') ?></label>
                 <input name='nassecret' type='text' id='nassecret' value='<?php echo $nassecret ?>' tabindex=101 />
                 <br />
 
-                <label for='nastype' class='form'><?php echo $l['all']['NasType'] ?></label>
+                <label for='nastype' class='form'><?php echo t('all','NasType') ?></label>
                 <input name='nastype' type='text' id='nastype' value='<?php echo $nastype ?>' tabindex=102 />
                 <select onChange="javascript:setStringText(this.id,'nastype')" id="optionSele" tabindex=103 class='form'>
                         <option value="">Select Type...</option>
@@ -216,7 +216,7 @@
                 <br />
 
 
-                <label for='nasname' class='form'><?php echo $l['all']['NasShortname'] ?></label>
+                <label for='nasname' class='form'><?php echo t('all','NasShortname') ?></label>
                 <input name='nasname' type='text' id='nasname' value='<?php echo $nasname ?>' tabindex=104 />
                 <br />
 
@@ -225,7 +225,7 @@
                 <br/><br/>
                 <hr><br/>
 
-                <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+                <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 
         </fieldset>
 
@@ -233,29 +233,29 @@
 
         <fieldset>
 
-                <h302> <?php echo $l['title']['NASAdvanced'] ?> </h302>
+                <h302> <?php echo t('title','NASAdvanced') ?> </h302>
                 <br/>
 
-                <label for='nasports' class='form'><?php echo $l['all']['NasPorts'] ?></label>
+                <label for='nasports' class='form'><?php echo t('all','NasPorts') ?></label>
                 <input name='nasports' type='text' id='nasports' value='<?php echo $nasports ?>' tabindex=105 />
                 <br />
 
-                <label for='nascommunity' class='form'><?php echo $l['all']['NasCommunity'] ?></label>
+                <label for='nascommunity' class='form'><?php echo t('all','NasCommunity') ?></label>
                 <input name='nascommunity' type='text' id='nascommunity' value='<?php echo $nascommunity ?>' tabindex=106 />
                 <br />
 
-                <label for='nasvirtualserver' class='form'><?php echo $l['all']['NasVirtualServer'] ?></label>
+                <label for='nasvirtualserver' class='form'><?php echo t('all','NasVirtualServer') ?></label>
                 <input name='nasvirtualserver' type= 'text' id='nasvirtualserver' value='<?php echo $nasvirtualserver ?>' tabindex=107 >
                 <br />
 
-                <label for='nasdescription' class='form'><?php echo $l['all']['NasDescription'] ?></label>
+                <label for='nasdescription' class='form'><?php echo t('all','NasDescription') ?></label>
 	        <textarea class='form' name='nasdescription' id='nasdescription' tabindex=108 ><?php echo $nasdescription ?></textarea>
                 <br />
 
                 <br/><br/>
                 <hr><br/>
 
-                <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+                <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 
         </fieldset>
 

--- a/mng-rad-nas-list.php
+++ b/mng-rad-nas-list.php
@@ -56,11 +56,11 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradnaslist.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradnaslist.php') ?>
 				<h144>+</h144></a></h2>
 				
 				<div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['mngradnaslist'] ?>
+					<?php echo t('helpPage','mngradnaslist') ?>
 					<br/>
 				</div>
 				<br/>
@@ -125,55 +125,55 @@
 	echo "<thread> <tr>
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=id&orderType=$orderType\">
-		".$l['all']['NasID']."</a>
+		".t('all','NasID')."</a>
 		<br/>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=nasname&orderType=$orderType\">
-		".$l['all']['NasIPHost']."</a>
+		".t('all','NasIPHost')."</a>
 		<br/>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=shortname&orderType=$orderType\">
-		".$l['all']['NasShortname']."</a>
+		".t('all','NasShortname')."</a>
 		<br/>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=type&orderType=$orderType\">
-		".$l['all']['NasType']."</a>
+		".t('all','NasType')."</a>
 		<br/>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=ports&orderType=$orderType\">
-		".$l['all']['NasPorts']."</a>
+		".t('all','NasPorts')."</a>
 		<br/>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=secret&orderType=$orderType\">
-		".$l['all']['NasSecret']."</a>
+		".t('all','NasSecret')."</a>
 		<br/>
 		</th>
 
                 <th scope='col'>
                 <a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=secret&orderType=$orderType\">
-                ".$l['all']['NasVirtualServer']."</a>
+                ".t('all','NasVirtualServer')."</a>
                 <br/>
                 </th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=community&orderType=$orderType\">
-		".$l['all']['NasCommunity']."</a>
+		".t('all','NasCommunity')."</a>
 		<br/>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=description&orderType=$orderType\">
-		".$l['all']['NasDescription']."</a>
+		".t('all','NasDescription')."</a>
 		<br/>
 		</th>
 	</tr> </thread>";
@@ -183,8 +183,8 @@
                                 <td> <a class='tablenovisit' href='javascript:return;'
                                 onclick=\"javascript:__displayTooltip();\"
                                 tooltipText=\"
-                                        <a class='toolTip' href='mng-rad-nas-edit.php?nashost=$row[1]'>".$l['Tooltip']['EditNAS']."</a>
-                                        <a class='toolTip' href='mng-rad-nas-del.php?nashost=$row[1]'>".$l['Tooltip']['RemoveNAS']."</a>
+                                        <a class='toolTip' href='mng-rad-nas-edit.php?nashost=$row[1]'>".t('Tooltip','EditNAS')."</a>
+                                        <a class='toolTip' href='mng-rad-nas-del.php?nashost=$row[1]'>".t('Tooltip','RemoveNAS')."</a>
                                         <br/>\"
                                         >$row[1]</a></td>
 				<td> $row[2] </td>

--- a/mng-rad-nas-new.php
+++ b/mng-rad-nas-new.php
@@ -123,11 +123,11 @@
 
 	<div id="contentnorightbar">
 	
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradnasnew.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradnasnew.php') ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >				
-			<?php echo $l['helpPage']['mngradnasnew'] ?>
+			<?php echo t('helpPage','mngradnasnew') ?>
 			<br/>
 		</div>
 		<?php
@@ -138,24 +138,24 @@
                 <form name="newnas" action="<?php echo $_SERVER['PHP_SELF']; ?>" method="post">
 <div class="tabber">
 
-     <div class="tabbertab" title="<?php echo $l['title']['NASInfo']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','NASInfo'); ?>">
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['NASInfo'] ?> </h302>
+		<h302> <?php echo t('title','NASInfo') ?> </h302>
 		<br/>
 
-                <label for='nashost' class='form'><?php echo $l['all']['NasIPHost'] ?></label>
+                <label for='nashost' class='form'><?php echo t('all','NasIPHost') ?></label>
                 <input name='nashost' type='text' id='nashost' value='' tabindex=100 />
                 <br />
 
 
-                <label for='nassecret' class='form'><?php echo $l['all']['NasSecret'] ?></label>
+                <label for='nassecret' class='form'><?php echo t('all','NasSecret') ?></label>
                 <input name='nassecret' type='text' id='nassecret' value='' tabindex=101 />
                 <br />
 
 
-                <label for='nastype' class='form'><?php echo $l['all']['NasType'] ?></label>
+                <label for='nastype' class='form'><?php echo t('all','NasType') ?></label>
                 <input name='nastype' type='text' id='nastype' value='' tabindex=102 />
                 <select onChange="javascript:setStringText(this.id,'nastype')" id="optionSele" tabindex=103 class='form'>
 					<option value="">Select Type...</option>
@@ -175,46 +175,46 @@
                 <br />
 		
 
-                <label for='nasname' class='form'><?php echo $l['all']['NasShortname'] ?></label>
+                <label for='nasname' class='form'><?php echo t('all','NasShortname') ?></label>
                 <input name='nasname' type='text' id='nasname' value='' tabindex=104 />
                 <br />
 
                 <br/><br/>
                 <hr><br/>
 
-                <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+                <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 
         </fieldset>
 
 
      </div>
-     <div class="tabbertab" title="<?php echo $l['title']['NASAdvanced']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','NASAdvanced'); ?>">
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['NASAdvanced'] ?> </h302>
+		<h302> <?php echo t('title','NASAdvanced') ?> </h302>
 		<br/>
 
-                <label for='nasports' class='form'><?php echo $l['all']['NasPorts'] ?></label>
+                <label for='nasports' class='form'><?php echo t('all','NasPorts') ?></label>
                 <input name='nasports' type='text' id='nasports' value='0' tabindex=105 />
                 <br />
 
-                <label for='nascommunity' class='form'><?php echo $l['all']['NasCommunity'] ?></label>
+                <label for='nascommunity' class='form'><?php echo t('all','NasCommunity') ?></label>
                 <input name='nascommunity' type='text' id='nascommunity' value='' tabindex=106 />
                 <br />
 
-                <label for='nasvirtualserver' class='form'><?php echo $l['all']['NasVirtualServer'] ?></label>
+                <label for='nasvirtualserver' class='form'><?php echo t('all','NasVirtualServer') ?></label>
                 <input name='nasvirtualserver' type= 'text' id='nasvirtualserver' value='' tabindex=107 >
                 <br />
 
-                <label for='nasdescription' class='form'><?php echo $l['all']['NasDescription'] ?></label>
+                <label for='nasdescription' class='form'><?php echo t('all','NasDescription') ?></label>
                 <textarea class='form' name='nasdescription' id='nasdescription' value='' tabindex=108 ></textarea>
                 <br />
 
                 <br/><br/>
                 <hr><br/>
 
-                <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+                <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 
         </fieldset>
 

--- a/mng-rad-nas.php
+++ b/mng-rad-nas.php
@@ -41,11 +41,11 @@
 ?>
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradnas.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradnas.php') ?>
 				<h144>+</h144></a></h2>
 				
 				<div id="helpPage" style="display:none;visibility:visible" >				
-					<?php echo $l['helpPage']['mngradnas'] ?>
+					<?php echo t('helpPage','mngradnas') ?>
 					<br/>
 				</div>
 				<br/>

--- a/mng-rad-profiles-del.php
+++ b/mng-rad-profiles-del.php
@@ -143,11 +143,11 @@
 
 		<div id="contentnorightbar">
 
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradprofilesdel.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradprofilesdel.php') ?>
 				:: <?php if (isset($profile)) { echo $profile; } ?><h144>+</h144></a></h2>
 
 				<div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['mngradprofilesdel'] ?>
+					<?php echo t('helpPage','mngradprofilesdel') ?>
 					<br/>
 				</div>
                 <?php
@@ -159,7 +159,7 @@
 
         <fieldset>
 
-                <h302> <?php echo $l['title']['ProfileInfo'] ?> </h302>
+                <h302> <?php echo t('title','ProfileInfo') ?> </h302>
                 <br/>
 
                 <label for='profile' class='form'>Profile Name</label>
@@ -173,7 +173,7 @@
                 <br/><br/>
                 <hr><br/>
 
-                <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+                <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 
         </fieldset>
 

--- a/mng-rad-profiles-duplicate.php
+++ b/mng-rad-profiles-duplicate.php
@@ -113,11 +113,11 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradprofilesduplicate.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradprofilesduplicate.php') ?>
 				:: <?php if (isset($profile)) { echo $profile; } ?><h144>+</h144></a></h2>
 
 				<div id="helpPage" style="display:none;visibility:visible" >
-					<?php echo $l['helpPage']['mngradprofilesduplicate'] ?>
+					<?php echo t('helpPage','mngradprofilesduplicate') ?>
 					<br/>
 				</div>
                 <?php
@@ -128,7 +128,7 @@
 
         <fieldset>
 
-                <h302> <?php echo $l['title']['ProfileInfo'] ?> </h302>
+                <h302> <?php echo t('title','ProfileInfo') ?> </h302>
                 <br/>
 
                 <label for='sourceProfile' class='form'>Profile Name to Duplicate</label>
@@ -145,7 +145,7 @@
                 <br/><br/>
                 <hr><br/>
 
-                <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+                <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 
         </fieldset>
 

--- a/mng-rad-profiles-edit.php
+++ b/mng-rad-profiles-edit.php
@@ -157,12 +157,12 @@
 
 	<div id="contentnorightbar">
 
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradprofilesedit.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradprofilesedit.php') ?>
 		:: <?php if (isset($profile)) { echo $profile; } ?><h144>+</h144></a></h2>
 
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradprofilesedit'] ?>
+			<?php echo t('helpPage','mngradprofilesedit') ?>
 			<br/>
 		</div>
 		<?php
@@ -176,11 +176,11 @@
 
 <div class="tabber">
 
-     <div class="tabbertab" title="<?php echo $l['title']['RADIUSCheck']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','RADIUSCheck'); ?>">
 
         <fieldset>
 
-                <h302> <?php echo $l['title']['RADIUSCheck']?> </h302>
+                <h302> <?php echo t('title','RADIUSCheck')?> </h302>
                 <br/>
 
 		<ul>
@@ -209,7 +209,7 @@
 
         if ($numrows = $res->numRows() == 0) {
 			echo "<center>";
-			echo $l['messages']['noCheckAttributesForGroup'];
+			echo t('messages','noCheckAttributesForGroup');
 			echo "</center>";
         }
 
@@ -269,18 +269,18 @@
         <br/><br/>
         <hr><br/>
         <br/>
-        <input type='submit' name='submit' value='<?php echo $l['buttons']['apply']?>' class='button' />
+        <input type='submit' name='submit' value='<?php echo t('buttons','apply')?>' class='button' />
 
 	</ul>
 
         </fieldset>
         </div>
 
-        <div class='tabbertab' title='<?php echo $l['title']['RADIUSReply']?>' >
+        <div class='tabbertab' title='<?php echo t('title','RADIUSReply')?>' >
 
         <fieldset>
 
-                <h302> <?php echo $l['title']['RADIUSReply']?> </h302>
+                <h302> <?php echo t('title','RADIUSReply')?> </h302>
                 <br/>
 
 		<ul>
@@ -304,7 +304,7 @@
 
         if ($numrows = $res->numRows() == 0) {
                 echo "<center>";
-                echo $l['messages']['noReplyAttributesForGroup'];
+                echo t('messages','noReplyAttributesForGroup');
                 echo "</center>";
         }
 
@@ -366,7 +366,7 @@
         <br/><br/>
         <hr><br/>
         <br/>
-        <input type='submit' name='submit' value='<?php echo $l['buttons']['apply']?>' class='button' />
+        <input type='submit' name='submit' value='<?php echo t('buttons','apply')?>' class='button' />
         <br/>
 
 	</ul>
@@ -380,7 +380,7 @@
 
 
 
-     <div class="tabbertab" title="<?php echo $l['title']['Attributes']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','Attributes'); ?>">
         <?php
 			include_once('include/management/attributes.php');
         ?>

--- a/mng-rad-profiles-list.php
+++ b/mng-rad-profiles-list.php
@@ -57,11 +57,11 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradprofiles.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradprofiles.php') ?>
 				<h144>+</h144></a></h2>
 
 				<div id="helpPage" style="display:none;visibility:visible" >				
-					<?php echo $l['helpPage']['mngradprofileslist'] ?>
+					<?php echo t('helpPage','mngradprofileslist') ?>
 					<br/>
 				</div>	
 				<br/>
@@ -136,12 +136,12 @@
 	echo "<thread> <tr>
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=groupname&orderType=$orderTypeNextPage\">
-		".$l['all']['Groupname']."</a>
+		".t('all','Groupname')."</a>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=users&orderType=$orderTypeNextPage\">
-		".$l['all']['TotalUsers']."</a>
+		".t('all','TotalUsers')."</a>
 		</th>
 
 	</tr> </thread>";
@@ -151,7 +151,7 @@
 				<a class='tablenovisit' href='javascript:return;'
                                 onclick=\"javascript:__displayTooltip();\"
                                 tooltipText=\"
-                                        <a class='toolTip' href='mng-rad-profiles-edit.php?profile=$row[0]'>".$l['Tooltip']['EditProfile']."</a>
+                                        <a class='toolTip' href='mng-rad-profiles-edit.php?profile=$row[0]'>".t('Tooltip','EditProfile')."</a>
                                         <br/>\"
 				>$row[0]</a></td>
 			<td>$row[1]</td>

--- a/mng-rad-profiles-new.php
+++ b/mng-rad-profiles-new.php
@@ -125,12 +125,12 @@
 		
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradprofilesnew.php'] ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradprofilesnew.php') ?>
 				<h144>+</h144></a></h2>
 
 
 				<div id="helpPage" style="display:none;visibility:visible" >				
-					<?php echo $l['helpPage']['mngradprofilesnew'] ?>
+					<?php echo t('helpPage','mngradprofilesnew') ?>
 					<br/>
 				</div>
                 <?php
@@ -141,7 +141,7 @@
 
         <fieldset>
 
-                <h302> <?php echo $l['title']['ProfileInfo'] ?> </h302>
+                <h302> <?php echo t('title','ProfileInfo') ?> </h302>
                 <br/>
 
                 <label for='profile' class='form'>Profile Name</label>
@@ -151,7 +151,7 @@
                 <br/><br/>
                 <hr><br/>
 
-                <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+                <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 
         </fieldset>
 

--- a/mng-rad-profiles.php
+++ b/mng-rad-profiles.php
@@ -48,12 +48,12 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradprofiles.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradprofiles.php') ?>
 		<h144>+</h144></a></h2>
 			
 
 		<div id="helpPage" style="display:none;visibility:visible" >				
-			<?php echo $l['helpPage']['mngradprofiles'] ?>
+			<?php echo t('helpPage','mngradprofiles') ?>
 			<br/>
 		</div>	
 		<br/>

--- a/mng-rad-proxys-del.php
+++ b/mng-rad-proxys-del.php
@@ -103,11 +103,11 @@
 
 	<div id="contentnorightbar">
 
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradproxysdel.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradproxysdel.php') ?>
 		<h144>+</h144></a></h2>
 		
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradproxysdel'] ?>
+			<?php echo t('helpPage','mngradproxysdel') ?>
 			<br/>
 		</div>
 		<?php   
@@ -119,17 +119,17 @@
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['ProxyInfo'] ?> </h302>
+		<h302> <?php echo t('title','ProxyInfo') ?> </h302>
 		<br/>
 
-			<label for='proxyname' class='form'><?php echo $l['all']['ProxyName'] ?></label>
+			<label for='proxyname' class='form'><?php echo t('all','ProxyName') ?></label>
 			<input name='proxyname[]' type='text' id='proxyname' value='<?php echo $proxyname ?>' tabindex=100 />
 			<br/>
 
 			<br/><br/>
 			<hr><br/>
 
-			<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=1000  class='button' />
+			<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=1000  class='button' />
 
 	</fieldset>
 

--- a/mng-rad-proxys-edit.php
+++ b/mng-rad-proxys-edit.php
@@ -142,11 +142,11 @@
 
 	<div id="contentnorightbar">
 
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradproxysedit.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradproxysedit.php') ?>
 		<h144>+</h144></a></h2>
 		
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradproxysedit'] ?>
+			<?php echo t('helpPage','mngradproxysedit') ?>
 			<br/>
 		</div>
 		<?php   
@@ -157,11 +157,11 @@
 
 <div class="tabber">
 
-     <div class="tabbertab" title="<?php echo $l['title']['ProxyInfo']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','ProxyInfo'); ?>">
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['ProxyInfo']; ?> </h302>
+		<h302> <?php echo t('title','ProxyInfo'); ?> </h302>
 		<br/>
 
 		<ul>
@@ -169,68 +169,68 @@
 		<input type='hidden' name='proxyname'  id='proxyname' value='<?php if (isset($proxyname)) echo $proxyname; ?>' />
 
                 <li class='fieldset'>
-                <label for='proxyname' class='form'><?php echo $l['all']['ProxyName'] ?></label>
+                <label for='proxyname' class='form'><?php echo t('all','ProxyName') ?></label>
                 <input disabled name='proxyname' type='text' id='proxyname' 
 					value='<?php if (isset($proxyname)) echo $proxyname; ?>' tabindex=100
 				<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('proxyNameTooltip')" />
 			
                 <div id='proxyNameTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 					<img src='images/icons/comment.png' alt='Tip' border='0' />
-					<?php echo $l['Tooltip']['proxyNameTooltip'] ?>
+					<?php echo t('Tooltip','proxyNameTooltip') ?>
                 </div>
                 </li>
 
                 <li class='fieldset'>
-                <label for='retry_delay' class='form'><?php echo $l['all']['RetryDelay'] ?></label>
+                <label for='retry_delay' class='form'><?php echo t('all','RetryDelay') ?></label>
                 <input name='retry_delay' type='text' id='retry_delay' 
 						value='<?php if (isset($retry_delay)) echo $retry_delay; ?>' tabindex=102
 				<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('proxyRetryDelayTooltip')" />
 				
                 <div id='proxyRetryDelayTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 					<img src='images/icons/comment.png' alt='Tip' border='0' />
-					<?php echo $l['Tooltip']['proxyRetryDelayTooltip'] ?>
+					<?php echo t('Tooltip','proxyRetryDelayTooltip') ?>
                 </div>
                 </li>
                 <li class='fieldset'>
-                <label for='retry_count' class='form'><?php echo $l['all']['RetryCount'] ?></label>
+                <label for='retry_count' class='form'><?php echo t('all','RetryCount') ?></label>
                 <input name='retry_count' type='text' id='retry_count' 
 					value='<?php if (isset($retry_count)) echo $retry_count; ?>' tabindex=103
 				<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('proxyRetryCountTooltip')" />
 				
                 <div id='proxyRetryCountTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 					<img src='images/icons/comment.png' alt='Tip' border='0' />
-					<?php echo $l['Tooltip']['proxyRetryCountTooltip'] ?>
+					<?php echo t('Tooltip','proxyRetryCountTooltip') ?>
                 </div>
                 </li>
 
                 <li class='fieldset'>
-                <label for='dead_time' class='form'><?php echo $l['all']['DeadTime'] ?></label>
+                <label for='dead_time' class='form'><?php echo t('all','DeadTime') ?></label>
                 <input name='dead_time' type='text' id='dead_time' 
 					value='<?php if (isset($dead_time)) echo $dead_time; ?>' tabindex=104
 				<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('proxyDeadTimeTooltip')" />
 				
                 <div id='proxyDeadTimeTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 					<img src='images/icons/comment.png' alt='Tip' border='0' />
-					<?php echo $l['Tooltip']['proxyDeadTimeTooltip'] ?>
+					<?php echo t('Tooltip','proxyDeadTimeTooltip') ?>
                 </div>
                 </li>
 
                 <li class='fieldset'>
-                <label for='default_fallback' class='form'><?php echo $l['all']['DefaultFallback'] ?></label>
+                <label for='default_fallback' class='form'><?php echo t('all','DefaultFallback') ?></label>
                 <input name='default_fallback' type='text' id='default_fallback' 
 					value='<?php if (isset($default_fallback)) echo $default_fallback; ?>' tabindex=104
 				<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('proxyDefaultFallbackTooltip')" />
 				
                 <div id='proxyDefaultFallbackTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 					<img src='images/icons/comment.png' alt='Tip' border='0' />
-					<?php echo $l['Tooltip']['proxyDefaultFallbackTooltip'] ?>
+					<?php echo t('Tooltip','proxyDefaultFallbackTooltip') ?>
                 </div>
                 </li>
 
                 <li class='fieldset'>
                 <br/>
                 <hr><br/>
-                <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
+                <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' />
 		</li>
 
 		</ul>

--- a/mng-rad-proxys-list.php
+++ b/mng-rad-proxys-list.php
@@ -57,11 +57,11 @@
 	
 	<div id="contentnorightbar">
 	
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradproxys.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradproxys.php') ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >				
-			<?php echo $l['helpPage']['mngradproxyslist'] ?>
+			<?php echo t('helpPage','mngradproxyslist') ?>
 			<br/>
 		</div>	
 		<br/>
@@ -118,7 +118,7 @@
 	echo "<thread> <tr>
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=proxyname&orderType=$orderType\">
-		".$l['all']['ProxyName']."</a>
+		".t('all','ProxyName')."</a>
 		</th>
 	</tr> </thread>";
 	while($row = $res->fetchRow()) {
@@ -127,7 +127,7 @@
 				<a class='tablenovisit' href='javascript:return;'
                                 onclick=\"javascript:__displayTooltip();\"
                                 tooltipText=\"
-                                        <a class='toolTip' href='mng-rad-proxys-edit.php?proxyname=$row[1]'>".$l['Tooltip']['EditProxy']."</a>
+                                        <a class='toolTip' href='mng-rad-proxys-edit.php?proxyname=$row[1]'>".t('Tooltip','EditProxy')."</a>
                                         <br/>\"
 				>$row[1]</a></td>
 		</tr>";

--- a/mng-rad-proxys-new.php
+++ b/mng-rad-proxys-new.php
@@ -131,11 +131,11 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradproxysnew.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradproxysnew.php') ?>
 		<h144>+</h144></a></h2>
 		
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradproxysnew'] ?>
+			<?php echo t('helpPage','mngradproxysnew') ?>
 			<br/>
 		</div>
 		<?php   
@@ -147,74 +147,74 @@
 
 <div class="tabber">
 
-	<div class="tabbertab" title="<?php echo $l['title']['ProxyInfo']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','ProxyInfo'); ?>">
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['ProxyInfo']; ?> </h302>
+		<h302> <?php echo t('title','ProxyInfo'); ?> </h302>
 		<br/>
 
 		<ul>
 
 		<li class='fieldset'>
-		<label for='proxyname' class='form'><?php echo $l['all']['ProxyName'] ?></label>
+		<label for='proxyname' class='form'><?php echo t('all','ProxyName') ?></label>
 		<input name='proxyname' type='text' id='proxyname' value='' tabindex=100 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('proxyNameTooltip')" />
 
 		<div id='proxyNameTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['proxyNameTooltip'] ?>
+			<?php echo t('Tooltip','proxyNameTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='retry_delay' class='form'><?php echo $l['all']['RetryDelay'] ?></label>
+		<label for='retry_delay' class='form'><?php echo t('all','RetryDelay') ?></label>
 		<input name='retry_delay' type='text' id='retry_delay' value='' tabindex=102 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('proxyRetryDelayTooltip')" />
 		
 		<div id='proxyRetryDelayTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['proxyRetryDelayTooltip'] ?>
+			<?php echo t('Tooltip','proxyRetryDelayTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='retry_count' class='form'><?php echo $l['all']['RetryCount'] ?></label>
+		<label for='retry_count' class='form'><?php echo t('all','RetryCount') ?></label>
 		<input name='retry_count' type='text' id='retry_count' value='' tabindex=103 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('proxyRetryCountTooltip')" />
 		
 		<div id='proxyRetryCountTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['proxyRetryCountTooltip'] ?>
+			<?php echo t('Tooltip','proxyRetryCountTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='dead_time' class='form'><?php echo $l['all']['DeadTime'] ?></label>
+		<label for='dead_time' class='form'><?php echo t('all','DeadTime') ?></label>
 		<input name='dead_time' type='text' id='dead_time' value='' tabindex=104 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('proxyDeadTimeTooltip')" />
 		
 		<div id='proxyDeadTimeTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['proxyDeadTimeTooltip'] ?>
+			<?php echo t('Tooltip','proxyDeadTimeTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='default_fallback' class='form'><?php echo $l['all']['DefaultFallback'] ?></label>
+		<label for='default_fallback' class='form'><?php echo t('all','DefaultFallback') ?></label>
 		<input name='default_fallback' type='text' id='default_fallback' value='' tabindex=104 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('proxyDefaultFallbackTooltip')" />
 
 		<div id='proxyDefaultFallbackTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['proxyDefaultFallbackTooltip'] ?>
+			<?php echo t('Tooltip','proxyDefaultFallbackTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' />
 		</li>
 
 		</ul>

--- a/mng-rad-realms-del.php
+++ b/mng-rad-realms-del.php
@@ -105,11 +105,11 @@
 
 	<div id="contentnorightbar">
 
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradrealmsdel.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradrealmsdel.php') ?>
 		<h144>+</h144></a></h2>
 		
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradrealmsdel'] ?>
+			<?php echo t('helpPage','mngradrealmsdel') ?>
 			<br/>
 		</div>
 		<?php   
@@ -122,17 +122,17 @@
 
         <fieldset>
 
-		<h302> <?php echo $l['title']['RealmInfo'] ?> </h302>
+		<h302> <?php echo t('title','RealmInfo') ?> </h302>
 		<br/>
 
-			<label for='realmname' class='form'><?php echo $l['all']['RealmName'] ?></label>
+			<label for='realmname' class='form'><?php echo t('all','RealmName') ?></label>
 			<input name='realmname[]' type='text' id='realmname' value='<?php echo $realmname ?>' tabindex=100 />
 			<br/>
 
 			<br/><br/>
 			<hr><br/>
 
-			<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=1000 class='button' />
+			<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=1000 class='button' />
 
 	</fieldset>
 

--- a/mng-rad-realms-edit.php
+++ b/mng-rad-realms-edit.php
@@ -153,11 +153,11 @@
 
 	<div id="contentnorightbar">
 
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradrealmsedit.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradrealmsedit.php') ?>
 		<h144>+</h144></a></h2>
 		
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradrealmsedit'] ?>
+			<?php echo t('helpPage','mngradrealmsedit') ?>
 			<br/>
 		</div>
 		<?php
@@ -168,11 +168,11 @@
 
 <div class="tabber">
 
-     <div class="tabbertab" title="<?php echo $l['title']['RealmInfo']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','RealmInfo'); ?>">
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['RealmInfo']; ?> </h302>
+		<h302> <?php echo t('title','RealmInfo'); ?> </h302>
 		<br/>
 
 		<ul>
@@ -180,65 +180,65 @@
 		<input type='hidden' name='realmname' id='realmname' value='<?php if (isset($realmname)) echo $realmname; ?>' />
 
 		<li class='fieldset'>
-		<label for='realmname' class='form'><?php echo $l['all']['RealmName'] ?></label>
+		<label for='realmname' class='form'><?php echo t('all','RealmName') ?></label>
 		<input disabled name='realmname' type='text' id='realmname' 
 			value='<?php if (isset($realmname)) echo $realmname; ?>' tabindex=100 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('realmNameTooltip')" />
 		
 		<div id='realmNameTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['realmNameTooltip'] ?>
+			<?php echo t('Tooltip','realmNameTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='type' class='form'><?php echo $l['all']['Type'] ?></label>
+		<label for='type' class='form'><?php echo t('all','Type') ?></label>
 		<input name='type' type='text' id='type' value='<?php if (isset($type)) echo $type; ?>' tabindex=101 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('realmTypeTooltip')"/>
 		
 		<div id='realmTypeTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['realmTypeTooltip'] ?>
+			<?php echo t('Tooltip','realmTypeTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='authhost' class='form'><?php echo $l['all']['AuthHost'] ?></label>
+		<label for='authhost' class='form'><?php echo t('all','AuthHost') ?></label>
 		<input name='authhost' type='text' id='authhost' value='<?php if (isset($authhost)) echo $authhost; ?>' tabindex=102 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('realmAuthhostTooltip')"/>
 		
 		<div id='realmAuthhostTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['realmAuthhostTooltip'] ?>
+			<?php echo t('Tooltip','realmAuthhostTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='accthost' class='form'><?php echo $l['all']['AcctHost'] ?></label>
+		<label for='accthost' class='form'><?php echo t('all','AcctHost') ?></label>
 		<input name='accthost' type='text' id='accthost' value='<?php if (isset($accthost)) echo $accthost; ?>' tabindex=103 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('realmAccthostTooltip')"/>
 		
 		<div id='realmAccthostTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['realmAccthostTooltip'] ?>
+			<?php echo t('Tooltip','realmAccthostTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='secret' class='form'><?php echo $l['all']['RealmSecret'] ?></label>
+		<label for='secret' class='form'><?php echo t('all','RealmSecret') ?></label>
 		<input name='secret' type='text' id='secret' value='<?php if (isset($secret)) echo $secret; ?>' tabindex=104 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('realmSecretTooltip')"/>
 		
 		<div id='realmSecretTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['realmSecretTooltip'] ?>
+			<?php echo t('Tooltip','realmSecretTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' />
 		</li>
 
 		</ul>
@@ -247,62 +247,62 @@
 	</div>
 
 
-     <div class="tabbertab" title="<?php echo $l['title']['Advanced']; ?>">
+     <div class="tabbertab" title="<?php echo t('title','Advanced'); ?>">
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['RealmInfo']; ?> </h302>
+		<h302> <?php echo t('title','RealmInfo'); ?> </h302>
 		<br/>
 		<ul>
 
 		<li class='fieldset'>
-		<label for='ldflag' class='form'><?php echo $l['all']['Ldflag'] ?></label>
+		<label for='ldflag' class='form'><?php echo t('all','Ldflag') ?></label>
 		<input name='ldflag' type='text' id='ldflag' value='<?php if (isset($ldflag)) echo $ldflag; ?>' tabindex=105 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('realmLdflagTooltip')"/>
 		
 		<div id='realmLdflagTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['realmLdflagTooltip'] ?>
+			<?php echo t('Tooltip','realmLdflagTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='nostrip' class='form'><?php echo $l['all']['Nostrip'] ?></label>
+		<label for='nostrip' class='form'><?php echo t('all','Nostrip') ?></label>
 		<input name='nostrip' type='text' id='nostrip' value='<?php if (isset($nostrip)) echo $nostrip; ?>' tabindex=106 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('realmNostripTooltip')"/>
 		
 		<div id='realmNostripTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['realmNostripTooltip'] ?>
+			<?php echo t('Tooltip','realmNostripTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='hints' class='form'><?php echo $l['all']['Hints'] ?></label>
+		<label for='hints' class='form'><?php echo t('all','Hints') ?></label>
 		<input name='hints' type='text' id='hints' value='<?php if (isset($hints)) echo $hints; ?>' tabindex=107 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('realmHintsTooltip')"/>
 		
 		<div id='realmHintsTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['realmHintsTooltip'] ?>
+			<?php echo t('Tooltip','realmHintsTooltip') ?>
 		</div>
 		</li>
 
                 <li class='fieldset'>
-		<label for='notrealm' class='form'><?php echo $l['all']['Notrealm'] ?></label>
+		<label for='notrealm' class='form'><?php echo t('all','Notrealm') ?></label>
 		<input name='notrealm' type='text' id='notrealm' value='<?php if (isset($notrealm)) echo $notrealm; ?>' tabindex=108 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('realmNotrealmTooltip')"/>
 		
 		<div id='realmNotrealmTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['realmNotrealmTooltip'] ?>
+			<?php echo t('Tooltip','realmNotrealmTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' /> 
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' /> 
 		</li>
 
 		</ul>

--- a/mng-rad-realms-list.php
+++ b/mng-rad-realms-list.php
@@ -57,11 +57,11 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradrealms.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradrealms.php') ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >				
-			<?php echo $l['helpPage']['mngradrealmslist'] ?>
+			<?php echo t('helpPage','mngradrealmslist') ?>
 			<br/>
 		</div>	
 		<br/>
@@ -118,7 +118,7 @@
 	echo "<thread> <tr>
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=realmname&orderType=$orderType\">
-		".$l['all']['RealmName']."</a>
+		".t('all','RealmName')."</a>
 		</th>
 	</tr> </thread>";
 	while($row = $res->fetchRow()) {
@@ -127,7 +127,7 @@
 				<a class='tablenovisit' href='javascript:return;'
                                 onclick=\"javascript:__displayTooltip();\"
                                 tooltipText=\"
-                                        <a class='toolTip' href='mng-rad-realms-edit.php?realmname=$row[1]'>".$l['Tooltip']['EditRealm']."</a>
+                                        <a class='toolTip' href='mng-rad-realms-edit.php?realmname=$row[1]'>".t('Tooltip','EditRealm')."</a>
                                         <br/>\"
 				>$row[1]</a></td>
 		</tr>";

--- a/mng-rad-realms-new.php
+++ b/mng-rad-realms-new.php
@@ -137,11 +137,11 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradrealmsnew.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradrealmsnew.php') ?>
 		<h144>+</h144></a></h2>
 		
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradrealmsnew'] ?>
+			<?php echo t('helpPage','mngradrealmsnew') ?>
 			<br/>
 		</div>
 		<?php 
@@ -152,74 +152,74 @@
 
 <div class="tabber">
 
-	<div class="tabbertab" title="<?php echo $l['title']['RealmInfo']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','RealmInfo'); ?>">
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['RealmInfo']; ?> </h302>
+		<h302> <?php echo t('title','RealmInfo'); ?> </h302>
 		<br/>
 
 		<ul>
 
 		<li class='fieldset'>
-		<label for='realmname' class='form'><?php echo $l['all']['RealmName'] ?></label>
+		<label for='realmname' class='form'><?php echo t('all','RealmName') ?></label>
 		<input name='realmname' type='text' id='realmname' value='' tabindex=100 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('realmNameTooltip')" />
 		
 		<div id='realmNameTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['realmNameTooltip'] ?>
+			<?php echo t('Tooltip','realmNameTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='type' class='form'><?php echo $l['all']['Type'] ?></label>
+		<label for='type' class='form'><?php echo t('all','Type') ?></label>
 		<input name='type' type='text' id='type' value='' tabindex=101 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('realmTypeTooltip')" />
 		
 		<div id='realmTypeTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['realmTypeTooltip'] ?>
+			<?php echo t('Tooltip','realmTypeTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='authhost' class='form'><?php echo $l['all']['AuthHost'] ?></label>
+		<label for='authhost' class='form'><?php echo t('all','AuthHost') ?></label>
 		<input name='authhost' type='text' id='authhost' value='' tabindex=102 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('realmAuthhostTooltip')" />
 		
 		<div id='realmAuthhostTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['realmAuthhostTooltip'] ?>
+			<?php echo t('Tooltip','realmAuthhostTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='accthost' class='form'><?php echo $l['all']['AcctHost'] ?></label>
+		<label for='accthost' class='form'><?php echo t('all','AcctHost') ?></label>
 		<input name='accthost' type='text' id='accthost' value='' tabindex=103 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('realmAccthostTooltip')" />
 		
 		<div id='realmAccthostTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['realmAccthostTooltip'] ?>
+			<?php echo t('Tooltip','realmAccthostTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='secret' class='form'><?php echo $l['all']['RealmSecret'] ?></label>
+		<label for='secret' class='form'><?php echo t('all','RealmSecret') ?></label>
 		<input name='secret' type='text' id='secret' value='' tabindex=104 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('realmSecretTooltip')" />
 		
 		<div id='realmSecretTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['realmSecretTooltip'] ?>
+			<?php echo t('Tooltip','realmSecretTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' />
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' />
 		</li>
 
 		</ul>
@@ -228,62 +228,62 @@
 	</div>
 
 
-	<div class="tabbertab" title="<?php echo $l['title']['Advanced']; ?>">
+	<div class="tabbertab" title="<?php echo t('title','Advanced'); ?>">
 
 	<fieldset>
 
-		<h302> <?php echo $l['title']['RealmInfo']; ?> </h302>
+		<h302> <?php echo t('title','RealmInfo'); ?> </h302>
 		<br/>
 		<ul>
 
 		<li class='fieldset'>
-		<label for='ldflag' class='form'><?php echo $l['all']['Ldflag'] ?></label>
+		<label for='ldflag' class='form'><?php echo t('all','Ldflag') ?></label>
 		<input name='ldflag' type='text' id='ldflag' value='' tabindex=105 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('realmLdflagTooltip')" />
 		
 		<div id='realmLdflagTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['realmLdflagTooltip'] ?>
+			<?php echo t('Tooltip','realmLdflagTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='nostrip' class='form'><?php echo $l['all']['Nostrip'] ?></label>
+		<label for='nostrip' class='form'><?php echo t('all','Nostrip') ?></label>
 		<input name='nostrip' type='text' id='nostrip' value='' tabindex=106 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('realmNostripTooltip')" />
 		
 		<div id='realmNostripTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['realmNostripTooltip'] ?>
+			<?php echo t('Tooltip','realmNostripTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='hints' class='form'><?php echo $l['all']['Hints'] ?></label>
+		<label for='hints' class='form'><?php echo t('all','Hints') ?></label>
 		<input name='hints' type='text' id='hints' value='' tabindex=107 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('realmHintsTooltip')" />
 		
 		<div id='realmHintsTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['realmHintsTooltip'] ?>
+			<?php echo t('Tooltip','realmHintsTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
-		<label for='notrealm' class='form'><?php echo $l['all']['Notrealm'] ?></label>
+		<label for='notrealm' class='form'><?php echo t('all','Notrealm') ?></label>
 		<input name='notrealm' type='text' id='notrealm' value='' tabindex=108 />
 		<img src='images/icons/comment.png' alt='Tip' border='0' onClick="javascript:toggleShowDiv('realrealmNotrealmTooltipmHintsTooltip')" />
 		
 		<div id='realmNotrealmTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 			<img src='images/icons/comment.png' alt='Tip' border='0' />
-			<?php echo $l['Tooltip']['realmNotrealmTooltip'] ?>
+			<?php echo t('Tooltip','realmNotrealmTooltip') ?>
 		</div>
 		</li>
 
 		<li class='fieldset'>
 		<br/>
 		<hr><br/>
-		<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' tabindex=10000 class='button' /> 
+		<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' tabindex=10000 class='button' /> 
 		</li>
 
 		</ul>

--- a/mng-rad-realms.php
+++ b/mng-rad-realms.php
@@ -48,12 +48,12 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradrealms.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradrealms.php') ?>
 		<h144>+</h144></a></h2>
 			
 
 		<div id="helpPage" style="display:none;visibility:visible" >				
-			<?php echo $l['helpPage']['mngradrealms'] ?>
+			<?php echo t('helpPage','mngradrealms') ?>
 			<br/>
 		</div>	
 		<br/>

--- a/mng-rad-usergroup-del.php
+++ b/mng-rad-usergroup-del.php
@@ -117,11 +117,11 @@
 
 	<div id="contentnorightbar">
 
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradusergroupdel.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradusergroupdel.php') ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradusergroupdel'] ?>
+			<?php echo t('helpPage','mngradusergroupdel') ?>
 			<br/>
 		</div>
 		<?php
@@ -133,7 +133,7 @@
 
         <fieldset>
 
-                <h302> <?php echo $l['title']['GroupInfo'] ?> </h302>
+                <h302> <?php echo t('title','GroupInfo') ?> </h302>
                 <br/>
 
                 <input type="hidden" value="<?php echo $group ?>" name="group"/><br/>
@@ -141,12 +141,12 @@
                 <ul>
 
                 <li class='fieldset'>
-                <label for='username' class='form'><?php echo $l['all']['Username'] ?></label>
+                <label for='username' class='form'><?php echo t('all','Username') ?></label>
                 <input name='username' type='text' id='username' value='<?php echo $username ?>' tabindex=100 />
                 </li>
 
                 <li class='fieldset'>
-                <label for='group' class='form'><?php echo $l['all']['Groupname'] ?></label>
+                <label for='group' class='form'><?php echo t('all','Groupname') ?></label>
                 <input name='group' type='text' id='group' value='<?php echo $group ?>' tabindex=101 />
                 <?php
                         include 'include/management/populate_selectbox.php';
@@ -154,7 +154,7 @@
                 ?>
                 <div id='groupTooltip'  style='display:none;visibility:visible' class='ToolTip'>
                         <img src='images/icons/comment.png' alt='Tip' border='0' />
-                        <?php echo $l['Tooltip']['groupTooltip'] ?>
+                        <?php echo t('Tooltip','groupTooltip') ?>
                 </div>
                 </li>
 
@@ -162,7 +162,7 @@
                 <li class='fieldset'>
                 <br/>
                 <hr><br/>
-                <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+                <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
                 </li>
 
 		</ul>

--- a/mng-rad-usergroup-edit.php
+++ b/mng-rad-usergroup-edit.php
@@ -136,11 +136,11 @@ AND GroupName='".$dbSocket->escapeSimple($groupOld)."'";
 
 	<div id="contentnorightbar">
 	
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradusergroupedit'] ?> 
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradusergroupedit') ?> 
 		<?php echo $username ?><h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >				
-			<?php echo $l['helpPage']['mngradusergroupedit'] ?>
+			<?php echo t('helpPage','mngradusergroupedit') ?>
 			<br/>
 		</div>
 		<?php
@@ -153,40 +153,40 @@ AND GroupName='".$dbSocket->escapeSimple($groupOld)."'";
 
         <fieldset>
 
-                <h302> <?php echo $l['title']['GroupInfo'] ?> </h302>
+                <h302> <?php echo t('title','GroupInfo') ?> </h302>
                 <br/>
 
                 <ul>
 
                 <li class='fieldset'>
-                <label for='username' class='form'><?php echo $l['all']['Username'] ?></label>
+                <label for='username' class='form'><?php echo t('all','Username') ?></label>
                 <input type='hidden' name='username' type='text' id='username' value='<?php echo $username ?>' tabindex=100 />
                 <input disabled type='text' id='username' value='<?php echo $username ?>' tabindex=100 />
                 </li>
 
 
                 <li class='fieldset'>
-                <label for='groupOld' class='form'><?php echo $l['all']['CurrentGroupname'] ?></label>
+                <label for='groupOld' class='form'><?php echo t('all','CurrentGroupname') ?></label>
                 <input type='hidden' name='groupOld' id='groupOld' value='<?php echo $groupOld ?>' tabindex=101 />
                 <input disabled type='text' id='groupOld' value='<?php echo $groupOld ?>' tabindex=101 />
 				Old Group Name
                 </li>
 
                 <li class='fieldset'>
-                <label for='group' class='form'><?php echo $l['all']['NewGroupname'] ?></label>
+                <label for='group' class='form'><?php echo t('all','NewGroupname') ?></label>
                 <?php   
 					include 'include/management/populate_selectbox.php';
 					populate_groups("Select Groups","group","form");
                 ?>
                 <div id='groupTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 					<img src='images/icons/comment.png' alt='Tip' border='0' />
-					<?php echo $l['Tooltip']['groupTooltip'] ?>
+					<?php echo t('Tooltip','groupTooltip') ?>
                 </div>
                 </li>
 
 
                 <li class='fieldset'>
-                <label for='priority' class='form'><?php echo $l['all']['Priority'] ?></label>
+                <label for='priority' class='form'><?php echo t('all','Priority') ?></label>
                 <input class='integer' name='priority' type='text' id='priority' value='<?php echo $priority ?>' tabindex=103 />
                 <img src="images/icons/bullet_arrow_up.png" alt="+" onclick="javascript:changeInteger('priority','increment')" />
                 <img src="images/icons/bullet_arrow_down.png" alt="-" onclick="javascript:changeInteger('priority','decrement')"/>
@@ -195,7 +195,7 @@ AND GroupName='".$dbSocket->escapeSimple($groupOld)."'";
                 <li class='fieldset'>
                 <br/>
                 <hr><br/>
-                <input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+                <input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
                 </li>
 
 

--- a/mng-rad-usergroup-list-user.php
+++ b/mng-rad-usergroup-list-user.php
@@ -60,11 +60,11 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradusergrouplistuser'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradusergrouplistuser') ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['mngradusergrouplistuser'] ?>
+			<?php echo t('helpPage','mngradusergrouplistuser') ?>
 			<br/>
 		</div>			
 		<br/>
@@ -121,17 +121,17 @@
 	echo "<thread> <tr>
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=username&orderType=$orderTypeNextPage\">
-		".$l['all']['Username']."</a>
+		".t('all','Username')."</a>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=groupname&orderType=$orderTypeNextPage\">
-		".$l['all']['Groupname']."</a>
+		".t('all','Groupname')."</a>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=priority&orderType=$orderTypeNextPage\">
-		".$l['all']['Priority']."</a>
+		".t('all','Priority')."</a>
 		</th>
 
 	</tr> </thread>";
@@ -141,9 +141,9 @@
 					<a class='tablenovisit' href='javascript:return;'
                         onclick=\"javascript:__displayTooltip();\"
                         tooltipText=\"
-                        <a class='toolTip' href='mng-rad-usergroup-edit.php?username=$row[0]&group=$row[1]'>".$l['Tooltip']['EditUserGroup']."</a>
+                        <a class='toolTip' href='mng-rad-usergroup-edit.php?username=$row[0]&group=$row[1]'>".t('Tooltip','EditUserGroup')."</a>
 					<br/><br/>
-                       <a class='toolTip' href='mng-rad-usergroup-del.php?username=$row[0]&group=$row[1]'>".$l['Tooltip']['DeleteUserGroup']."</a>
+                       <a class='toolTip' href='mng-rad-usergroup-del.php?username=$row[0]&group=$row[1]'>".t('Tooltip','DeleteUserGroup')."</a>
                        <br/>\"
 					>$row[1]</a></td>
 				<td> $row[1] </td>

--- a/mng-rad-usergroup-list.php
+++ b/mng-rad-usergroup-list.php
@@ -57,11 +57,11 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradusergrouplist'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradusergrouplist') ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >				
-			<?php echo $l['helpPage']['mngradusergrouplist'] ?>
+			<?php echo t('helpPage','mngradusergrouplist') ?>
 			<br/>
 		</div>	
 		<br/>
@@ -130,22 +130,22 @@
 	echo "<thread> <tr>
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=username&orderType=$orderTypeNextPage\">
-		".$l['all']['Username']."</a>
+		".t('all','Username')."</a>
 		</th>
 
                 <th scope='col'>
                 <a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=firstname&orderType=$orderTypeNextPage\">
-                ".$l['all']['Name']."</a>
+                ".t('all','Name')."</a>
                 </th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=groupname&orderType=$orderTypeNextPage\">
-		".$l['all']['Groupname']."</a>
+		".t('all','Groupname')."</a>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=priority&orderType=$orderTypeNextPage\">
-		".$l['all']['Priority']."</a>
+		".t('all','Priority')."</a>
 		</th>
 
 	</tr> </thread>";
@@ -156,9 +156,9 @@
 			<td> <a class='tablenovisit' href='javascript:return;'
                                 onclick=\"javascript:__displayTooltip();\"
                                 tooltipText=\"
-                                        <a class='toolTip' href='mng-rad-usergroup-edit.php?username=$row[0]&group=$row[1]'>".$l['Tooltip']['EditUserGroup']."</a>
+                                        <a class='toolTip' href='mng-rad-usergroup-edit.php?username=$row[0]&group=$row[1]'>".t('Tooltip','EditUserGroup')."</a>
 					<br/>
-                                        <a class='toolTip' href='mng-rad-usergroup-list-user.php?username=$row[0]&group=$row[1]'>".$l['Tooltip']['ListUserGroups']."</a>
+                                        <a class='toolTip' href='mng-rad-usergroup-list-user.php?username=$row[0]&group=$row[1]'>".t('Tooltip','ListUserGroups')."</a>
                                         <br/>\"
 					>$row[1]</a></td>
 				<td> $row[2] </td>

--- a/mng-rad-usergroup-new.php
+++ b/mng-rad-usergroup-new.php
@@ -102,12 +102,12 @@
 
 	<div id="contentnorightbar">
 	
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradusergroupnew.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradusergroupnew.php') ?>
 		<h144>+</h144></a></h2>
 
 
 		<div id="helpPage" style="display:none;visibility:visible" >				
-			<?php echo $l['helpPage']['mngradusergroupnew'] ?>
+			<?php echo t('helpPage','mngradusergroupnew') ?>
 			<br/>
 		</div>
 		<?php
@@ -118,31 +118,31 @@
 
         <fieldset>
 
-			<h302> <?php echo $l['title']['GroupInfo'] ?> </h302>
+			<h302> <?php echo t('title','GroupInfo') ?> </h302>
 			<br/>
 
 		<ul>
 
 			<li class='fieldset'>
-			<label for='username' class='form'><?php echo $l['all']['Username'] ?></label>
+			<label for='username' class='form'><?php echo t('all','Username') ?></label>
 			<input name='username' type='text' id='username' value='<?php echo $username ?>' tabindex=100 />
 			</li>
 
 			<li class='fieldset'>
-			<label for='group' class='form'><?php echo $l['all']['Groupname'] ?></label>
+			<label for='group' class='form'><?php echo t('all','Groupname') ?></label>
 			<?php   
 				include 'include/management/populate_selectbox.php';
 				populate_groups("Select Groups","group","long");
 			?>
 			<div id='groupTooltip'  style='display:none;visibility:visible' class='ToolTip'>
 				<img src='images/icons/comment.png' alt='Tip' border='0' />
-				<?php echo $l['Tooltip']['groupTooltip'] ?>
+				<?php echo t('Tooltip','groupTooltip') ?>
 			</div>
 			</li>
 
 
 			<li class='fieldset'>
-				<label for='priority' class='form'><?php echo $l['all']['Priority'] ?></label>
+				<label for='priority' class='form'><?php echo t('all','Priority') ?></label>
 				<input class='integer' name='priority' type='text' id='priority' value='0' tabindex=102 />
 				<img src="images/icons/bullet_arrow_up.png" alt="+" onclick="javascript:changeInteger('priority','increment')" />
 				<img src="images/icons/bullet_arrow_down.png" alt="-" onclick="javascript:changeInteger('priority','decrement')"/>
@@ -151,7 +151,7 @@
 			<li class='fieldset'>
 				<br/>
 				<hr><br/>
-				<input type='submit' name='submit' value='<?php echo $l['buttons']['apply'] ?>' class='button' />
+				<input type='submit' name='submit' value='<?php echo t('buttons','apply') ?>' class='button' />
 			</li>
 
 

--- a/mng-rad-usergroup.php
+++ b/mng-rad-usergroup.php
@@ -48,11 +48,11 @@
 
 	<div id="contentnorightbar">
 	
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngradusergroup.php'] ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngradusergroup.php') ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >				
-			<?php echo $l['helpPage']['mngradusergroup'] ?>
+			<?php echo t('helpPage','mngradusergroup') ?>
 			<br/>
 		</div>	
 		<br/>

--- a/mng-search.php
+++ b/mng-search.php
@@ -62,7 +62,7 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['mngsearch.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','mngsearch.php'); ?>
 		:: <?php if (isset($username)) { echo $username; } ?><h144>+</h144></a></h2>
 		
 		<div id="helpPage" style="display:none;visibility:visible" >
@@ -141,12 +141,12 @@
 	echo "<thread> <tr>
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=id&orderType=$orderTypeNextPage\">
-		".$l['all']['ID']. "</a>
+		".t('all','ID'). "</a>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=Username&orderType=$orderTypeNextPage\">
-	 	".$l['all']['Username']."</a>
+	 	".t('all','Username')."</a>
 		</th>
 
 		<th scope='col'> 
@@ -168,15 +168,15 @@
                                         javascript:__displayTooltip();'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-edit.php?username=$row[0]\">
-	                                        {$l['Tooltip']['UserEdit']}</a>
+	                                        {t('Tooltip','UserEdit')}</a>
                                         &nbsp
 					<br/>
 					<a class=\"toolTip\" href=\"config-maint-test-user.php?username=$row[0]&password=$row[1]\">
-						{$l['all']['TestUser']}</a>
+						{t('all','TestUser')}</a>
 					&nbsp
 					<br/>
 					 <a class=\"toolTip\" href=\"acct-username.php?username=$row[0]\">
-						{$l['all']['Accounting']}</a>
+						{t('all','Accounting')}</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerUserInfo\">

--- a/mng-users.php
+++ b/mng-users.php
@@ -43,7 +43,7 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#"><?php echo $l['Intro']['mngmain.php'] ?></a></h2>
+		<h2 id="Intro"><a href="#"><?php echo t('Intro','mngmain.php') ?></a></h2>
 		<p>
 			<table><center><br/>
 			<img src="library/chart-mng-total-users.php" />

--- a/msg-error-permissions.php
+++ b/msg-error-permissions.php
@@ -40,11 +40,11 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['msgerrorpermissions.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','msgerrorpermissions.php'); ?>
 		<h144>+</h144></a></h2>
 		
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['msgerrorpermissions'] ?>
+			<?php echo t('helpPage','msgerrorpermissions') ?>
 			<br/>
 		</div>
 		<br/>

--- a/page-footer.php
+++ b/page-footer.php
@@ -22,7 +22,7 @@
 
 echo '
 
-<p><br/> '.$l['all']['copyright2'].'
+<p><br/> '.t('all','copyright2').'
 <br />
 </p>
 ';

--- a/rep-batch-details.php
+++ b/rep-batch-details.php
@@ -51,11 +51,11 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['repbatchdetails.php']; ?>
+		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','repbatchdetails.php'); ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['repbatchdetails'] ?>
+			<?php echo t('helpPage','repbatchdetails') ?>
 			<br/>
 		</div>
 
@@ -162,43 +162,43 @@
 		
 			<thread> <tr>
 			<th scope='col'> 
-			".$l['all']['BatchName']."
+			".t('all','BatchName')."
 			</th>
 	
 			<th scope='col'> 
-			".$l['all']['HotSpot']."
+			".t('all','HotSpot')."
 			</th>
 	
 			<th scope='col'> 
-			".$l['all']['BatchStatus']."
+			".t('all','BatchStatus')."
 			</th>
 			
 			<th scope='col'> 
-			".$l['all']['TotalUsers']."
+			".t('all','TotalUsers')."
 			</th>
 	
 			<th scope='col'> 
-			".$l['all']['ActiveUsers']."
+			".t('all','ActiveUsers')."
 			</th>
 	
 			<th scope='col'> 
-			".$l['all']['PlanName']."
+			".t('all','PlanName')."
 			</th>
 	
 			<th scope='col'> 
-			".$l['all']['PlanCost']."
+			".t('all','PlanCost')."
 			</th>
 	
 			<th scope='col'> 
-			".$l['all']['BatchCost']."
+			".t('all','BatchCost')."
 			</th>
 	
 			<th scope='col'> 
-			".$l['all']['CreationDate']."
+			".t('all','CreationDate')."
 			</th>
 	
 			<th scope='col'> 
-			".$l['all']['CreationBy']."
+			".t('all','CreationBy')."
 			</th>
 	
 			</tr> </thread>";
@@ -227,7 +227,7 @@
 						onClick='javascript:__displayTooltip();'
 						tooltipText='
 									<div id=\"divContainerUserInfo\">
-										<b>{$l['all']['batchDescription']}</b>:<br/><br/>
+										<b>{t('all','batchDescription')}</b>:<br/><br/>
 										{$row['batch_description']}
 									</div>
 									<br/>
@@ -412,15 +412,15 @@
 	echo "<thread> <tr>
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=id&orderType=$orderType\">
-		".$l['all']['BatchName']."</a>
+		".t('all','BatchName')."</a>
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['Username']."
+		".t('all','Username')."
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['StartTime']."
+		".t('all','StartTime')."
 		</th>
 
 		</tr> </thread>";

--- a/rep-batch-list.php
+++ b/rep-batch-list.php
@@ -47,11 +47,11 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['repbatchlist.php']; ?>
+		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','repbatchlist.php'); ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['repbatchlist'] ?>
+			<?php echo t('helpPage','repbatchlist') ?>
 			<br/>
 		</div>
 
@@ -198,45 +198,45 @@
 	echo "<thread> <tr>
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=id&orderType=$orderType\">
-		".$l['all']['BatchName']."</a>
+		".t('all','BatchName')."</a>
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['HotSpot']."
+		".t('all','HotSpot')."
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['BatchStatus']."
+		".t('all','BatchStatus')."
 		</th>
 		
 		<th scope='col'> 
-		".$l['all']['TotalUsers']."
+		".t('all','TotalUsers')."
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['ActiveUsers']."
+		".t('all','ActiveUsers')."
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['PlanName']."
+		".t('all','PlanName')."
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['PlanCost']."
+		".t('all','PlanCost')."
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['BatchCost']."
+		".t('all','BatchCost')."
 		</th>
 
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=creationdate&orderType=$orderType\">
-		".$l['all']['CreationDate']."</a>
+		".t('all','CreationDate')."</a>
 		</th>
 
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=creationby&orderType=$orderType\">
-		".$l['all']['CreationBy']."</a>
+		".t('all','CreationBy')."</a>
 		</th>
 
 		</tr> </thread>";
@@ -265,10 +265,10 @@
 					onClick='javascript:__displayTooltip();'
 					tooltipText='
 					<a class=\"toolTip\" href=\"rep-batch-details.php?batch_name={$row['batch_name']}\">
-						{$l['Tooltip']['BatchDetails']}</a>
+						{t('Tooltip','BatchDetails')}</a>
 						<br/><br/>
 								<div id=\"divContainerUserInfo\">
-									<b>{$l['all']['batchDescription']}</b>:<br/><br/>
+									<b>{t('all','batchDescription')}</b>:<br/><br/>
 									{$row['batch_description']}
 								</div>
 								<br/>

--- a/rep-batch.php
+++ b/rep-batch.php
@@ -37,11 +37,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['repbatch.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','repbatch.php'); ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['repbatch'] ?>
+			<?php echo t('helpPage','repbatch') ?>
 			<br/>
 		</div>
 		<br/>

--- a/rep-hb-dashboard.php
+++ b/rep-hb-dashboard.php
@@ -50,11 +50,11 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['rephbdashboard.php']; ?>
+		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','rephbdashboard.php'); ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['rephbdashboard'] ?>
+			<?php echo t('helpPage','rephbdashboard') ?>
 			<br/>
 		</div>
 
@@ -171,47 +171,47 @@
 	echo "<thread> <tr>
 		<th scope='col'> 
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=id&orderType=$orderType\">
-		".$l['all']['HotSpot']."</a>
+		".t('all','HotSpot')."</a>
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['Firmware']."
+		".t('all','Firmware')."
 		</th>
 		
 		<th scope='col'> 
-		".$l['all']['WanIface']."
+		".t('all','WanIface')."
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['LanIface']."
+		".t('all','LanIface')."
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['WifiIface']."
+		".t('all','WifiIface')."
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['Uptime']."
+		".t('all','Uptime')."
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['CPU']."
+		".t('all','CPU')."
 		</th>
 		
 		<th scope='col'> 
-		".$l['all']['Memfree']."
+		".t('all','Memfree')."
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['BandwidthUp']."
+		".t('all','BandwidthUp')."
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['BandwidthDown']."
+		".t('all','BandwidthDown')."
 		</th>
 
 		<th scope='col'> 
-		".$l['all']['CheckinTime']."
+		".t('all','CheckinTime')."
 		</th>
 
 		</tr> </thread>";
@@ -221,8 +221,8 @@
 		
 		
 		//$js = "javascript:ajaxGeneric('include/management/retUserInfo.php','retBandwidthInfo','divContainerUserInfo','username=".$row[0]."');";
-		$content =  '<a class="toolTip" href="mng-hs-edit.php?name='.$row['hotspotname'].'">'.$l['Tooltip']['HotspotEdit'].'</a>';
-		$content .= '<br/><br/><b>'.$l['all']['NASMAC'].':</b> '.$row['mac'];
+		$content =  '<a class="toolTip" href="mng-hs-edit.php?name='.$row['hotspotname'].'">'.t('Tooltip','HotspotEdit').'</a>';
+		$content .= '<br/><br/><b>'.t('all','NASMAC').':</b> '.$row['mac'];
 		$str = addToolTipBalloon(array(
 									'content' => $content,
 									'onClick' => '',
@@ -245,14 +245,14 @@
 			";
 					
 					
-		$content = '<b>'.$l['all']['WanIface'].":</b> ".$row['wan_iface'].
+		$content = '<b>'.t('all','WanIface').":</b> ".$row['wan_iface'].
 					"<br/>".
-					'<b>'.$l['all']['WanMAC'].":</b> ".$row['wan_mac'].
+					'<b>'.t('all','WanMAC').":</b> ".$row['wan_mac'].
 					"<br/>".
-					'<b>'.$l['all']['WanIP'].":</b> ".$row['wan_ip'].
+					'<b>'.t('all','WanIP').":</b> ".$row['wan_ip'].
 					"<br/>".
-					'<b>'.$l['all']['WanGateway'].":</b> ".$row['wan_ip'];
-		$value = '<b>'.$l['all']['WanIP'].":</b> ".$row['wan_ip'];
+					'<b>'.t('all','WanGateway').":</b> ".$row['wan_ip'];
+		$value = '<b>'.t('all','WanIP').":</b> ".$row['wan_ip'];
 		$str = addToolTipBalloon(array(
 									'content' => $content,
 									'onClick' => '',
@@ -265,12 +265,12 @@
 				
 		
 		
-		$content = $l['all']['LanIface'].":</b> ".$row['lan_iface'].
+		$content = t('all','LanIface').":</b> ".$row['lan_iface'].
 						"<br/><b>".
-					$l['all']['LanMAC'].":</b> ".$row['lan_mac'].
+					t('all','LanMAC').":</b> ".$row['lan_mac'].
 						"<br/><b>".
-					$l['all']['LanIP'].":</b> ".$row['lan_ip'];
-		$value = '<b>'.$l['all']['LanIP'].":</b> ".$row['lan_ip'];
+					t('all','LanIP').":</b> ".$row['lan_ip'];
+		$value = '<b>'.t('all','LanIP').":</b> ".$row['lan_ip'];
 		$str = addToolTipBalloon(array(
 									'content' => $content,
 									'onClick' => '',
@@ -283,20 +283,20 @@
 				
 		
 
-		$content = $l['all']['WifiIface'].":</b> ".$row['wifi_iface'].
+		$content = t('all','WifiIface').":</b> ".$row['wifi_iface'].
 						"<br/><b>".
-					$l['all']['WifiMAC'].":</b> ".$row['wifi_mac'].
+					t('all','WifiMAC').":</b> ".$row['wifi_mac'].
 						"<br/><b>".
-					$l['all']['WifiIP'].":</b> ".$row['wifi_ip'].
+					t('all','WifiIP').":</b> ".$row['wifi_ip'].
 						"<br/><b>".
-					$l['all']['WifiSSID'].":</b> ".$row['wifi_ssid'].
+					t('all','WifiSSID').":</b> ".$row['wifi_ssid'].
 						"<br/><b>".
-					$l['all']['WifiKey'].":</b> ".$row['wifi_key'].
+					t('all','WifiKey').":</b> ".$row['wifi_key'].
 						"<br/><b>".
-					$l['all']['WifiChannel'].":</b> ".$row['wifi_channel'];
-		$value = '<b>'.$l['all']['WifiSSID'].":</b> ".$row['wifi_ssid'].
+					t('all','WifiChannel').":</b> ".$row['wifi_channel'];
+		$value = '<b>'.t('all','WifiSSID').":</b> ".$row['wifi_ssid'].
 					"<br/><b>".
-					$l['all']['WifiKey'].":</b> ".$row['wifi_key'];
+					t('all','WifiKey').":</b> ".$row['wifi_key'];
 		$str = addToolTipBalloon(array(
 									'content' => $content,
 									'onClick' => '',

--- a/rep-hb.php
+++ b/rep-hb.php
@@ -37,11 +37,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['rephb.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','rephb.php'); ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['rephb'] ?>
+			<?php echo t('helpPage','rephb') ?>
 			<br/>
 		</div>
 		<br/>

--- a/rep-history.php
+++ b/rep-history.php
@@ -48,11 +48,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['rephistory.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','rephistory.php'); ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['rephistory'] ?>
+			<?php echo t('helpPage','rephistory') ?>
 			<br/>
 		</div>
 		<br/>
@@ -116,32 +116,32 @@
         echo "<thread> <tr>
                 <th scope='col'>
                 <a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=section&orderType=$orderTypeNextPage\">
-		".$l['all']['Section']." 
+		".t('all','Section')." 
 		</th>
 
                 <th scope='col'>
                 <a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=item&orderType=$orderTypeNextPage\">
-		".$l['all']['Item']." 
+		".t('all','Item')." 
 		</th>
 
                 <th scope='col'>
                 <a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=creationdate&orderType=$orderTypeNextPage\">
-		".$l['all']['CreationDate']." 
+		".t('all','CreationDate')." 
 		</th>
 
                 <th scope='col'>
                 <a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=creationby&orderType=$orderTypeNextPage\">
-		".$l['all']['CreationBy']." 
+		".t('all','CreationBy')." 
 		</th>
 
                 <th scope='col'>
                 <a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=updatedate&orderType=$orderTypeNextPage\">
-		".$l['all']['UpdateDate']." 
+		".t('all','UpdateDate')." 
 		</th>
 
                 <th scope='col'>
                 <a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?orderBy=updateby&orderType=$orderTypeNextPage\">
-		".$l['all']['UpdateBy']." 
+		".t('all','UpdateBy')." 
 		</th>
         </tr> </thread>";
 

--- a/rep-lastconnect.php
+++ b/rep-lastconnect.php
@@ -48,11 +48,11 @@
 ?>		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['replastconnect.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','replastconnect.php'); ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['replastconnect'] ?>
+			<?php echo t('helpPage','replastconnect') ?>
 			<br/>
 		</div>
 		<br/>
@@ -169,22 +169,22 @@
         echo "<thread> <tr>
                 <th scope='col'>
                 <a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?usernameLastConnect=$usernameLastConnect&startdate=$startdate&enddate=$enddate&orderBy=".$tableSetting['postauth']['user']."&orderType=$orderTypeNextPage\">
-		".$l['all']['Username']." 
+		".t('all','Username')." 
 		</th>
 
                 <th scope='col'>
                 <a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?usernameLastConnect=$usernameLastConnect&startdate=$startdate&enddate=$enddate&orderBy=pass&orderType=$orderTypeNextPage\">
-		".$l['all']['Password']." 
+		".t('all','Password')." 
 		</th>
 
                 <th scope='col'>
                 <a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?usernameLastConnect=$usernameLastConnect&startdate=$startdate&enddate=$enddate&orderBy=".$tableSetting['postauth']['date']."&orderType=$orderTypeNextPage\">
-		".$l['all']['StartTime']." 
+		".t('all','StartTime')." 
 		</th>
 
                 <th scope='col'>
                 <a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?usernameLastConnect=$usernameLastConnect&startdate=$startdate&enddate=$enddate&orderBy=reply&orderType=$orderTypeNextPage\">
-		".$l['all']['RADIUSReply']." 
+		".t('all','RADIUSReply')." 
 		</th>
 
         </tr> </thread>";

--- a/rep-logs-boot.php
+++ b/rep-logs-boot.php
@@ -43,13 +43,13 @@
 ?>	
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['replogsboot.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','replogsboot.php'); ?>
                 :: <?php if (isset($bootLineCount)) { echo $bootLineCount . " Lines Count "; } ?>
                    <?php if (isset($bootFilter)) { echo " with filter set to " . $bootFilter; } ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['replogsboot'] ?>
+			<?php echo t('helpPage','replogsboot') ?>
 			<br/>
 		</div>
 		<br/>

--- a/rep-logs-daloradius.php
+++ b/rep-logs-daloradius.php
@@ -44,13 +44,13 @@
 
 	<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['replogsdaloradius.php']; ?>
+		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','replogsdaloradius.php'); ?>
 		:: <?php if (isset($daloradiusLineCount)) { echo $daloradiusLineCount . " Lines Count "; } ?>
 		   <?php if (isset($daloradiusFilter)) { echo " with filter set to " . $daloradiusFilter; } ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['replogsdaloradius'] ?>
+			<?php echo t('helpPage','replogsdaloradius') ?>
 			<br/>
 		</div>
 

--- a/rep-logs-radius.php
+++ b/rep-logs-radius.php
@@ -46,13 +46,13 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['replogsradius.php']; ?>
+		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','replogsradius.php'); ?>
                 :: <?php if (isset($radiusLineCount)) { echo $radiusLineCount . " Lines Count "; } ?>
                    <?php if (isset($radiusFilter)) { echo " with radiusFilter set to " . $radiusFilter; } ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['replogsradius'] ?>
+			<?php echo t('helpPage','replogsradius') ?>
 			<br/>
 		</div>
 		<br/>

--- a/rep-logs-system.php
+++ b/rep-logs-system.php
@@ -42,13 +42,13 @@
 ?>	
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['replogssystem.php']; ?>
+		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','replogssystem.php'); ?>
                 :: <?php if (isset($systemLineCount)) { echo $systemLineCount . " Lines Count "; } ?>
                    <?php if (isset($systemFilter)) { echo " with filter set to " . $systemFilter; } ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['replogssystem'] ?>
+			<?php echo t('helpPage','replogssystem') ?>
 			<br/>
 		</div>
 		<br/>

--- a/rep-logs.php
+++ b/rep-logs.php
@@ -37,11 +37,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['replogs.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','replogs.php'); ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['replogs'] ?>
+			<?php echo t('helpPage','replogs') ?>
 			<br/>
 		</div>
 		<br/>

--- a/rep-main.php
+++ b/rep-main.php
@@ -37,11 +37,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['repmain.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','repmain.php'); ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['repmain'] ?>	
+			<?php echo t('helpPage','repmain') ?>	
 			<br/>
 		</div>				
 

--- a/rep-newusers.php
+++ b/rep-newusers.php
@@ -67,11 +67,11 @@
 
                 <div id="contentnorightbar">
                 
-                                <h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['repnewusers.php']; ?>
+                                <h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','repnewusers.php'); ?>
                                 <h144>+</h144></a></h2>
                                 
                 <div id="helpPage" style="display:none;visibility:visible" >
-                        <?php echo $l['helpPage']['repnewusers']; ?>
+                        <?php echo t('helpPage','repnewusers'); ?>
                         <br/>
                 </div>
                 <br/>
@@ -131,11 +131,11 @@
 
         echo "<thread> <tr>
                 <th scope='col'>
-                ".$l['all']['Month']. "
+                ".t('all','Month'). "
                 </th>
 
                 <th scope='col'>
-                        ".$l['all']['Users']."
+                        ".t('all','Users')."
                 </th>
 
         </tr> </thread>";

--- a/rep-online.php
+++ b/rep-online.php
@@ -68,11 +68,11 @@
 
 		<div id="contentnorightbar">
 		
-				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['reponline.php']; ?>
+				<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','reponline.php'); ?>
 				<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['reponline']; ?>
+			<?php echo t('helpPage','reponline'); ?>
 			<br/>
 		</div>
 		<br/>
@@ -152,7 +152,7 @@
 
                                 <a class=\"table\" href=\"javascript:SetChecked(0,'clearSessionsUsers[]','usersonline')\">None</a>
                         <br/>
-                                <input class='button' type='button' value='".$l['button']['ClearSessions']."' onClick='javascript:removeCheckbox(\"usersonline\",\"mng-del.php\")' />
+                                <input class='button' type='button' value='".t('button','ClearSessions')."' onClick='javascript:removeCheckbox(\"usersonline\",\"mng-del.php\")' />
                                 <input class='button' type='button' value='CSV Export'
                                         onClick=\"javascript:window.location.href='include/management/fileExport.php?reportFormat=csv'\"
                                         />
@@ -175,37 +175,37 @@
 	echo "<thread> <tr>
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?usernameOnline=$usernameOnline&orderBy=username&orderType=$orderTypeNextPage\">
-		".$l['all']['Username']. "</a>
+		".t('all','Username'). "</a>
 		</th>
 
 		<th scope='col'>
-			".$l['all']['Name']."
+			".t('all','Name')."
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?usernameOnline=$usernameOnline&orderBy=framedipaddress&orderType=$orderTypeNextPage\">
-		".$l['all']['IPAddress']."</a>
+		".t('all','IPAddress')."</a>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?usernameOnline=$usernameOnline&orderBy=acctstarttime&orderType=$orderTypeNextPage\">
-		".$l['all']['StartTime']."</a>
+		".t('all','StartTime')."</a>
 		</th>
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?usernameOnline=$usernameOnline&orderBy=acctsessiontime&orderType=$orderTypeNextPage\">
-		".$l['all']['TotalTime']."</a>
+		".t('all','TotalTime')."</a>
 		</th>
 
 
 		<th scope='col'>
 		<a title='Sort' class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?usernameOnline=$usernameOnline&orderBy=NASshortname&orderType=$orderTypeNextPage\">
-			".$l['all']['HotSpot']." / 
-			".$l['all']['NasShortname']."
+			".t('all','HotSpot')." / 
+			".t('all','NasShortname')."
 		</th>
 
 		<th scope='col'>
-			".$l['all']['TotalTraffic']."
+			".t('all','TotalTraffic')."
 		</th>		
 		
 
@@ -236,10 +236,10 @@
 					onclick=\"javascript:__displayTooltip();\" 
 					tooltipText=\"
 						<a class='toolTip' href='mng-edit.php?username=$username'>".
-							$l['Tooltip']['UserEdit']."</a>
+							t('Tooltip','UserEdit')."</a>
 						&nbsp;
 						<a class='toolTip' href='config-maint-disconnect-user.php?username=$username&nasaddr=$nasip&customattributes=Acct-Session-Id=$acctsessionid,Framed-IP-Address=$ip'>".
-							$l['all']['Disconnect']."</a>
+							t('all','Disconnect')."</a>
 						<br/>\"
 					>$username</a>
 					</td>
@@ -248,7 +248,7 @@
 				<td> $start </td>
 				<td> $totalTime </td>
 				<td> $hotspot $nasshortname </td>
-				<td> ".$l['all']['Upload'].": $upload <br/> ".$l['all']['Download'].": $download <br/> ".$l['all']['TotalTraffic'].": <b>$traffic</b> </td>
+				<td> ".t('all','Upload').": $upload <br/> ".t('all','Download').": $download <br/> ".t('all','TotalTraffic').": <b>$traffic</b> </td>
 		</tr>";
 	}
 

--- a/rep-stat-server.php
+++ b/rep-stat-server.php
@@ -43,11 +43,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['repstatserver.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','repstatserver.php'); ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['repstatserver'] ?>
+			<?php echo t('helpPage','repstatserver') ?>
 			<br/>
 		</div>
 		<br/>

--- a/rep-stat-services.php
+++ b/rep-stat-services.php
@@ -45,11 +45,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['repstatradius.php']; ?>
+		<h2 id="Intro"><a href="#"  onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','repstatradius.php'); ?>
 		<h144>+</h144></a></h2>
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['repstatradius'] ?>
+			<?php echo t('helpPage','repstatradius') ?>
 			<br/>
 		</div>
 		<br/>

--- a/rep-status.php
+++ b/rep-status.php
@@ -37,11 +37,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['repstatus.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','repstatus.php'); ?>
 		<h144>+</h144></a></h2>
 			
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['repstatus'] ?>
+			<?php echo t('helpPage','repstatus') ?>
 			<br/>
 		</div>	
 		<br/>

--- a/rep-topusers.php
+++ b/rep-topusers.php
@@ -60,12 +60,12 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['reptopusers.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','reptopusers.php'); ?>
 		<h144>+</h144></a></h2></a></h2>
 				
 
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['reptopusers']." ".$orderBy ?>
+			<?php echo t('helpPage','reptopusers')." ".$orderBy ?>
 			<br/>
 		</div>
 		<br/>
@@ -104,7 +104,7 @@
 
 					<thead>
 							<tr>
-							<th colspan='10'>".$l['all']['Records']."</th>
+							<th colspan='10'>".t('all','Records')."</th>
 							</tr>
 					</thead>
 			";
@@ -120,47 +120,47 @@
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?limit=$limit&orderBy=username&orderType=$orderType&username=$username&startdate=$startdate&enddate=$enddate\">
-		".$l['all']['Username']." </a>
+		".t('all','Username')." </a>
 		</th>
 		<th scope='col'>
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?limit=$limit&orderBy=framedipaddress&orderType=$orderType&username=$username&startdate=$startdate&enddate=$enddate\">
-		".$l['all']['IPAddress']."</a>
+		".t('all','IPAddress')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?limit=$limit&orderBy=acctstarttime&orderType=$orderType&username=$username&startdate=$startdate&enddate=$enddate\">
-		".$l['all']['StartTime']."</a>
+		".t('all','StartTime')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?limit=$limit&orderBy=acctstoptime&orderType=$orderType&username=$username&startdate=$startdate&enddate=$enddate\">
-		".$l['all']['StopTime']."</a>
+		".t('all','StopTime')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?limit=$limit&orderBy=Time&orderType=$orderType&username=$username&startdate=$startdate&enddate=$enddate\">
-		".$l['all']['TotalTime']."</a>
+		".t('all','TotalTime')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?limit=$limit&orderBy=Upload&orderType=$orderType&username=$username&startdate=$startdate&enddate=$enddate\">
-		".$l['all']['Upload']." (".$l['all']['Bytes'].")</a>
+		".t('all','Upload')." (".t('all','Bytes').")</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?limit=$limit&orderBy=Download&orderType=$orderType&username=$username&startdate=$startdate&enddate=$enddate\">
-		".$l['all']['Download']." (".$l['all']['Bytes'].")</a>
+		".t('all','Download')." (".t('all','Bytes').")</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?limit=$limit&orderBy=acctterminatecause&orderType=$orderType&username=$username&startdate=$startdate&enddate=$enddate\">
-		".$l['all']['Termination']."</a>
+		".t('all','Termination')."</a>
 		</th>
 		<th scope='col'> 
 		<br/>
 		<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?limit=$limit&orderBy=nasipaddress&orderType=$orderType&username=$username&startdate=$startdate&enddate=$enddate\">
-		".$l['all']['NASIPAddress']."</a>
+		".t('all','NASIPAddress')."</a>
 		</th>
 		</tr> </thread>";
 		

--- a/rep-username.php
+++ b/rep-username.php
@@ -50,11 +50,11 @@
 		
 		<div id="contentnorightbar">
 		
-		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo $l['Intro']['repusername.php']; ?>
+		<h2 id="Intro"><a href="#" onclick="javascript:toggleShowDiv('helpPage')"><?php echo t('Intro','repusername.php'); ?>
 		<h144>+</h144></a></h2>
 				
 		<div id="helpPage" style="display:none;visibility:visible" >
-			<?php echo $l['helpPage']['repusername']." ".$username ?>
+			<?php echo t('helpPage','repusername')." ".$username ?>
 			<br/>
 		</div>
 		<br/>
@@ -78,33 +78,33 @@
         echo "
                         <thead>
                                 <tr>
-                                <th colspan='10'>".$l['captions']['radcheckrecords']."</th>
+                                <th colspan='10'>".t('captions','radcheckrecords')."</th>
                                 </tr>
                         </thead>
                 ";
 
         echo "<thread> <tr>
-                        <th scope='col'> ".$l['all']['ID']."
+                        <th scope='col'> ".t('all','ID')."
 						<br/>
 						<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=id&orderType=asc\"> > </a>
 						<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=id&orderType=desc\"> < </a>
 						</th>
-                        <th scope='col'> ".$l['all']['Username']."
+                        <th scope='col'> ".t('all','Username')."
 						<br/>
 						<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=username&orderType=asc\"> > </a>
 						<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=username&orderType=desc\"> < </a>
 						</th>
-                        <th scope='col'> ".$l['all']['Attribute']."
+                        <th scope='col'> ".t('all','Attribute')."
 						<br/>
 						<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=attribute&orderType=asc\"> > </a>
 						<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=attribute&orderType=desc\"> < </a>
 						</th>
-                        <th scope='col'> ".$l['all']['Value']."
+                        <th scope='col'> ".t('all','Value')."
 						<br/>
 						<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=value&orderType=asc\"> > </a>
 						<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=value&orderType=desc\"> < </a>
 						</th>
-                        <th scope='col'> ".$l['all']['Action']." </th>
+                        <th scope='col'> ".t('all','Action')." </th>
                 </tr> </thread>";
 	while($row = $res->fetchRow()) {
                 echo "<tr>
@@ -112,8 +112,8 @@
                         <td> $row[1] </td>
                         <td> $row[2] </td>
                         <td> $row[4] </td>
-                        <td> <a href='mng-edit.php?username=$row[1]'> ".$l['all']['edit']." </a> 
-	                     <a href='mng-del.php?username=$row[1]'> ".$l['all']['del']." </a>
+                        <td> <a href='mng-edit.php?username=$row[1]'> ".t('all','edit')." </a> 
+	                     <a href='mng-del.php?username=$row[1]'> ".t('all','del')." </a>
 			     </td>
                 </tr>";
         }
@@ -132,41 +132,41 @@
         echo "
                         <thead>
                                 <tr>
-                                <th colspan='10'>".$l['captions']['radreplyrecords']."</th>
+                                <th colspan='10'>".t('captions','radreplyrecords')."</th>
                                 </tr>
                         </thead>
                 ";
 
         echo "<thread> <tr>                        
-                        <th scope='col'> ".$l['all']['ID']."
+                        <th scope='col'> ".t('all','ID')."
 						<br/>
 						<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=id&orderType=asc\"> > </a>
 						<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=id&orderType=desc\"> < </a>
 						</th>
-                        <th scope='col'> ".$l['all']['Username']."
+                        <th scope='col'> ".t('all','Username')."
 						<br/>
 						<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=username&orderType=asc\"> > </a>
 						<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=username&orderType=desc\"> < </a>
 						</th>
-                        <th scope='col'> ".$l['all']['Attribute']."
+                        <th scope='col'> ".t('all','Attribute')."
 						<br/>
 						<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=attribute&orderType=asc\"> > </a>
 						<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=attribute&orderType=desc\"> < </a>
 						</th>
-                        <th scope='col'> ".$l['all']['Value']."
+                        <th scope='col'> ".t('all','Value')."
 						<br/>
 						<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=value&orderType=asc\"> > </a>
 						<a class='novisit' href=\"" . $_SERVER['PHP_SELF'] . "?username=$username&orderBy=value&orderType=desc\"> < </a>
 						</th>
-                        <th scope='col'> ".$l['all']['Action']." </th>                </tr> </thread>";
+                        <th scope='col'> ".t('all','Action')." </th>                </tr> </thread>";
 	while($row = $res->fetchRow()) {
                 echo "<tr>
                         <td> $row[0] </td>
                         <td> $row[1] </td>
                         <td> $row[2] </td>
                         <td> $row[4] </td>
-                        <td> <a href='mng-edit.php?username=$row[1]'> ".$l['all']['edit']." </a> 
-	                     <a href='mng-del.php?username=$row[1]'> ".$l['all']['del']." </a>
+                        <td> <a href='mng-edit.php?username=$row[1]'> ".t('all','edit')." </a> 
+	                     <a href='mng-del.php?username=$row[1]'> ".t('all','del')." </a>
 			     </td>
                 </tr>";
         }

--- a/update.php
+++ b/update.php
@@ -2003,7 +2003,7 @@ if (isset($_POST['submit'])) {
 
 <?php
 echo "
-	".$l['all']['copyright2']."
+	".t('all','copyright2')."
 	<br />
 	</p>
 ";


### PR DESCRIPTION
Hi @lirantal 

In order to avoid more issues related with language translations, as in #66, now solved with #68, I have done the following major changes, included in this PR:

- Create a translation function, located in both files `lang/main.php` and `daloradius-users/lang/main.php`, that returns the appropiate translated text on success, or a text indicating translation error on failure (no more `PHP Notices`).
- Locate every PHP file using the global array `$l` directly (`grep` is your friend, see attached file).
- Modify the source of these PHP files in order to use the new translation function (using a PHP script, I'm not totally crazy - yet).

All seems running ok after the changes were applied.

Please, consider this PR for merging.

[files_to_change.txt](https://github.com/lirantal/daloradius/files/2848227/files_to_change.txt)
