### PR TITLE
fix Error parsing "stdin" on radclient test

### DIFF
--- a/library/exten-maint-radclient.php
+++ b/library/exten-maint-radclient.php
@@ -100,7 +100,7 @@ function user_disconnect($options,$user,$nasaddr,$nasport="3779",$nassecret,$com
 	if ($options['dictionary'])
 		$radclient_options .= " -d ".escapeshellarg($options['dictionary']);
 
-	$cmd = "echo ".escapeshellcmd($query)." | $radclient $radclient_options $args 2>&1";
+	$cmd = "echo \"".escapeshellcmd($query)."\" | $radclient $radclient_options $args 2>&1";
 	$print_cmd = "<b>Executed:</b><br/>$cmd<br/><br/><b>Results:</b><br/>";
 	$res = shell_exec($cmd);
 


### PR DESCRIPTION
fix Error parsing "stdin" on radclient test in case of User-Password empty