### PR TITLE
Right use of translation function inside double-quoted strings.

### DIFF
--- a/acct-active.php
+++ b/acct-active.php
@@ -152,7 +152,7 @@
                                 onClick='javascript:ajaxGeneric(\"include/management/retUserInfo.php\",\"retBandwidthInfo\",\"divContainerUserInfo\",\"username=$row[0]\");'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-edit.php?username=$row[0]\">
-                                                {t('Tooltip','UserEdit')}</a>
+                                                ".t('Tooltip','UserEdit')."</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerUserInfo\">

--- a/acct-all.php
+++ b/acct-all.php
@@ -174,10 +174,10 @@
                                 onClick='javascript:ajaxGeneric(\"include/management/retHotspotInfo.php\",\"retHotspotGeneralStat\",\"divContainerHotspotInfo\",\"hotspot=$row[1]\");'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-hs-edit.php?name=$row[1]\">
-						{t('Tooltip','HotspotEdit')}</a>
+						".t('Tooltip','HotspotEdit')."</a>
 					&nbsp;
                                         <a class=\"toolTip\" href=\"acct-hotspot-compare.php?\">
-	                                        {t('all','Compare')}</a>
+	                                        ".t('all','Compare')."</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerHotspotInfo\">
@@ -192,7 +192,7 @@
                                 onClick='javascript:ajaxGeneric(\"include/management/retUserInfo.php\",\"retBandwidthInfo\",\"divContainerUserInfo\",\"username=$row[2]\");'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-edit.php?username=$row[2]\">
-	                                        {t('Tooltip','UserEdit')}</a>
+	                                        ".t('Tooltip','UserEdit')."</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerUserInfo\">

--- a/acct-date.php
+++ b/acct-date.php
@@ -208,10 +208,10 @@
                                 onClick='javascript:ajaxGeneric(\"include/management/retHotspotInfo.php\",\"retHotspotGeneralStat\",\"divContainerHotspotInfo\",\"hotspot=$row[1]\");'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-hs-edit.php?name=$row[1]\">
-                                                {t('Tooltip','HotspotEdit')}</a>
+                                                ".t('Tooltip','HotspotEdit')."</a>
                                         &nbsp;
                                         <a class=\"toolTip\" href=\"acct-hotspot-compare.php?\">
-                                                {t('all','Compare')}</a>
+                                                ".t('all','Compare')."</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerHotspotInfo\">
@@ -225,7 +225,7 @@
                                 onClick='javascript:ajaxGeneric(\"include/management/retUserInfo.php\",\"retBandwidthInfo\",\"divContainerUserInfo\",\"username=$row[2]\");'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-edit.php?username=$row[2]\">
-	                                        {t('Tooltip','UserEdit')}</a>
+	                                        ".t('Tooltip','UserEdit')."</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerUserInfo\">

--- a/acct-hotspot-accounting.php
+++ b/acct-hotspot-accounting.php
@@ -186,7 +186,7 @@
                                 onClick='javascript:ajaxGeneric(\"include/management/retUserInfo.php\",\"retBandwidthInfo\",\"divContainerUserInfo\",\"username=$row[2]\");'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-edit.php?username=$row[2]\">
-                                                {t('Tooltip','UserEdit')}</a>
+                                                ".t('Tooltip','UserEdit')."</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerUserInfo\">

--- a/acct-ipaddress.php
+++ b/acct-ipaddress.php
@@ -183,10 +183,10 @@
                                 onClick='javascript:ajaxGeneric(\"include/management/retHotspotInfo.php\",\"retHotspotGeneralStat\",\"divContainerHotspotInfo\",\"hotspot=$row[1]\");'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-hs-edit.php?name=$row[1]\">
-                                                {t('Tooltip','HotspotEdit')}</a>
+                                                ".t('Tooltip','HotspotEdit')."</a>
                                         &nbsp;
                                         <a class=\"toolTip\" href=\"acct-hotspot-compare.php?\">
-                                                {t('all','Compare')}</a>
+                                                ".t('all','Compare')."</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerHotspotInfo\">
@@ -200,7 +200,7 @@
                                 onClick='javascript:ajaxGeneric(\"include/management/retUserInfo.php\",\"retBandwidthInfo\",\"divContainerUserInfo\",\"username=$row[2]\");'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-edit.php?username=$row[2]\">
-	                                        {t('Tooltip','UserEdit')}</a>
+	                                        ".t('Tooltip','UserEdit')."</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerUserInfo\">

