### PR TITLE
Set right column names for table radpostauth in FreeRADIUS v3 plus language fixes.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+release 1.1-2 - 08 Aug 2019
+    - syntax fix in language translations
+	- set right column names for table radpostauth in FreeRADIUS v3
+
 release 1.1-1 - 28 Jul 2019
     - fix memory overflow on database backups
 	- added daloRADIUS version date to configuration

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ Helpful resources to find help and support with daloRADIUS:
 Copyright Liran Tal 2007-2019. All rights reserved.
 For release information and license, read LICENSE.
 
-[daloRADIUS](http://www.daloradius.com) version 1.1-1 stable release
+[daloRADIUS](http://www.daloradius.com) version 1.1-2 stable release
 by Liran Tal <liran.tal@gmail.com>,
 Miguel García <miguelvisgarcia@gmail.com>.
 

--- a/daloradius-users/library/tableConventions.php
+++ b/daloradius-users/library/tableConventions.php
@@ -24,10 +24,17 @@
 // Syntax:
 // $row['TABLE']['FIELD'] = 'mysql';
 
-if (isset($configValues['FREERADIUS_VERSION']) && ($configValues['FREERADIUS_VERSION'] == '2')) {
-	$row['postauth']['user'] = 'username';
-	$row['postauth']['date'] = 'authdate';
-} elseif (isset($configValues['FREERADIUS_VERSION']) && ($configValues['FREERADIUS_VERSION'] == '1')) {
-	$row['postauth']['user'] = 'user';
-	$row['postauth']['date'] = 'date';
+switch($configValues['FREERADIUS_VERSION']) {
+	case '1' :
+		$row['postauth']['user'] = 'user';
+		$row['postauth']['date'] = 'date';
+		break;
+	case '2' :
+		// down
+	case '3' :
+		// down
+	default  :
+		$row['postauth']['user'] = 'username';
+		$row['postauth']['date'] = 'authdate';
+		break;
 }

--- a/lang/en.php
+++ b/lang/en.php
@@ -1407,10 +1407,10 @@ update request {
 <i> What this does is perform a lookup in the radhuntgroup table using the ip-address as a key to return the huntgroup name. It then adds an attribute/value pair to the request where the name of the attribute is Huntgroup-Name and it's value is whatever was returned from the SQL query. If the query did not find anything then the value is the empty string. </i>";
 
 
-+$l['helpPage']['mngradhuntdel'] = "To remove a huntgroup entry from the database you must provide the ip/host and port id of the huntgroup";
-+$l['helpPage']['mngradhuntnew'] = "";
-+$l['helpPage']['mngradhuntlist'] = "";
-+$l['helpPage']['mngradhuntedit'] = "";
+$l['helpPage']['mngradhuntdel'] = "To remove a huntgroup entry from the database you must provide the ip/host and port id of the huntgroup";
+$l['helpPage']['mngradhuntnew'] = "";
+$l['helpPage']['mngradhuntlist'] = "";
+$l['helpPage']['mngradhuntedit'] = "";
 
 $l['helpPage']['mnghsdel'] = "To remove a hotspot from the database you must provide the hotspot's name<br/>";
 $l['helpPage']['mnghsedit'] = "You may edit below details for hotspot<br/>";

--- a/lang/ja.php
+++ b/lang/ja.php
@@ -1560,10 +1560,10 @@ Huntgroup-Name := \"%{sql:select groupname from radhuntgroup where nasipaddress=
 <i> What this does is perform a lookup in the radhuntgroup table using the ip-address as a key to return the huntgroup name. It then adds an attribute/value pair to the request where the name of the attribute is Huntgroup-Name and it's value is whatever was returned from the SQL query. If the query did not find anything then the value is the empty string. </i>";
 
 
-+$l['helpPage']['mngradhuntdel'] = "データベスからハントグループエントリを削除するには、ハントグループの IP/ホスト とポートIDを入力しなければなりません";
-+$l['helpPage']['mngradhuntnew'] = "";
-+$l['helpPage']['mngradhuntlist'] = "";
-+$l['helpPage']['mngradhuntedit'] = "";
+$l['helpPage']['mngradhuntdel'] = "データベスからハントグループエントリを削除するには、ハントグループの IP/ホスト とポートIDを入力しなければなりません";
+$l['helpPage']['mngradhuntnew'] = "";
+$l['helpPage']['mngradhuntlist'] = "";
+$l['helpPage']['mngradhuntedit'] = "";
 
 $l['helpPage']['mnghsdel'] = "データベースからホットスポットを削除するには、ホットスポットの名前を入力しなければなりません<br/>";
 

--- a/lang/zh.php
+++ b/lang/zh.php
@@ -1405,10 +1405,10 @@ update request {
 <i> 这是使用IP地址作为回报huntgroup名字中的一个重要radhuntgroup表中执行查找。然后添加一个属性/值对该请求的属性名称是huntgroup的名字和它的值就是从SQL查询返回的。如果查询没有发现任何值是空字符串。 </i>";
 
 
-+$l['helpPage']['mngradhuntdel'] = "从数据库中删除组条目必须提供的ip /主机和端口id";
-+$l['helpPage']['mngradhuntnew'] = "";
-+$l['helpPage']['mngradhuntlist'] = "";
-+$l['helpPage']['mngradhuntedit'] = "";
+$l['helpPage']['mngradhuntdel'] = "从数据库中删除组条目必须提供的ip /主机和端口id";
+$l['helpPage']['mngradhuntnew'] = "";
+$l['helpPage']['mngradhuntlist'] = "";
+$l['helpPage']['mngradhuntedit'] = "";
 
 $l['helpPage']['mnghsdel'] = "从数据库中删除一个热点必须提供热点的名称<br/>";
 $l['helpPage']['mnghsedit'] = "您可以编辑以下细节热点<br/>";

--- a/library/daloradius.conf.php
+++ b/library/daloradius.conf.php
@@ -23,8 +23,8 @@
  */
 
 
-$configValues['DALORADIUS_VERSION'] = '1.1-1';
-$configValues['DALORADIUS_DATE'] = '28 Jul 2019';
+$configValues['DALORADIUS_VERSION'] = '1.1-2';
+$configValues['DALORADIUS_DATE'] = '08 Aug 2019';
 $configValues['FREERADIUS_VERSION'] = '2';
 $configValues['CONFIG_DB_ENGINE'] = 'mysqli';
 $configValues['CONFIG_DB_HOST'] = 'localhost';

--- a/library/tableConventions.php
+++ b/library/tableConventions.php
@@ -24,10 +24,17 @@
 // Syntax:
 // $row['TABLE']['FIELD'] = 'mysql';
 
-if (isset($configValues['FREERADIUS_VERSION']) && ($configValues['FREERADIUS_VERSION'] == '2')) {
-	$row['postauth']['user'] = 'username';
-	$row['postauth']['date'] = 'authdate';
-} elseif (isset($configValues['FREERADIUS_VERSION']) && ($configValues['FREERADIUS_VERSION'] == '1')) {
-	$row['postauth']['user'] = 'user';
-	$row['postauth']['date'] = 'date';
+switch($configValues['FREERADIUS_VERSION']) {
+	case '1' :
+		$row['postauth']['user'] = 'user';
+		$row['postauth']['date'] = 'date';
+		break;
+	case '2' :
+		// down
+	case '3' :
+		// down
+	default  :
+		$row['postauth']['user'] = 'username';
+		$row['postauth']['date'] = 'authdate';
+		break;
 }

--- a/mng-batch-del.php
+++ b/mng-batch-del.php
@@ -95,13 +95,20 @@
 				$res = $dbSocket->query($sql);
 				$logDebugSQL .= $sql . "\n";
 				
-				// setting table-related parameters first
-				if (isset($configValues['FREERADIUS_VERSION']) && ($configValues['FREERADIUS_VERSION'] == '2')) {
-					$tableSetting['postauth']['user'] = 'username';
-					$tableSetting['postauth']['date'] = 'authdate';
-				} elseif (isset($configValues['FREERADIUS_VERSION']) && ($configValues['FREERADIUS_VERSION'] == '1')) {
-					$tableSetting['postauth']['user'] = 'user';
-					$tableSetting['postauth']['date'] = 'date';
+				// setting table-related parameters first				
+				switch($configValues['FREERADIUS_VERSION']) {
+					case '1' :
+						$tableSetting['postauth']['user'] = 'user';
+						$tableSetting['postauth']['date'] = 'date';
+						break;
+					case '2' :
+						// down
+					case '3' :
+						// down
+					default  :
+						$tableSetting['postauth']['user'] = 'username';
+						$tableSetting['postauth']['date'] = 'authdate';
+						break;
 				}
 								
 				// loop through each user and delete it

--- a/mng-del.php
+++ b/mng-del.php
@@ -58,12 +58,20 @@
 
 				include 'library/opendb.php';
 
-				if (isset($configValues['FREERADIUS_VERSION']) && ($configValues['FREERADIUS_VERSION'] == '2')) {
-					$tableSetting['postauth']['user'] = 'username';
-					$tableSetting['postauth']['date'] = 'authdate';
-				} elseif (isset($configValues['FREERADIUS_VERSION']) && ($configValues['FREERADIUS_VERSION'] == '1')) {
-					$tableSetting['postauth']['user'] = 'user';
-					$tableSetting['postauth']['date'] = 'date';
+				// setting table-related parameters first
+				switch($configValues['FREERADIUS_VERSION']) {
+					case '1' :
+						$tableSetting['postauth']['user'] = 'user';
+						$tableSetting['postauth']['date'] = 'date';
+						break;
+					case '2' :
+						// down
+					case '3' :
+						// down
+					default  :
+						$tableSetting['postauth']['user'] = 'username';
+						$tableSetting['postauth']['date'] = 'authdate';
+						break;
 				}
 
 				// delete all attributes associated with a username

--- a/rep-lastconnect.php
+++ b/rep-lastconnect.php
@@ -66,19 +66,28 @@
 	$radiusReplySQL = "";
 	if ($radiusReply <> "Any") $radiusReplySQL = " AND (".$configValues['CONFIG_DB_TBL_RADPOSTAUTH'].".reply = '$radiusReply') ";
 	
-	if (isset($configValues['FREERADIUS_VERSION']) && ($configValues['FREERADIUS_VERSION'] == '2' || $configValues['FREERADIUS_VERSION'] == '3')) {
-		$tableSetting['postauth']['user'] = 'username';
-		$tableSetting['postauth']['date'] = 'authdate';
-	} elseif (isset($configValues['FREERADIUS_VERSION']) && ($configValues['FREERADIUS_VERSION'] == '1')) {
-		$tableSetting['postauth']['user'] = 'user';
-		$tableSetting['postauth']['date'] = 'date';
+	// setting table-related parameters first
+	switch($configValues['FREERADIUS_VERSION']) {
+		case '1' :
+			$tableSetting['postauth']['user'] = 'user';
+			$tableSetting['postauth']['date'] = 'date';
+			break;
+		case '2' :
+			// down
+		case '3' :
+			// down
+		default  :
+			$tableSetting['postauth']['user'] = 'username';
+			$tableSetting['postauth']['date'] = 'authdate';
+			break;
 	}
-        // setup php session variables for exporting
-        $_SESSION['reportTable'] = $configValues['CONFIG_DB_TBL_RADACCT'];
-        $_SESSION['reportQuery'] = " WHERE (".$tableSetting['postauth']['user']." LIKE '".
-					$dbSocket->escapeSimple($usernameLastConnect)."%') $radiusReplySQL ".
-					" AND (".$tableSetting['postauth']['date']." >='$startdate' AND ".$tableSetting['postauth']['date']." <='$enddate') ";
-        $_SESSION['reportType'] = "reportsLastConnectionAttempts";
+	
+	// setup php session variables for exporting
+	$_SESSION['reportTable'] = $configValues['CONFIG_DB_TBL_RADACCT'];
+	$_SESSION['reportQuery'] = " WHERE (".$tableSetting['postauth']['user']." LIKE '".
+				$dbSocket->escapeSimple($usernameLastConnect)."%') $radiusReplySQL ".
+				" AND (".$tableSetting['postauth']['date']." >='$startdate' AND ".$tableSetting['postauth']['date']." <='$enddate') ";
+	$_SESSION['reportType'] = "reportsLastConnectionAttempts";
 
 	//orig: used as maethod to get total rows - this is required for the pages_numbering.php page 
 	$sql = "SELECT ".


### PR DESCRIPTION
Set right column names for table radpostauth in FreeRADIUS v3, plus syntax fix in language translations.

Fixes issue #44.