### PR TITLE
Fix ownership of daloradius configuration file for docker deployment

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -9,6 +9,7 @@ function init_daloradius {
 
     if ! test -f "$DALORADIUS_CONF_PATH" || ! test -s "$DALORADIUS_CONF_PATH"; then
         cp "$DALORADIUS_CONF_PATH.sample" "$DALORADIUS_CONF_PATH"
+        chown www-data:www-data "$DALORADIUS_CONF_PATH"
     fi
     [ -n "$MYSQL_HOST" ] && sed -i "s/\$configValues\['CONFIG_DB_HOST'\] = .*;/\$configValues\['CONFIG_DB_HOST'\] = '$MYSQL_HOST';/" $DALORADIUS_CONF_PATH || MYSQL_HOST=localhost
     [ -n "$MYSQL_PORT" ] && sed -i "s/\$configValues\['CONFIG_DB_PORT'\] = .*;/\$configValues\['CONFIG_DB_PORT'\] = '$MYSQL_PORT';/" $DALORADIUS_CONF_PATH


### PR DESCRIPTION
When deploying docker image config file was not writable by apache group.