### PR TITLE
fix preg_split function regular expression for correctly detect || between nasipaddress and portid

### DIFF
--- a/mng-rad-hunt-del.php
+++ b/mng-rad-hunt-del.php
@@ -47,7 +47,7 @@
 
                 foreach ($hgroup_array as $hgroup) {
 
-                        list($nasipaddress, $nasportid) = preg_split('\|\|', $hgroup);
+                        list($nasipaddress, $nasportid) = preg_split('/\|\|/', $hgroup);
 
                         if (trim($nasipaddress) != "") {
 


### PR DESCRIPTION
#### What does this implement/fix? This fix regular expression in the preg_split function 