### PR TITLE
Fix CSRF token validation in NAS deletion operation

### DIFF
--- a/app/operators/mng-rad-nas-list.php
+++ b/app/operators/mng-rad-nas-list.php
@@ -184,7 +184,7 @@
                                 'multiple_pages' => $drawNumberLinks
                            );
 
-        $descriptor = array( 'table_foot' => $table_foot );
+        $descriptor = array( 'form' => $form_descriptor, 'table_foot' => $table_foot );
         print_table_bottom($descriptor);
 
         // get and print "links"


### PR DESCRIPTION
Fix for issue [#590](https://github.com/lirantal/daloradius/issues/590#issue-2763955516) and issue [#572](https://github.com/lirantal/daloradius/issues/572#issue-2582569653).  Cannot delete NAS.