### PR TITLE
Fix MAC validation in new user (requires PHP v5.5).

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@
 	- dockerfile-freeradius and init-freeradius.sh
 	- fix regex query for rollback
 	- fix mysql directory in dockerfile
+	- fix MAC validation in new user (requires PHP v5.5)
 
 release 1.1-2 - 08 Aug 2019
     - syntax fix in language translations

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Thanks goes to these wonderful people :
 # Requirements
 
  * Apache.
- * PHP v5 or higher.
+ * PHP v5.5 or higher.
  * MySQL v4.1 or higher.
  * [PEAR](https://pear.php.net/) PHP extension.
  * PEAR package DB in order to access the database. To install it, execute at the command line:

--- a/mng-new.php
+++ b/mng-new.php
@@ -461,9 +461,10 @@
 
 		   } elseif ($authType == "macAuth") {
 			    
-				$macaddress = preg_replace("/:|\.|\-/", "", trim($macaddress));
+				$macaddress = trim($macaddress);
 				
-				if (preg_match('/[a-fA-F0-9]/', $macaddress) == 1 && strlen($macaddress) == 12){
+				if (filter_var($macaddress, FILTER_VALIDATE_MAC)) {
+
 					// insert username/password
 					$sql = "INSERT INTO ".$configValues['CONFIG_DB_TBL_RADCHECK']." (id,Username,Attribute,op,Value) ".
 						" VALUES (0, '".$dbSocket->escapeSimple($macaddress)."', 'Auth-Type', ':=', 'Accept')";


### PR DESCRIPTION
Fix:
> PR #164 
> ISSUE #191
> ISSUE #166

Requires PHP v5.5 or higher.