### PR TITLE
fixed incompatibility error with php < 5.6.0 when handling sessions

### DIFF
--- a/library/sessions.php
+++ b/library/sessions.php
@@ -46,7 +46,12 @@ function dalo_check_csrf_token($token) {
         return false;
     }
 
-    return hash_equals($_SESSION['csrf_token'], $token);
+    // this should provide backward compatibility with PHP < 5.6.0
+    $result = (function_exists('hash_equals'))
+            ? hash_equals($_SESSION['csrf_token'], $token)
+            : $_SESSION['csrf_token'] === $token;
+
+    return $result;
 }
 
 // daloRADIUS session start function support timestamp management


### PR DESCRIPTION
I have fixed an incompatibility error with PHP versions < 5.6.0 (when handling sessions), which do not have hash_equals function.