### PR TITLE
fix: Disable TLS for mysql

### DIFF
--- a/init-freeradius.sh
+++ b/init-freeradius.sh
@@ -9,6 +9,7 @@ function init_freeradius {
 	sed -i 's|dialect = "sqlite"|dialect = "mysql"|' $RADIUS_PATH/mods-available/sql
 	sed -i 's|dialect = ${modules.sql.dialect}|dialect = "mysql"|' $RADIUS_PATH/mods-available/sqlcounter # avoid instantiation error
 	sed -i 's|ca_file = "/etc/ssl/certs/my_ca.crt"|#ca_file = "/etc/ssl/certs/my_ca.crt"|' $RADIUS_PATH/mods-available/sql #disable sql encryption
+        sed -i 's|ca_path = "/etc/ssl/certs/"|#ca_path = "/etc/ssl/certs/"|' $RADIUS_PATH/mods-available/sql #disable sql encryption
 	sed -i 's|certificate_file = "/etc/ssl/certs/private/client.crt"|#certificate_file = "/etc/ssl/certs/private/client.crt"|' $RADIUS_PATH/mods-available/sql #disable sql encryption
 	sed -i 's|private_key_file = "/etc/ssl/certs/private/client.key"|#private_key_file = "/etc/ssl/certs/private/client.key"|' $RADIUS_PATH/mods-available/sql #disable sql encryption
 	sed -i 's|tls_required = yes|tls_required = no|' $RADIUS_PATH/mods-available/sql #disable sql encryption


### PR DESCRIPTION
if any params in the mysql TLS config is set then tls is enabled. This fixes the issue

https://github.com/FreeRADIUS/freeradius-server/blob/d864ca7c176c0c1ab8b0fda6cdacb5edea774f40/src/modules/rlm_sql/drivers/rlm_sql_mysql/rlm_sql_mysql.c#L287