### PR TITLE
Autocomplete fix

### DIFF
--- a/include/management/autocomplete.php
+++ b/include/management/autocomplete.php
@@ -31,11 +31,15 @@
     {
         $autoComplete = true; # Set boolean for throughout the page
         echo "
-		<link rel=\"stylesheet\" href=\"css/auto-complete.css\" media=\"screen\" type=\"text/css\">
 		<script type=\"text/javascript\" src=\"library/javascript/ajax.js\"></script>
-                <script type=\"text/javascript\" src=\"library/javascript/dhtmlSuite-common.js\"></script>
-                <script type=\"text/javascript\" src=\"library/javascript/auto-complete.js\"></script>
-                ";
+		<script type=\"text/javascript\" src=\"library/javascript/dhtmlSuite-common.js\"></script>
+		<script type=\"text/javascript\" src=\"library/javascript/auto-complete.js\"></script>
+		<script>
+			var DHTML_SUITE_THEME_FOLDER = './';
+			var DHTML_SUITE_JS_FOLDER = 'library/javascript/';
+			var DHTML_SUITE_THEME = '.';
+		</script>
+        ";
     }
 
 

--- a/mng-batch-add.php
+++ b/mng-batch-add.php
@@ -522,8 +522,6 @@
 <title>daloRADIUS</title>
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <link rel="stylesheet" href="css/1.css" type="text/css" media="screen,projection" />
-<link rel="stylesheet" href="css/auto-complete.css" media="screen" type="text/css">
-
 <link rel="stylesheet" type="text/css" href="library/js_date/datechooser.css">
 <!--[if lte IE 6.5]>
 <link rel="stylesheet" type="text/css" href="library/js_date/select-free.css"/>

--- a/mng-batch-list.php
+++ b/mng-batch-list.php
@@ -44,8 +44,6 @@
 <title>daloRADIUS</title>
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <link rel="stylesheet" href="css/1.css" type="text/css" media="screen,projection" />
-<link rel="stylesheet" href="css/auto-complete.css" media="screen" type="text/css">
-
 <link rel="stylesheet" type="text/css" href="library/js_date/datechooser.css">
 <!--[if lte IE 6.5]>
 <link rel="stylesheet" type="text/css" href="library/js_date/select-free.css"/>

--- a/mng-edit.php
+++ b/mng-edit.php
@@ -668,8 +668,6 @@
 <title>daloRADIUS</title>
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <link rel="stylesheet" href="css/1.css" type="text/css" media="screen,projection" />
-<link rel="stylesheet" href="css/auto-complete.css" media="screen" type="text/css">
-
 <link rel="stylesheet" type="text/css" href="library/js_date/datechooser.css">
 <!--[if lte IE 6.5]>
 <link rel="stylesheet" type="text/css" href="library/js_date/select-free.css"/>

--- a/mng-new.php
+++ b/mng-new.php
@@ -523,7 +523,6 @@
 <title>daloRADIUS</title>
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <link rel="stylesheet" href="css/1.css" type="text/css" media="screen,projection" />
-<link rel="stylesheet" href="css/auto-complete.css" media="screen" type="text/css">
 <link rel="stylesheet" type="text/css" href="library/js_date/datechooser.css">
 <!--[if lte IE 6.5]>
 <link rel="stylesheet" type="text/css" href="library/js_date/select-free.css"/>

--- a/mng-rad-groupcheck-new.php
+++ b/mng-rad-groupcheck-new.php
@@ -129,7 +129,6 @@
 <title>daloRADIUS</title>
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <link rel="stylesheet" href="css/1.css" type="text/css" media="screen,projection" />
-<link rel="stylesheet" href="css/auto-complete.css" media="screen" type="text/css">
 <link rel="stylesheet" type="text/css" href="library/js_date/datechooser.css">
 <!--[if lte IE 6.5]>
 <link rel="stylesheet" type="text/css" href="library/js_date/select-free.css"/>

--- a/mng-rad-groupreply-new.php
+++ b/mng-rad-groupreply-new.php
@@ -128,7 +128,6 @@
 <title>daloRADIUS</title>
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <link rel="stylesheet" href="css/1.css" type="text/css" media="screen,projection" />
-<link rel="stylesheet" href="css/auto-complete.css" media="screen" type="text/css">
 <link rel="stylesheet" type="text/css" href="library/js_date/datechooser.css">
 <!--[if lte IE 6.5]>
 <link rel="stylesheet" type="text/css" href="library/js_date/select-free.css"/>

--- a/mng-rad-profiles-edit.php
+++ b/mng-rad-profiles-edit.php
@@ -144,7 +144,6 @@
 <title>daloRADIUS</title>
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <link rel="stylesheet" href="css/1.css" type="text/css" media="screen,projection" />
-<link rel="stylesheet" href="css/auto-complete.css" media="screen" type="text/css">
 </head>
 
 <?php

--- a/mng-rad-profiles-new.php
+++ b/mng-rad-profiles-new.php
@@ -116,7 +116,6 @@
 <title>daloRADIUS</title>
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <link rel="stylesheet" href="css/1.css" type="text/css" media="screen,projection" />
-<link rel="stylesheet" href="css/auto-complete.css" media="screen" type="text/css">
 </head>
  
 <?php


### PR DESCRIPTION
It includes:

- Initialize DHTML Suite "properly" to let it load the file `auto-complete.css` by itself, avoiding load errors. _(1)_
- Delete direct links to the file `auto-complete.css`.

_(1)_
[DHTML Suite](http://www.dhtmlgoodies.com/index.html?dhtml-suite-page=dhtmlSuite-configuration-variables)

> Themes
> Which theme to use in the DHTML Suite is controlled by a variable named DHTML_SUITE_THEME. The default value of this variable is "blue". This value will always correspond with the name of one of the sub folders inside the "themes" folder:
> 
> Example: "blue", "gray" or "light-cyan".
> 
> If you want to use a different theme, you need to change this variable before creating any DHTMLSuite objects.
> 
> Path to the "themes" folder
> The DHTML_SUITE_THEME_FOLDER variable is used to specify the path from your html files to the "themes" folder. The default value of this variable is "../themes/" since that's the path from the files inside the "demos" folder.
> 
> Path to js/separateFiles
> The DHTMLSuite.include function uses the variable DHTML_SUITE_JS_FOLDER when it includes Javascript files dynamically. This variable specifies the path from your html files to the "separateFiles" folder which is inside the "js" folder. The default value of this variable is "../js/separateFiles/".
> 
> Creating your own configuration file
> To set up your own environment, you can create a configuration file which you include in the <HEAD> section of all your "DHTML Suite" pages. This is example of the content of this file:
> 
> var DHTML_SUITE_THEME_FOLDER = 'themes/';
> var DHTML_SUITE_JS_FOLDER = 'js/separateFiles/';
> var DHTML_SUITE_THEME = 'gray';
> 
> And you will include it in a line like this:
> 
> <script type="text/javascript" src="folderName/dhtmlSuite-config.js"></script>