### PR TITLE
Some Dockerfile improvements

### DIFF
--- a/Dockerfile-freeradius
+++ b/Dockerfile-freeradius
@@ -24,13 +24,6 @@ ENV RADPASS radpass
 ENV CLIENT_NET "0.0.0.0/0"
 ENV CLIENT_SECRET 891011121314
 
-# Local Ubuntu mirror Repository
-RUN echo "deb http://foobar.turbo.net.id/ubuntu xenial main universe multiverse restricted" > /etc/apt/sources.list && \
-echo "deb http://foobar.turbo.net.id/ubuntu xenial-security main universe multiverse restricted" >> /etc/apt/sources.list && \
-echo "deb http://foobar.turbo.net.id/ubuntu xenial-updates main universe multiverse restricted" >> /etc/apt/sources.list && \
-echo "deb http://foobar.turbo.net.id/ubuntu xenial-backports main universe multiverse restricted" >> /etc/apt/sources.list
-
-
 # PHP,Apache2,MySQL and FreeRADIUS install
 RUN apt-get update && \
 	apt-get -y install php7.0 \

--- a/Dockerfile-freeradius
+++ b/Dockerfile-freeradius
@@ -3,7 +3,7 @@
 #
 # Build image:
 # 1. git pull git@github.com:lirantal/daloradius.git
-# 2. docker build . -t lirantal/daloradius
+# 2. docker build . -t lirantal/daloradius -f Dockerfile-freeradius
 #
 # Run the container:
 # 1. docker run -p 80:80 -d lirantal/daloradius

--- a/Dockerfile-freeradius
+++ b/Dockerfile-freeradius
@@ -27,23 +27,25 @@ ENV CLIENT_SECRET 891011121314
 # PHP,Apache2,MySQL and FreeRADIUS install
 RUN apt-get update && \
 	apt-get -y install php7.0 \
-  php7.0-cli \
+        php7.0-cli \
 	php7.0-common \
 	php7.0-curl \
-  php7.0-gd \
-  php7.0-mcrypt \
+        php7.0-gd \
+        php7.0-mcrypt \
 	php7.0-mysql \
 	php-mail \
 	php-mail-mime nano \
-  php-pear \
-  php-db \
-  freeradius-utils \
-  apache2 libapache2-mod-php7.0 \
-  mysql-server mysql-client \
-  freeradius freeradius-mysql \
-  cron
-
-
+        php-pear \
+        php-db \
+        freeradius-utils \
+        apache2 \
+	libapache2-mod-php7.0 \
+        mysql-server \
+	mysql-client \
+        freeradius \
+	freeradius-mysql \
+        cron
+	
 # PHP Pear DB library install
 RUN pear install DB && rm -rf /var/cache/apk/*
 

--- a/Dockerfile-freeradius
+++ b/Dockerfile-freeradius
@@ -50,7 +50,7 @@ RUN apt-get update && \
  && rm -rf /var/lib/apt/lists/*
 
 # PHP Pear DB library install
-RUN pear install DB && rm -rf /var/cache/apk/*
+RUN pear install DB
 
 # Add current project directory which should be a clone of daloradius from:
 # git@github.com:lirantal/daloradius.git

--- a/Dockerfile-freeradius
+++ b/Dockerfile-freeradius
@@ -37,6 +37,7 @@ RUN apt-get update && \
 	php-mail-mime nano \
         php-pear \
         php-db \
+	net-tools \
         freeradius-utils \
         apache2 \
 	libapache2-mod-php7.0 \

--- a/Dockerfile-freeradius
+++ b/Dockerfile-freeradius
@@ -18,7 +18,7 @@ LABEL Description="daloRADIUS Official Docker based on Ubuntu 16.04 LTS and PHP7
 
 # silence package installations to that debpkg doesn't prompt for mysql
 # passwords and other input
-ENV DEBIAN_FRONTEND "noninteractive"
+ARG DEBIAN_FRONTEND noninteractive
 ENV mysql_pass ""
 ENV RADPASS radpass
 ENV CLIENT_NET "0.0.0.0/0"

--- a/Dockerfile-freeradius
+++ b/Dockerfile-freeradius
@@ -81,7 +81,7 @@ RUN rm -rf /var/www/html/index.html
 RUN touch /var/log/daloradius.log && chown -R www-data:www-data /var/log/daloradius.log
 
 # Expose FreeRADIUS Ports, MySQL, and Web for daloRADIUS
-EXPOSE 1812 1813 80 443 3306
+EXPOSE 1812 1813 80 443
 
 # Run the script which executes Apache2 in the foreground as a running process
 CMD ["/var/www/html/init-freeradius.sh"]

--- a/Dockerfile-freeradius
+++ b/Dockerfile-freeradius
@@ -18,7 +18,7 @@ LABEL Description="daloRADIUS Official Docker based on Ubuntu 16.04 LTS and PHP7
 
 # silence package installations to that debpkg doesn't prompt for mysql
 # passwords and other input
-ARG DEBIAN_FRONTEND noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 ENV mysql_pass ""
 ENV RADPASS radpass
 ENV CLIENT_NET "0.0.0.0/0"

--- a/Dockerfile-freeradius
+++ b/Dockerfile-freeradius
@@ -3,7 +3,7 @@
 #
 # Build image:
 # 1. git pull git@github.com:lirantal/daloradius.git
-# 2. docker build . -t lirantal/daloradius -f Dockerfile-freeradius
+# 2. docker build -t lirantal/daloradius -f Dockerfile-freeradius
 #
 # Run the container:
 # 1. docker run -p 80:80 -d lirantal/daloradius

--- a/Dockerfile-freeradius
+++ b/Dockerfile-freeradius
@@ -47,10 +47,11 @@ RUN apt-get update && \
 	freeradius-mysql \
         cron \
  && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
-
+ && rm -rf /var/lib/apt/lists/* \
 # PHP Pear DB library install
-RUN pear install DB
+ && pear install DB \
+ && pear install -a Mail \
+ && pear install -a Mail_Mime
 
 # Add current project directory which should be a clone of daloradius from:
 # git@github.com:lirantal/daloradius.git

--- a/Dockerfile-freeradius
+++ b/Dockerfile-freeradius
@@ -45,8 +45,10 @@ RUN apt-get update && \
 	mysql-client \
         freeradius \
 	freeradius-mysql \
-        cron
-	
+        cron \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
 # PHP Pear DB library install
 RUN pear install DB && rm -rf /var/cache/apk/*
 

--- a/Dockerfile-freeradius
+++ b/Dockerfile-freeradius
@@ -13,7 +13,7 @@ MAINTAINER Liran Tal <liran.tal@gmail.com>
 
 LABEL Description="daloRADIUS Official Docker based on Ubuntu 16.04 LTS and PHP7." \
 	License="GPLv2" \
-	Usage="docker build . -t lirantal/daloradius && docker run -d -p 80:80 lirantal/daloradius" \
+	Usage="docker build -t lirantal/daloradius -f Dockerfile-freeradius && docker run -d -p 80:80 lirantal/daloradius" \
 	Version="1.0"
 
 # silence package installations to that debpkg doesn't prompt for mysql


### PR DESCRIPTION
I improved the Dockerfile a bit. Some cosmetics, some Dockerfile best practices. I added net-tools for the Server-Status page. I also added pear Mail and Maile-Mime as suggested in the requirements. I deleted the explicit Ubuntu mirrors to let Ubuntu choose it's own download location.

Maybe it's also time to switch to Ubtunu 18.04? My own Daloradius Docker image works fine with it.

The Dockerfile does build and start fine.