### PR TITLE
Right use of href and onclick attributes in <a> tags in tooltips.

### DIFF
--- a/daloradius-users/include/management/pages_common.php
+++ b/daloradius-users/include/management/pages_common.php
@@ -121,19 +121,20 @@ function time2str($time) {
  */
 function addToolTipBalloon($view) {
 
-
 	if ($view['divId'])
 		$viewId = '<div id="'.$view['divId'].'">Loading...</div>';
 	else
 		$viewId = '';
-
-	$str = "<a class='tablenovisit' href='javascript:return;'
+	
+	$sep = ($view['onClick'] != '' && substr($view['onClick'], -1) != ';' ? ';' : '');
+	
+	$str = "<a class='tablenovisit' href='#'
+				onClick=\"".$view['onClick'].$sep."return false;\"
                 tooltipText='".$view['content']."
 							<br/><br/>
 							$viewId
 							<br/>'
 			>".$view['value']."</a>";
-
 
 	return $str;
 }

--- a/include/management/pages_common.php
+++ b/include/management/pages_common.php
@@ -336,19 +336,20 @@ function getPrevBillingDate($planRecurringBillingSchedule = "Fixed", $planRecurr
  */
 function addToolTipBalloon($view) {
 	
-	
 	if ($view['divId'])
 		$viewId = '<div id="'.$view['divId'].'">Loading...</div>';
 	else
 		$viewId = '';
-		
-	$str = "<a class='tablenovisit' href='javascript:return;'
+	
+	$sep = ($view['onClick'] != '' && substr($view['onClick'], -1) != ';' ? ';' : '');
+	
+	$str = "<a class='tablenovisit' href='#'
+				onClick=\"".$view['onClick'].$sep."return false;\"
                 tooltipText='".$view['content']."
 							<br/><br/>
 							$viewId
 							<br/>'
 			>".$view['value']."</a>";
-
 
 	return $str;
 }


### PR DESCRIPTION
Use:

`<a href="#" onclick="javascript:func();return false;">...</a>`

instead of:

`<a href="javascript:return;" onclick="javascript:func();>...</a>`