### PR TITLE
Log authentication requests with sane defaults

### DIFF
--- a/init-freeradius.sh
+++ b/init-freeradius.sh
@@ -22,6 +22,14 @@ function init_freeradius {
 	# Enable used tunnel for unifi
 	sed -i 's|use_tunneled_reply = no|use_tunneled_reply = yes|' $RADIUS_PATH/mods-available/eap
 
+        # Log authentication request in radius-log file
+        sed -i 's|auth = no|auth = yes|' $RADIUS_PATH/radiusd.conf
+        # Sane default log setings for authentication
+        sed -i 's|#\s*msg_goodpass =.*|msg_goodpass = "authenticationtype:\\\"%{control:Auth-Type}\\\";nasipv4address:\\\"%{request:NAS-IP-Address}\\\";nasipv6address:\\\"%{request:NAS-IPv6-Address}\\\";nasid:\\\"%{request:NAS-Identifier}\\\";srcipaddress:\\\"%{request:Packet-Src-IP-Address}\\\";nasport:\\\"%{request:NAS-Port-Id}\\\";nasporttype:\\\"%{request:NAS-Port-Type}\\\";vlan:\\\"%{reply:Tunnel-Private-Group-Id}\\\";calledstationid:\\\"%{request:Called-Station-Id}\\\";callingstationid:\\\"%{request:Calling-Station-Id}\\\";session_timeout:\\\"%{reply:Session-Timeout}\\\""|' \
+        $RADIUS_PATH/radiusd.conf
+        sed -i 's|#\s*msg_badpass =.*|msg_badpass = "authenticationtype:\\\"%{control:Auth-Type}\\\";nasipv4address:\\\"%{request:NAS-IP-Address}\\\";nasipv6address:\\\"%{request:NAS-IPv6-Address}\\\";nasid:\\\"%{request:NAS-Identifier}\\\";srcipaddress:\\\"%{request:Packet-Src-IP-Address}\\\";nasport:\\\"%{request:NAS-Port-Id}\\\";nasporttype:\\\"%{request:NAS-Port-Type}\\\";calledstationid:\\\"%{request:Called-Station-Id}\\\";callingstationid:\\\"%{request:Calling-Station-Id}\\\""|' \
+        $RADIUS_PATH/radiusd.conf
+
 	# Enable status in freeadius
 	ln -s $RADIUS_PATH/sites-available/status $RADIUS_PATH/sites-enabled/status
 


### PR DESCRIPTION
This logs all authentication requests with proper details. This is best practice.

Without having `auth = yes` there is no authentication logs produced. Having this enabled makes the default `radius.log` contain authentication attempts. 

Setting the `msg_goodpass` & `msg_badpass` makes the log lines contain more (extended) details about the authenication attempt.
Default:
- goodpass : `Thu Jun 26 16:25:07 2025 : Auth: (1) Login OK: [user] (from client NAS-NAME port 0) `
- badpass : `Thu Jun 26 16:24:23 2025 : Auth: (0) Login incorrect (pap: Cleartext password does not match "known good" password): [user]  (from client NAS-NAME port 0)`

with extended details we get:
- goodpass : `Thu Jun 26 16:25:07 2025 : Auth: (1) Login OK: [user] (from client NAS-NAME port 0) authenticationtype:"PAP";nasipv4address:"10.0.0.10";nasipv6address:"";nasid:"";srcipaddress:"10.0.0.10";nasport:"";nasporttype:"";vlan:"";calledstationid:"";callingstationid:"";session_timeout:"5"`
- badpass : `Thu Jun 26 16:24:23 2025 : Auth: (0) Login incorrect (pap: Cleartext password does not match "known good" password): [user] (from client NAS-NAME port 0) authenticationtype:"PAP";nasipv4address:"10.0.0.10";nasipv6address:"";nasid:"";srcipaddress:"10.0.0.10";nasport:"";nasporttype:"";calledstationid:"";callingstationid:""`
