### PR TITLE
fix/acct-maintenance-delete: delete records in specific day

### DIFF
--- a/app/operators/acct-maintenance-delete.php
+++ b/app/operators/acct-maintenance-delete.php
@@ -88,7 +88,7 @@
             if (empty($enddate)) {
                 $required_fields['enddate'] = t('all','EndingDate');
             } else {
-                $sql_WHERE[] = sprintf("AcctStartTime < '%s'", $enddate);
+                $sql_WHERE[] = sprintf("AcctStartTime < DATE_ADD('%s', INTERVAL 1 DAY)", $enddate);
             }
             
             // further checks


### PR DESCRIPTION
The current DELETE query does not remove entries until the end of the specified date, as it only matches entries within the range. This PR modifies the SQL query by adding one day to the end date to ensure it matches and deletes all entries up to and including the specified date.