### PR TITLE
Quick fix for batch user add error

### DIFF
--- a/mng-batch-add.php
+++ b/mng-batch-add.php
@@ -189,7 +189,7 @@
 					if (!($group_priority))
 						$group_priority=0;		// if group priority wasn't set we
 										// initialize it to 0 by default
-					$sql = "INSERT INTO ". $configValues['CONFIG_DB_TBL_RADUSERGROUP'] ." VALUES ('".
+					$sql = "INSERT INTO ". $configValues['CONFIG_DB_TBL_RADUSERGROUP'] ." VALUES (NULL,'".
 						$dbSocket->escapeSimple($username)."', '".
 						$dbSocket->escapeSimple($group)."', ".
 						$dbSocket->escapeSimple($group_priority).") ";


### PR DESCRIPTION
On batch user add the radusergroup table expects four values as the fields aren't explicitly declared in the INSERT statement. This causes an error on INSERT, this patch adds the ID field as NULL (it will auto-increment regardless of the value being declared as NULL)