### PR TITLE
Fix SQL query for last connection attempts where FreeRADIUS is v3.

### DIFF
--- a/rep-lastconnect.php
+++ b/rep-lastconnect.php
@@ -66,7 +66,7 @@
 	$radiusReplySQL = "";
 	if ($radiusReply <> "Any") $radiusReplySQL = " AND (".$configValues['CONFIG_DB_TBL_RADPOSTAUTH'].".reply = '$radiusReply') ";
 	
-	if (isset($configValues['FREERADIUS_VERSION']) && ($configValues['FREERADIUS_VERSION'] == '2')) {
+	if (isset($configValues['FREERADIUS_VERSION']) && ($configValues['FREERADIUS_VERSION'] == '2' || $configValues['FREERADIUS_VERSION'] == '3')) {
 		$tableSetting['postauth']['user'] = 'username';
 		$tableSetting['postauth']['date'] = 'authdate';
 	} elseif (isset($configValues['FREERADIUS_VERSION']) && ($configValues['FREERADIUS_VERSION'] == '1')) {


### PR DESCRIPTION
Possibly a fix for #58.

Potential bug in `rep-lastconnect.php` if we are running daloRADIUS under FreeRadius 3 and we have set `$configValues['FREERADIUS_VERSION']` to the value `'3'`:

```
	if (isset($configValues['FREERADIUS_VERSION']) && ($configValues['FREERADIUS_VERSION'] == '2')) {
		$tableSetting['postauth']['user'] = 'username';
		$tableSetting['postauth']['date'] = 'authdate';
	} elseif (isset($configValues['FREERADIUS_VERSION']) && ($configValues['FREERADIUS_VERSION'] == '1')) {
		$tableSetting['postauth']['user'] = 'user';
		$tableSetting['postauth']['date'] = 'date';
	}
```

If that is the case, both `$tableSetting['postauth']['user']` and `$tableSetting['postauth']['date']` will be undefined, so the SQL queries would be bad formed:

```
$sql = "SELECT ".
			$configValues['CONFIG_DB_TBL_RADPOSTAUTH'].".".$tableSetting['postauth']['user']." 
		FROM ".$configValues['CONFIG_DB_TBL_RADPOSTAUTH']. 
        " WHERE (".$configValues['CONFIG_DB_TBL_RADPOSTAUTH'].".".$tableSetting['postauth']['user']." LIKE '".
	$dbSocket->escapeSimple($usernameLastConnect)."%') $radiusReplySQL ".
		" AND (".$tableSetting['postauth']['date']." >='$startdate' AND ".$tableSetting['postauth']['date']." <='$enddate') ";
```