### PR TITLE
Handful of fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN a2dissite 000-default.conf && \
 
 # Create directories
 # /data should be mounted as volume to avoid recreation of database entries
-RUN mkdir /data /internal_data
+RUN mkdir /data
 ADD . /var/www/daloradius
 
 #RUN touch /var/www/html/library/daloradius.conf.php

--- a/Dockerfile-freeradius
+++ b/Dockerfile-freeradius
@@ -35,7 +35,7 @@ RUN apt-get update \
 
 # Create directories
 # /data should be mounted as volume to avoid recreation of database entries
-RUN mkdir /app /data /internal_data
+RUN mkdir /app /data
 WORKDIR /app
 
 # Copy init script to image

--- a/app/operators/config-maint-test-user.php
+++ b/app/operators/config-maint-test-user.php
@@ -38,15 +38,15 @@
     $logAction = "";
     $logDebugSQL = "";
 
-    if (isset($configValues['CONFIG_MAINT_TEST_USER_RADIUSSERVER'])) {
+    if (!isset($configValues['CONFIG_MAINT_TEST_USER_RADIUSSERVER'])) {
         $configValues['CONFIG_MAINT_TEST_USER_RADIUSSERVER'] = "127.0.0.1";
     }
 
-    if (isset($configValues['CONFIG_MAINT_TEST_USER_RADIUSPORT'])) {
+    if (!isset($configValues['CONFIG_MAINT_TEST_USER_RADIUSPORT'])) {
         $configValues['CONFIG_MAINT_TEST_USER_RADIUSPORT'] = '1812';
     }
 
-    if (isset($configValues['CONFIG_MAINT_TEST_USER_RADIUSSECRET'])) {
+    if (!isset($configValues['CONFIG_MAINT_TEST_USER_RADIUSSECRET'])) {
         $configValues['CONFIG_MAINT_TEST_USER_RADIUSSECRET'] = "testing123";
     }
 
@@ -85,6 +85,7 @@
                 ? trim($_REQUEST['secret']) : $configValues['CONFIG_MAINT_TEST_USER_RADIUSSECRET'];
 
         $username = (isset($_REQUEST['username']) && !empty(trim($_REQUEST['username']))) ? trim($_REQUEST['username']) : "";
+        $password = (isset($_REQUEST['password']) && !empty(trim($_REQUEST['password']))) ? trim($_REQUEST['password']) : "";
 
 
         include('../common/includes/db_open.php');
@@ -224,12 +225,14 @@
                                         "name" => "password1",
                                         "caption" => t('all','Password'),
                                         "type" => "password",
+                                        "value" => ((isset($password)) ? $password : ""),
                                      );
 
         $input_descriptors0[] = array(
                                         "name" => "password2",
                                         "caption" => t('all','Password') . " (confirmation)",
                                         "type" => "password",
+                                        "value" => ((isset($password)) ? $password : ""),
                                      );
 
         $input_descriptors0[] = array(

--- a/app/operators/mng-del.php
+++ b/app/operators/mng-del.php
@@ -62,6 +62,7 @@
                 $tmp = (!is_array($_POST['username'])) ? array($_POST['username']) : $_POST['username'];
                 foreach ($tmp as $value) {
                     
+                    $value = urldecode($value);
                     $value = trim(str_replace("%", "", $value));
                     
                     if (!in_array($value, $usernames)) {

--- a/app/operators/mng-new-quick.php
+++ b/app/operators/mng-new-quick.php
@@ -140,6 +140,8 @@
                     // we "inject" specified attribute in the $_POST array.
                     // handleAttributes() - called later - will take care of it.
                     $injected_attribute = array();
+                    // we record which attributes should be Reply instead of Check
+                    $reply_attribute_list = array();
 
                     $injected_attribute[$passwordType] = $password;
 
@@ -153,10 +155,12 @@
 
                     if ($sessiontimeout) {
                         $injected_attribute['Session-Timeout'] = $sessiontimeout;
+                        $reply_attribute_list[] = "Session-Timeout";
                     }
 
                     if ($idletimeout) {
                         $injected_attribute['Idle-Timeout'] = $idletimeout;
+                        $reply_attribute_list[] = "Idle-Timeout";
                     }
 
                     if ($simultaneoususe) {
@@ -165,14 +169,19 @@
 
                     if ($framedipaddress) {
                         $injected_attribute['Framed-IP-Address'] = $framedipaddress;
+                        $reply_attribute_list[] = "Framed-IP-Address";
                     }
 
-                    $i = 0;
-                    foreach ($injected_attribute as $attribute => $value) {
-                        $index = 'injected_attribute' . $i;
-                        $_POST[$index] = array( $attribute, $value, ':=', 'check' );
-                        $i++;
-                    }
+                     $i = 0;
+                     foreach ($injected_attribute as $attribute => $value) {
+                         $index = 'injected_attribute' . $i;
+                         if (in_array($attribute, $reply_attribute_list)) {
+                             $_POST[$index] = array( $attribute, $value, ':=', 'reply' );
+                         } else {
+                             $_POST[$index] = array( $attribute, $value, ':=', 'check' );
+                         }
+                         $i++;
+                     }
 
                     include("library/attributes.php");
                     $skipList = array(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,4 +64,3 @@ services:
 
     volumes:
       - ./data/daloradius:/data
-      - ./internal_data:/internal_data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       - radius-mysql
     ports:
       - '80:80'
+      - '8000:8000'
     environment:
       - MYSQL_HOST=radius-mysql
       - MYSQL_PORT=3306
@@ -63,3 +64,4 @@ services:
 
     volumes:
       - ./data/daloradius:/data
+      - ./internal_data:/internal_data

--- a/init-freeradius.sh
+++ b/init-freeradius.sh
@@ -17,7 +17,7 @@ function init_freeradius {
 	ln -s $RADIUS_PATH/mods-available/sqlcounter $RADIUS_PATH/mods-enabled/sqlcounter
 	ln -s $RADIUS_PATH/mods-available/sqlippool $RADIUS_PATH/mods-enabled/sqlippool
 	sed -i 's|instantiate {|instantiate {\nsql|' $RADIUS_PATH/radiusd.conf # mods-enabled does not ensure the right order
-	
+
 	# Enable used tunnel for unifi
 	sed -i 's|use_tunneled_reply = no|use_tunneled_reply = yes|' $RADIUS_PATH/mods-available/eap
 
@@ -28,12 +28,12 @@ function init_freeradius {
 	sed -i 's|^#\s*server = .*|server = "'$MYSQL_HOST'"|' $RADIUS_PATH/mods-available/sql
 	sed -i 's|^#\s*port = .*|port = "'$MYSQL_PORT'"|' $RADIUS_PATH/mods-available/sql
 	sed -i '1,$s/radius_db.*/radius_db="'$MYSQL_DATABASE'"/g' $RADIUS_PATH/mods-available/sql
-	sed -i 's|^#\s*password = .*|password = "'$MYSQL_PASSWORD'"|' $RADIUS_PATH/mods-available/sql 
+	sed -i 's|^#\s*password = .*|password = "'$MYSQL_PASSWORD'"|' $RADIUS_PATH/mods-available/sql
 	sed -i 's|^#\s*login = .*|login = "'$MYSQL_USER'"|' $RADIUS_PATH/mods-available/sql
 
 	if [ -n "$DEFAULT_CLIENT_SECRET" ]; then
 		sed -i 's|testing123|'$DEFAULT_CLIENT_SECRET'|' $RADIUS_PATH/mods-available/sql
-	fi 
+	fi
 	echo "freeradius initialization completed."
 }
 
@@ -63,7 +63,7 @@ while ! mysqladmin ping -h"$MYSQL_HOST" --silent; do
 	sleep 20
 done
 
-INIT_LOCK=/internal_data/.init_done
+INIT_LOCK=/data/.freeradius_init_done
 if test -f "$INIT_LOCK"; then
 	echo "Init lock file exists, skipping initial setup."
 else

--- a/init.sh
+++ b/init.sh
@@ -7,71 +7,69 @@ DALORADIUS_CONF_PATH=/var/www/daloradius/app/common/includes/daloradius.conf.php
 
 function init_daloradius {
 
-	if ! test -f "$DALORADIUS_CONF_PATH"; then
-		cp "$DALORADIUS_CONF_PATH.sample" "$DALORADIUS_CONF_PATH"
-	fi
-	[ -n "$MYSQL_HOST" ] && sed -i "s/\$configValues\['CONFIG_DB_HOST'\] = .*;/\$configValues\['CONFIG_DB_HOST'\] = '$MYSQL_HOST';/" $DALORADIUS_CONF_PATH || MYSQL_HOST=localhost
-	[ -n "$MYSQL_PORT" ] && sed -i "s/\$configValues\['CONFIG_DB_PORT'\] = .*;/\$configValues\['CONFIG_DB_PORT'\] = '$MYSQL_PORT';/" $DALORADIUS_CONF_PATH
-	[ -n "$MYSQL_PASSWORD" ] && sed -i "s/\$configValues\['CONFIG_DB_PASS'\] = .*;/\$configValues\['CONFIG_DB_PASS'\] = '$MYSQL_PASSWORD';/" $DALORADIUS_CONF_PATH || MYSQL_PASSWORD=radpass
-	[ -n "$MYSQL_USER" ] && sed -i "s/\$configValues\['CONFIG_DB_USER'\] = .*;/\$configValues\['CONFIG_DB_USER'\] = '$MYSQL_USER';/" $DALORADIUS_CONF_PATH || MYSQL_USER=raduser
-	[ -n "$MYSQL_DATABASE" ] && sed -i "s/\$configValues\['CONFIG_DB_NAME'\] = .*;/\$configValues\['CONFIG_DB_NAME'\] = '$MYSQL_DATABASE';/" $DALORADIUS_CONF_PATH || MYSQL_DATABASE=raddb
-	sed -i "s/\$configValues\['FREERADIUS_VERSION'\] = .*;/\$configValues\['FREERADIUS_VERSION'\] = '3';/" $DALORADIUS_CONF_PATH
+    if ! test -f "$DALORADIUS_CONF_PATH" || ! test -s "$DALORADIUS_CONF_PATH"; then
+        cp "$DALORADIUS_CONF_PATH.sample" "$DALORADIUS_CONF_PATH"
+    fi
+    [ -n "$MYSQL_HOST" ] && sed -i "s/\$configValues\['CONFIG_DB_HOST'\] = .*;/\$configValues\['CONFIG_DB_HOST'\] = '$MYSQL_HOST';/" $DALORADIUS_CONF_PATH || MYSQL_HOST=localhost
+    [ -n "$MYSQL_PORT" ] && sed -i "s/\$configValues\['CONFIG_DB_PORT'\] = .*;/\$configValues\['CONFIG_DB_PORT'\] = '$MYSQL_PORT';/" $DALORADIUS_CONF_PATH
+    [ -n "$MYSQL_PASSWORD" ] && sed -i "s/\$configValues\['CONFIG_DB_PASS'\] = .*;/\$configValues\['CONFIG_DB_PASS'\] = '$MYSQL_PASSWORD';/" $DALORADIUS_CONF_PATH || MYSQL_PASSWORD=radpass
+    [ -n "$MYSQL_USER" ] && sed -i "s/\$configValues\['CONFIG_DB_USER'\] = .*;/\$configValues\['CONFIG_DB_USER'\] = '$MYSQL_USER';/" $DALORADIUS_CONF_PATH || MYSQL_USER=raduser
+    [ -n "$MYSQL_DATABASE" ] && sed -i "s/\$configValues\['CONFIG_DB_NAME'\] = .*;/\$configValues\['CONFIG_DB_NAME'\] = '$MYSQL_DATABASE';/" $DALORADIUS_CONF_PATH || MYSQL_DATABASE=raddb
+    sed -i "s/\$configValues\['FREERADIUS_VERSION'\] = .*;/\$configValues\['FREERADIUS_VERSION'\] = '3';/" $DALORADIUS_CONF_PATH
+    [ -n "$PASSWORD_MIN_LENGTH" ] && sed -i "s/\$configValues\['CONFIG_DB_PASSWORD_MIN_LENGTH'\] = .*;/\$configValues\['CONFIG_DB_PASSWORD_MIN_LENGTH'\] = '$PASSWORD_MIN_LENGTH';/" $DALORADIUS_CONF_PATH
+    [ -n "$PASSWORD_MAX_LENGTH" ] && sed -i "s/\$configValues\['CONFIG_DB_PASSWORD_MAX_LENGTH'\] = .*;/\$configValues\['CONFIG_DB_PASSWORD_MAX_LENGTH'\] = '$PASSWORD_MAX_LENGTH';/" $DALORADIUS_CONF_PATH
 
-	if [ -n "$DEFAULT_FREERADIUS_SERVER" ]; then
-		sed -i "s/\$configValues\['CONFIG_MAINT_TEST_USER_RADIUSSERVER'\] = .*;/\$configValues\['CONFIG_MAINT_TEST_USER_RADIUSSERVER'\] = '$DEFAULT_FREERADIUS_SERVER';/" $DALORADIUS_CONF_PATH
-	else
-		sed -i "s/\$configValues\['CONFIG_MAINT_TEST_USER_RADIUSSERVER'\] = .*;/\$configValues\['CONFIG_MAINT_TEST_USER_RADIUSSERVER'\] = 'radius';/" $DALORADIUS_CONF_PATH
-	fi
-	if [ -n "$DEFAULT_CLIENT_SECRET" ]; then
-		sed -i "s/\$configValues\['CONFIG_MAINT_TEST_USER_RADIUSSECRET'\] = .*;/\$configValues\['CONFIG_MAINT_TEST_USER_RADIUSSECRET'\] = '$DEFAULT_CLIENT_SECRET';/" $DALORADIUS_CONF_PATH
-	fi
+    [ -n "$DEFAULT_FREERADIUS_SERVER" ] \
+        && sed -i "s/\$configValues\['CONFIG_MAINT_TEST_USER_RADIUSSERVER'\] = .*;/\$configValues\['CONFIG_MAINT_TEST_USER_RADIUSSERVER'\] = '$DEFAULT_FREERADIUS_SERVER';/" $DALORADIUS_CONF_PATH \
+        || sed -i "s/\$configValues\['CONFIG_MAINT_TEST_USER_RADIUSSERVER'\] = .*;/\$configValues\['CONFIG_MAINT_TEST_USER_RADIUSSERVER'\] = 'radius';/" $DALORADIUS_CONF_PATH
+    [ -n "$DEFAULT_FREERADIUS_PORT" ] && sed -i "s/\$configValues\['CONFIG_MAINT_TEST_USER_RADIUSPORT'\] = .*;/\$configValues\['CONFIG_MAINT_TEST_USER_RADIUSPORT'\] = '$DEFAULT_FREERADIUS_PORT';/" $DALORADIUS_CONF_PATH
+    [ -n "$DEFAULT_CLIENT_SECRET" ] && sed -i "s/\$configValues\['CONFIG_MAINT_TEST_USER_RADIUSSECRET'\] = .*;/\$configValues\['CONFIG_MAINT_TEST_USER_RADIUSSECRET'\] = '$DEFAULT_CLIENT_SECRET';/" $DALORADIUS_CONF_PATH
 
-	[ -n "$MAIL_SMTPADDR" ] && sed -i "s/\$configValues\['CONFIG_MAIL_SMTPADDR'\] = .*;/\$configValues\['CONFIG_MAIL_SMTPADDR'\] = '$MAIL_SMTPADDR';/" $DALORADIUS_CONF_PATH
-	[ -n "$MAIL_PORT" ] && sed -i "s/\$configValues\['CONFIG_MAIL_SMTPPORT'\] = .*;/\$configValues\['CONFIG_MAIL_SMTPPORT'\] = '$MAIL_PORT';/" $DALORADIUS_CONF_PATH
-	[ -n "$MAIL_FROM" ] && sed -i "s/\$configValues\['CONFIG_MAIL_SMTPFROM'\] = .*;/\$configValues\['CONFIG_MAIL_SMTPFROM'\] = '$MAIL_FROM';/" $DALORADIUS_CONF_PATH
-	[ -n "$MAIL_AUTH" ] && sed -i "s/\$configValues\['CONFIG_MAIL_SMTPAUTH'\] = .*;/\$configValues\['CONFIG_MAIL_SMTPAUTH'\] = '$MAIL_AUTH';/" $DALORADIUS_CONF_PATH
-  sed -i "s/\$configValues\['CONFIG_LOG_FILE'\] = .*;/\$configValues\['CONFIG_LOG_FILE'\] = '\/tmp\/daloradius.log';/" $DALORADIUS_CONF_PATH
+    [ -n "$MAIL_SMTPADDR" ] && sed -i "s/\$configValues\['CONFIG_MAIL_SMTPADDR'\] = .*;/\$configValues\['CONFIG_MAIL_SMTPADDR'\] = '$MAIL_SMTPADDR';/" $DALORADIUS_CONF_PATH
+    [ -n "$MAIL_PORT" ] && sed -i "s/\$configValues\['CONFIG_MAIL_SMTPPORT'\] = .*;/\$configValues\['CONFIG_MAIL_SMTPPORT'\] = '$MAIL_PORT';/" $DALORADIUS_CONF_PATH
+    [ -n "$MAIL_FROM" ] && sed -i "s/\$configValues\['CONFIG_MAIL_SMTPFROM'\] = .*;/\$configValues\['CONFIG_MAIL_SMTPFROM'\] = '$MAIL_FROM';/" $DALORADIUS_CONF_PATH
+    [ -n "$MAIL_AUTH" ] && sed -i "s/\$configValues\['CONFIG_MAIL_SMTPAUTH'\] = .*;/\$configValues\['CONFIG_MAIL_SMTPAUTH'\] = '$MAIL_AUTH';/" $DALORADIUS_CONF_PATH
+    sed -i "s/\$configValues\['CONFIG_LOG_FILE'\] = .*;/\$configValues\['CONFIG_LOG_FILE'\] = '\/tmp\/daloradius.log';/" $DALORADIUS_CONF_PATH
 
-	echo "daloRADIUS initialization completed."
+    echo "daloRADIUS initialization completed."
 }
 
 function init_database {
-	mysql -u root -p"$MYSQL_ROOT_PASSWORD" -e "CREATE DATABASE $MYSQL_DATABASE;"
-	mysql -u root -p"$MYSQL_ROOT_PASSWORD" -e "CREATE USER '$MYSQL_USER'@'localhost' IDENTIFIED BY '$MYSQL_PASSWORD';"
-	mysql -u root -p"$MYSQL_ROOT_PASSWORD" -e "GRANT ALL PRIVILEGES ON $MYSQL_DATABASE.* TO '$MYSQL_USER'@'localhost'";
-	mysql -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" < $DALORADIUS_PATH/contrib/db/mysql-daloradius.sql
-	echo "Database initialization for daloRADIUS completed."
+    mysql -u root -p"$MYSQL_ROOT_PASSWORD" -e "CREATE DATABASE $MYSQL_DATABASE;"
+    mysql -u root -p"$MYSQL_ROOT_PASSWORD" -e "CREATE USER '$MYSQL_USER'@'localhost' IDENTIFIED BY '$MYSQL_PASSWORD';"
+    mysql -u root -p"$MYSQL_ROOT_PASSWORD" -e "GRANT ALL PRIVILEGES ON $MYSQL_DATABASE.* TO '$MYSQL_USER'@'localhost'";
+    mysql -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" < $DALORADIUS_PATH/contrib/db/mysql-daloradius.sql
+    echo "Database initialization for daloRADIUS completed."
 }
 
 echo "Starting daloRADIUS..."
 
-
-INIT_LOCK=/internal_data/.init_done
+INIT_LOCK=/data/.init_done
 if test -f "$INIT_LOCK"; then
-  #
-	if ! test -f "$DALORADIUS_CONF_PATH"; then
-	  echo "Init lock file exists but config file does not exist, performing initial setup of daloRADIUS."
-    init_daloradius
-  fi
-	echo "Init lock file exists and config file exists, skipping initial setup of daloRADIUS."
+    #
+    if ! test -f "$DALORADIUS_CONF_PATH" || ! test -s "$DALORADIUS_CONF_PATH"; then
+        echo "Init lock file exists but config file does not exist or is 0 bytes, performing initial setup of daloRADIUS."
+        init_daloradius
+    fi
+    echo "Init lock file exists and config file exists, skipping initial setup of daloRADIUS."
 else
-	init_daloradius
-	date > $INIT_LOCK
+    init_daloradius
+    date > $INIT_LOCK
 fi
 
 # wait for MySQL-Server to be ready
-echo -n"Waiting for mysql ($MYSQL_HOST)..."
-while ! mysqladmin ping -h"$MYSQL_HOST" -p"$MYSQL_PASS" --silent; do
-	sleep 20
+echo -n "Waiting for mysql ($MYSQL_HOST)..."
+while ! mysqladmin ping -h"$MYSQL_HOST" -p"$MYSQL_PASSWORD" --silent; do
+    sleep 20
 done
 echo "ok"
 
 DB_LOCK=/data/.db_init_done
 if test -f "$DB_LOCK"; then
-	echo "Database lock file exists, skipping initial setup of mysql database."
+    echo "Database lock file exists, skipping initial setup of mysql database."
 else
-	init_database
-	date > $DB_LOCK
+    init_database
+    date > $DB_LOCK
 fi
 
 # Start Apache2 in the foreground


### PR DESCRIPTION
Tweaks for docker:
- password length fields from environment into config
- radius port to test against
- consistent file location for lockfile, /data instead of mix of /data + /internal_data
- init script startup now catches empty config files and regenerates

Fixing user attribute delete problem with clobbering of @ in usernames making the SQL fail.
Create user wizard now has awareness of which fields are Check vs Reply
Fixes for user test, 3 x if statements previously were checking if there was radius config, and if there was, ignore it and use defaults instead; now correctly uses the config if it's found.  Also populates password boxes if it's come through from the user page

