### PR TITLE
Update install.sh

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -561,6 +561,7 @@ main() {
     freeradius_setup_sql_mod
     freeradius_enable_restart
 
+    apache_disable_all_sites
     apache_setup_envvars
     apache_setup_ports
     apache_setup_operators_site


### PR DESCRIPTION
The default site was not disabled, leading to instead of the user site, the apache default page being displayed.  I added the already existing apache_disable_all_sites to the main function.
Sorry, this is a very small pull request, but it confused me for 5 minutes, so I think its worth it.