### PR TITLE
fix: Realm options

### DIFF
--- a/include/management/saveRealmsProxys.php
+++ b/include/management/saveRealmsProxys.php
@@ -80,7 +80,7 @@ if ($fileFlag == 1) {
                                 if ($row['ldflag'])
                                         fwrite($realmsFd, "\tldflag = " .$row['ldflag']. "\n");
                                 if ($row['nostrip'])
-                                        fwrite($realmsFd, "\tnostrip = " .$row['nostrip']. "\n");
+                                        fwrite($realmsFd, "\tnostrip\n");
                                 if ($row['hints'])
                                         fwrite($realmsFd, "\thints = " .$row['hints']. "\n");
                                 if ($row['notrealm'])


### PR DESCRIPTION
I have made a change in the file saveRealmsProxys.php and now the nostrip option is applied correctly.

Maybe we can do the same for options "hints" and "notrealm" but I have not tested it yet.