--- a/acct-nasipaddress.php
+++ b/acct-nasipaddress.php
@@ -187,10 +187,10 @@
                                 onClick='javascript:ajaxGeneric(\"include/management/retHotspotInfo.php\",\"retHotspotGeneralStat\",\"divContainerHotspotInfo\",\"hotspot=$row[1]\");'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-hs-edit.php?name=$row[1]\">
-                                                {t('Tooltip','HotspotEdit')}</a>
+                                                ".t('Tooltip','HotspotEdit')."</a>
                                         &nbsp;
                                         <a class=\"toolTip\" href=\"acct-hotspot-compare.php?\">
-                                                {t('all','Compare')}</a>
+                                                ".t('all','Compare')."</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerHotspotInfo\">
@@ -204,7 +204,7 @@
                                 onClick='javascript:ajaxGeneric(\"include/management/retUserInfo.php\",\"retBandwidthInfo\",\"divContainerUserInfo\",\"username=$row[2]\");'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-edit.php?username=$row[2]\">
-	                                        {t('Tooltip','UserEdit')}</a>
+	                                        ".t('Tooltip','UserEdit')."</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerUserInfo\">

--- a/acct-plans-usage.php
+++ b/acct-plans-usage.php
@@ -243,7 +243,7 @@
 						onClick='javascript:ajaxGeneric(\"include/management/retUserInfo.php\",\"retBandwidthInfo\",\"divContainerUserInfo\",\"username={$row['username']}\");'
                                 tooltipText='
 								<a class=\"toolTip\" href=\"bill-pos-edit.php?username={$row['username']}\">
-	                                        {t('Tooltip','UserEdit')}</a>
+	                                        ".t('Tooltip','UserEdit')."</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerUserInfo\">

--- a/acct-username.php
+++ b/acct-username.php
@@ -218,10 +218,10 @@
 								onClick='javascript:ajaxGeneric(\"include/management/retHotspotInfo.php\",\"retHotspotGeneralStat\",\"divContainerHotspotInfo\",\"hotspot=$row[1]\");'
 								tooltipText='
 										<a class=\"toolTip\" href=\"mng-hs-edit.php?name=$row[1]\">
-												{t('Tooltip','HotspotEdit')}</a>
+												".t('Tooltip','HotspotEdit')."</a>
 										&nbsp;
 										<a class=\"toolTip\" href=\"acct-hotspot-compare.php?\">
-												{t('all','Compare')}</a>
+												".t('all','Compare')."</a>
 										<br/><br/>
 
 										<div id=\"divContainerHotspotInfo\">
@@ -235,7 +235,7 @@
 								onClick='javascript:ajaxGeneric(\"include/management/retUserInfo.php\",\"retBandwidthInfo\",\"divContainerUserInfo\",\"username=$row[2]\");'
 								tooltipText='
 										<a class=\"toolTip\" href=\"mng-edit.php?username=$row[2]\">
-											{t('Tooltip','UserEdit')}</a>
+											".t('Tooltip','UserEdit')."</a>
 										<br/><br/>
 
 										<div id=\"divContainerUserInfo\">

--- a/bill-plans-list.php
+++ b/bill-plans-list.php
@@ -146,7 +146,7 @@
                         <td> <a class='tablenovisit' href='javascript:return;'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"bill-plans-edit.php?planName=$row[1]\">
-                                                {t('button','EditPlan')}</a>
+                                                ".t('button','EditPlan')."</a>
                                         <br/><br/>'
                                 >$row[1]</a>
                         </td>

--- a/bill-pos-list.php
+++ b/bill-pos-list.php
@@ -235,7 +235,7 @@
                                 onClick='javascript:ajaxGeneric(\"include/management/retUserInfo.php\",\"retBandwidthInfo\",\"divContainerUserInfo\",\"username=".urlencode($row['username'])."\");'
                                 tooltipText='
 	                                <a class=\"toolTip\" href=\"bill-pos-edit.php?username=".urlencode($row['username'])."\">
-						{t('Tooltip','UserEdit')}</a>
+						".t('Tooltip','UserEdit')."</a>
 					<br/><br/>
 
 					<div id=\"divContainerUserInfo\">

--- a/mng-batch-list.php
+++ b/mng-batch-list.php
@@ -277,10 +277,10 @@
 				<a class='tablenovisit' href='javascript:return;'
 					tooltipText='
 					<a class=\"toolTip\" href=\"rep-batch-details.php?batch_name={$row['batch_name']}\">
-						{t('Tooltip','BatchDetails')}</a>
+						".t('Tooltip','BatchDetails')."</a>
 						<br/><br/>
 								<div id=\"divContainerUserInfo\">
