### PR TITLE
Missing closing bracket.

### DIFF
--- a/library/exten-daloradius_log.php
+++ b/library/exten-daloradius_log.php
@@ -67,6 +67,7 @@ if (isset($configValues['CONFIG_LOG_FILE'])) {
 				// 		$counter--;
 				// 	}
 				// }
+			}
 		}
 	}
 }


### PR DESCRIPTION
Just that, a closing bracket was missing.