### PR TITLE
Fix support for multiple db locations.

### DIFF
--- a/dologin.php
+++ b/dologin.php
@@ -25,14 +25,13 @@
  */
 
 include('library/sessions.php');
+include_once('library/config_read.php');
 
 // set's the session max lifetime to 3600 seconds
 ini_set('session.gc_maxlifetime', 3600);
 
 dalo_session_start();
 dalo_session_regenerate_id();
-
-include('library/opendb.php');
 
 $errorMessage = '';
 
@@ -42,11 +41,17 @@ $errorMessage = '';
 // validate location
 $location_name = (!empty($_POST['location'])) ? $_POST['location']: "default";
 
+/*
 $_SESSION['location_name'] = (array_key_exists('CONFIG_LOCATIONS', $configValues)
     && is_array($configValues['CONFIG_LOCATIONS'])
     && count($configValues['CONFIG_LOCATIONS']) > 0
     && in_array($location_name, $configValues['CONFIG_LOCATIONS'])) ?
         $location_name : "default";
+*/
+
+$_SESSION['location_name'] = isset($configValues['CONFIG_LOCATIONS'][$location_name]) ? $location_name : 'default';
+
+include('library/opendb.php');		
         
 $operator_user = $dbSocket->escapeSimple($_POST['operator_user']);
 $operator_pass = $dbSocket->escapeSimple($_POST['operator_pass']);

--- a/library/daloradius.conf.php.sample
+++ b/library/daloradius.conf.php.sample
@@ -111,6 +111,7 @@ $configValues['CONFIG_LOCATIONS'] =                     array(
                 "Password" => "",
                 "Database" => "radius",
                 "Hostname" => "127.0.0.1",
+				"Port"     => "3306",
 				"CONFIG_INVOICE_TEMPLATE" => "invoice_template_location_1.html",
 				"CONFIG_INVOICE_ITEM_TEMPLATE" => "invoice_item_template_location_1.html"
         ),
@@ -120,7 +121,8 @@ $configValues['CONFIG_LOCATIONS'] =                     array(
                 "Username" => "db_usertest",
                 "Password" => "db_passtest",
                 "Database" => "test_db1",
-                "Hostname" => "localhost"
+                "Hostname" => "localhost",
+				"Port"     => "3306"
         )
 );
 */

--- a/library/opendb.php
+++ b/library/opendb.php
@@ -23,26 +23,11 @@
 	include (dirname(__FILE__).'/config_read.php');
 	include (dirname(__FILE__).'/tableConventions.php');
 
-	// setup database connectio information according to the session's location name which is held in $SESSION['location_name'].
+	// setup database connection information according to the session's location name which is held in $SESSION['location_name'].
 	// this is introduced in order to provide daloRADIUS to authenticate and manage several database backends without having to
 	// install several web directories of daloradius
 
-	if ((isset($_SESSION['location_name'])) && ($_SESSION['location_name'] == "default")) {
-
-		$mydbEngine = $configValues['CONFIG_DB_ENGINE'];
-		$mydbUser = $configValues['CONFIG_DB_USER'];
-		$mydbPass = $configValues['CONFIG_DB_PASS'];
-		$mydbHost = $configValues['CONFIG_DB_HOST'];
-		$mydbPort = $configValues['CONFIG_DB_PORT'];
-		$mydbName = $configValues['CONFIG_DB_NAME'];
-
-		if (!$mydbPort)
-			$mydbPort = '3306';
-
-		$dbConnectString = $mydbEngine . "://".$mydbUser.":".$mydbPass."@".
-					$mydbHost.":".$mydbPort."/".$mydbName;
-
-	} elseif ((isset($_SESSION['location_name'])) && ($_SESSION['location_name'] != "default")) {
+	if ((isset($_SESSION['location_name'])) && ($_SESSION['location_name'] != "default")) {
 
 		$mydbEngine = $configValues['CONFIG_LOCATIONS'][$_SESSION['location_name']]['Engine'];
 		$mydbUser = $configValues['CONFIG_LOCATIONS'][$_SESSION['location_name']]['Username'];
@@ -50,9 +35,6 @@
 		$mydbHost = $configValues['CONFIG_LOCATIONS'][$_SESSION['location_name']]['Hostname'];
 		$mydbPort = $configValues['CONFIG_LOCATIONS'][$_SESSION['location_name']]['Port'];
 		$mydbName = $configValues['CONFIG_LOCATIONS'][$_SESSION['location_name']]['Database'];
-
-		if (!$mydbPort)
-			$mydbPort = '3306';
 
 		$dbConnectString = $mydbEngine . "://".$mydbUser.":".$mydbPass."@".
 					$mydbHost.":".$mydbPort."/".$mydbName;
@@ -68,9 +50,6 @@
 		$mydbHost = $configValues['CONFIG_DB_HOST'];
 		$mydbPort = $configValues['CONFIG_DB_PORT'];
 		$mydbName = $configValues['CONFIG_DB_NAME'];
-
-		if (!$mydbPort)
-			$mydbPort = '3306';
 
 		$dbConnectString = $mydbEngine . "://".$mydbUser.":".$mydbPass."@".
 					$mydbHost.":".$mydbPort."/".$mydbName;


### PR DESCRIPTION
This PR fixes #248.

The previous code failed to read the db configuration for a given location.

Also it failed to select the db port in case it was not set.

Now it's compulsory to set the db port for each location in the configuration file, in order to be consistent with the default configuration.

The configuration sample file has been modified to reflect this change:

```
// Locations Configuration directives
// Locations directives are support for accessing different databases from the daloRADIUS Login console
// adjust the locations below for databases you are running (if you are running more than one).
// You could configure invoice templates for each location - optional.
$configValues['CONFIG_LOCATIONS'] = array(

        "Location Example 1" => array(
                "Engine"   => "mysql",
                "Username" => "root",
                "Password" => "",
                "Database" => "radius",
                "Hostname" => "127.0.0.1",
                "Port"     => "3306",
                "CONFIG_INVOICE_TEMPLATE" => "invoice_template_location_1.html",
                "CONFIG_INVOICE_ITEM_TEMPLATE" => "invoice_item_template_location_1.html"
        ),
        "Location Example 2" => array(
                "Engine"   => "mysql",
                "Username" => "db_usertest",
                "Password" => "db_passtest",
                "Database" => "test_db1",
                "Hostname" => "localhost",
                "Port"     => "3306"
        )
);
```