-									<b>{t('all','batchDescription')}</b>:<br/><br/>
+									<b>".t('all','batchDescription')."</b>:<br/><br/>
 									{$row['batch_description']}
 								</div>
 								<br/>

--- a/mng-hs-list.php
+++ b/mng-hs-list.php
@@ -158,10 +158,10 @@
                                 onClick='javascript:ajaxGeneric(\"include/management/retHotspotInfo.php\",\"retHotspotGeneralStat\",\"divContainerHotspotInfo\",\"hotspot=$row[1]\");'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-hs-edit.php?name=$row[1]\">
-                                                {t('Tooltip','HotspotEdit')}</a>
+                                                ".t('Tooltip','HotspotEdit')."</a>
                                         &nbsp;
                                         <a class=\"toolTip\" href=\"acct-hotspot-compare.php?\">
-                                                {t('all','Compare')}</a>
+                                                ".t('all','Compare')."</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerHotspotInfo\">

--- a/mng-rad-attributes-list.php
+++ b/mng-rad-attributes-list.php
@@ -157,7 +157,7 @@
                                 onClick='javascript:ajaxGeneric(\"include/management/retVendorAttributeInfo.php\",\"retAttributeInfo\",\"divContainerAttributeInfo\",\"attribute=$row[2]\");'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-rad-attributes-edit.php?vendor=$row[1]&attribute=$row[2]\">
-                                                {t('Tooltip','AttributeEdit')}</a>
+                                                ".t('Tooltip','AttributeEdit')."</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerAttributeInfo\">

--- a/mng-rad-attributes-search.php
+++ b/mng-rad-attributes-search.php
@@ -148,7 +148,7 @@
                                 onClick='javascript:ajaxGeneric(\"include/management/retVendorAttributeInfo.php\",\"retAttributeInfo\",\"divContainerAttributeInfo\",\"attribute=$row[2]\");'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-rad-attributes-edit.php?vendor=$row[1]&attribute=$row[2]\">
-                                                {t('Tooltip','AttributeEdit')}</a>
+                                                ".t('Tooltip','AttributeEdit')."</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerAttributeInfo\">

--- a/mng-search.php
+++ b/mng-search.php
@@ -167,15 +167,15 @@
                                 onClick='javascript:ajaxGeneric(\"include/management/retUserInfo.php\",\"retBandwidthInfo\",\"divContainerUserInfo\",\"username=$row[0]\");'
                                 tooltipText='
                                         <a class=\"toolTip\" href=\"mng-edit.php?username=$row[0]\">
-	                                        {t('Tooltip','UserEdit')}</a>
+	                                        ".t('Tooltip','UserEdit')."</a>
                                         &nbsp
 					<br/>
 					<a class=\"toolTip\" href=\"config-maint-test-user.php?username=$row[0]&password=$row[1]\">
-						{t('all','TestUser')}</a>
+						".t('all','TestUser')."</a>
 					&nbsp
 					<br/>
 					 <a class=\"toolTip\" href=\"acct-username.php?username=$row[0]\">
-						{t('all','Accounting')}</a>
+						".t('all','Accounting')."</a>
                                         <br/><br/>
 
                                         <div id=\"divContainerUserInfo\">

--- a/rep-batch-details.php
+++ b/rep-batch-details.php
@@ -226,7 +226,7 @@
 					<a class='tablenovisit' href='javascript:return;'
 						tooltipText='
 									<div id=\"divContainerUserInfo\">
-										<b>{t('all','batchDescription')}</b>:<br/><br/>
+										<b>".t('all','batchDescription')."</b>:<br/><br/>
 										{$row['batch_description']}
 									</div>
 									<br/>

--- a/rep-batch-list.php
+++ b/rep-batch-list.php
@@ -264,10 +264,10 @@
 				<a class='tablenovisit' href='javascript:return;'
 					tooltipText='
 					<a class=\"toolTip\" href=\"rep-batch-details.php?batch_name={$row['batch_name']}\">
-						{t('Tooltip','BatchDetails')}</a>
+						".t('Tooltip','BatchDetails')."</a>
 						<br/><br/>
 								<div id=\"divContainerUserInfo\">
-									<b>{t('all','batchDescription')}</b>:<br/><br/>
+									<b>".t('all','batchDescription')."</b>:<br/><br/>
 									{$row['batch_description']}
 								</div>
 								<br/>


### PR DESCRIPTION
That's the reason I don't like to include $vars inside double-quoted strings.

Before, it was:

`"<a>$l['name']</a>"`

After the changes in translation procedure now it is - wrong:

`"<a>t('name')</a>"`

This PR converts it to:

`"<a>".t('name')."</a>"`

