### PR TITLE
Add email enconding options

### DIFF
--- a/app/common/includes/daloradius.conf.php.sample
+++ b/app/common/includes/daloradius.conf.php.sample
@@ -98,6 +98,7 @@ $configValues['CONFIG_MAIL_SMTP_SENDER_NAME'] = 'daloRADIUS Mailer';
 $configValues['CONFIG_MAIL_SMTP_SUBJECT_PREFIX'] = '[daloRADIUS]';
 $configValues['CONFIG_MAIL_SMTP_USERNAME'] = '';
 $configValues['CONFIG_MAIL_SMTP_PASSWORD'] = '';
+$configValues['CONFIG_MAIL_CHARSET'] = 'utf-8';
 $configValues['CONFIG_DASHBOARD_DALO_SECRETKEY'] = 'sillykey';
 $configValues['CONFIG_DASHBOARD_DALO_DEBUG'] = '1';
 $configValues['CONFIG_DASHBOARD_DALO_DELAYSOFT'] = '5';

--- a/app/common/includes/mail.php
+++ b/app/common/includes/mail.php
@@ -72,9 +72,12 @@ function send_email($config_values, $recipient_email_address, $recipient_name, $
         $mail->Subject = $subject;
         $mail->Body = $body;
 
+        // Set email charset
+        $mail->CharSet = $config_values['CONFIG_MAIL_CHARSET'];
+
         if (is_array($attachment) && array_key_exists('content', $attachment) && array_key_exists('filename', $attachment) ) {
             $mail->addStringAttachment($attachment['content'], $attachment['filename'],
-                                       PHPMailer\PHPMailer\PHPMailer::ENCODING_BASE64, 'application/pdf', 'attachment');
+                                       PHPMailer\PHPMailer\PHPMailer::ENCODING_BASE64, 'text/plain', 'attachment');
         }
 
         // Send the email

--- a/app/operators/config-mail-settings.php
+++ b/app/operators/config-mail-settings.php
@@ -149,6 +149,17 @@
                 $configValues['CONFIG_MAIL_SMTP_PASSWORD'] = "";
             }
 
+            // validate email charset
+            if (
+                    array_key_exists('CONFIG_MAIL_CHARSET', $_POST) &&
+                    !empty(trim($_POST['CONFIG_MAIL_CHARSET'])) &&
+                    in_array(strtolower(trim($_POST['CONFIG_MAIL_CHARSET'])), array("utf-8", "iso-8859-1", "us-ascii", "utf-16", "windows-1251", "iso-8859-15", "iso-2022-jp", "shift-jis", "koi8-r", "windows-1252", "iso-8859-5"))
+               ) {
+               $configValues['CONFIG_MAIL_CHARSET'] = strtolower(trim($_POST['CONFIG_MAIL_CHARSET']));
+            } else {
+                $configValues['CONFIG_MAIL_CHARSET'] = "utf-8";
+            }
+
             // display message
             if (count($invalid_input) > 0) {
                 $failureMsg = sprintf("Invalid input: [%s]", implode(", ", array_values($invalid_input)));
@@ -298,6 +309,16 @@
         "pattern" => trim(SUBJECT_PREFIX_REGEX, "/"),
         "title" => "allowed letters, numbers, spaces, and square brackets",
         "tooltipText" => "A prefix for the email subjects",
+    );
+
+    $input_descriptors1[] = array(
+        "type" => "select",
+        "options" => array("utf-8", "iso-8859-1", "us-ascii", "utf-16", "windows-1251", "iso-8859-15", "iso-2022-jp", "shift-jis", "koi8-r", "windows-1252", "iso-8859-5"),
+        "caption" => "Email Character Encoding",
+        "name" => 'CONFIG_MAIL_CHARSET',
+        "selected_value" => (!array_key_exists('CONFIG_MAIL_CHARSET', $invalid_input)
+            ? $configValues['CONFIG_MAIL_CHARSET'] : "utf-8"),
+        "tooltipText" => "Character encoding for outgoing emails",
     );
 
 


### PR DESCRIPTION
Hello there!

To enhance the user experience, I've added a setting that allows you to select the email encoding. We now support the top 10 most common character encodings:
    utf-8
    iso-8859-1
    us-ascii
    utf-16
    windows-1251
    iso-8859-15
    iso-2022-jp
    shift-jis
    koi8-r
    windows-1252
    iso-8859-5

This should make handling various regional and legacy formats much smoother. Hope this update makes your workflow easier!