### PR TITLE
Update Dockerfile-standalone

### DIFF
--- a/Dockerfile-standalone
+++ b/Dockerfile-standalone
@@ -1,17 +1,19 @@
-FROM php:7.4-apache-buster
+FROM php:7-apache
 # default timezone
 ENV TZ Asia/Jakarta
 
 RUN apt update && apt -y upgrade \
 && apt -y install libpng-dev libjpeg62-turbo-dev libfreetype6-dev libwebp-dev libmariadb-dev \
+&& && rm -rf /var/lib/apt/lists/* \
 && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
 && update-ca-certificates -f 
-RUN docker-php-ext-configure mysqli \
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
 && docker-php-ext-configure pdo_mysql \
-&& docker-php-ext-configure gd \
-&& docker-php-ext-install mysqli \
-&& docker-php-ext-install pdo_mysql \
-&& docker-php-ext-install gd 
+&& docker-php-ext-configure mysqli \
+&& docker-php-ext-install \
+                       gd \
+                pdo_mysql \
+                   mysqli
 RUN pear channel-update pear.php.net \
  && pear install -a -f DB \
  && pear install -a -f Mail \


### PR DESCRIPTION
update base image to bullseye, compile gd with freetype and jpeg support.

also fixes https://github.com/lirantal/daloradius/issues/436