### PR TITLE
Use radius.log by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,8 +35,9 @@ services:
       - DEFAULT_CLIENT_SECRET=testing123
     volumes:
       - ./data/freeradius:/data
-    # If you want to disable debug output, remove the command parameter
-    command: -X
+      - radius_logs:/var/log/freeradius
+    # Uncomment below to enable debug logging.
+    #command: -X
 
   radius-web:
     build: .
@@ -64,3 +65,7 @@ services:
 
     volumes:
       - ./data/daloradius:/data
+      - radius_logs:/var/log/freeradius
+
+volumes:
+  radius_logs:


### PR DESCRIPTION
This change makes so `radius.log` file functions as intended. This forces the freeradius to log file and the web-app is able to read the log files. Docker stdout also functions properly so the system administrator can directy read the logs.

Enabling debug log (note that this will disable log to file - hard coded in freeradius) is simple as uncommint `command: -X` in the compose file.