### PR TITLE
lang: use value in language file

### DIFF
--- a/rep-newusers.php
+++ b/rep-newusers.php
@@ -131,7 +131,7 @@
 
         echo "<thread> <tr>
                 <th scope='col'>
-                ".t('all','Month'). "
+                ".t('all','Monthly'). "
                 </th>
 
                 <th scope='col'>


### PR DESCRIPTION
@MiguelVis this came over on a private email but the email itself was not very clear. I think the original author intended to say that there is no language value defined as `month`, but rather `monthly`. Does this change make sense to you?