### PR TITLE
Fix background process error detection in setup/install.sh

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -118,7 +118,9 @@ system_ensure_root() {
 system_update() {
     echo -n "[+] Updating system package lists... "
 
-    apt update >/dev/null 2>&1 & print_spinner $!
+    apt update >/dev/null 2>&1 &
+    print_spinner $!
+    wait $!
     if [ $? -ne 0 ]; then
         echo "KO"
             echo "[!] Failed to update package lists. Aborting." >&2
@@ -127,7 +129,9 @@ system_update() {
     print_green "OK"
 
     echo -n "[+] Upgrading system packages... "
-    apt dist-upgrade -y >/dev/null 2>&1 & print_spinner $!
+    apt dist-upgrade -y >/dev/null 2>&1 &
+    print_spinner $!
+    wait $!
     if [ $? -ne 0 ]; then
         print_red "KO"
         echo "[!] Failed to upgrade system packages. Aborting." >&2
@@ -139,7 +143,9 @@ system_update() {
 # Function to install MariaDB
 mariadb_install() {
     echo -n "[+] Installing MariaDB... "
-    apt --no-install-recommends install mariadb-server mariadb-client -y >/dev/null 2>&1 & print_spinner $!
+    apt --no-install-recommends install mariadb-server mariadb-client -y >/dev/null 2>&1 &
+    print_spinner $!
+    wait $!
     if [ $? -ne 0 ]; then
         print_red "KO"
         echo "[!] Failed to install MariaDB. Aborting." >&2
@@ -187,7 +193,9 @@ SQL
 # Function to install freeRADIUS
 freeradius_install() {
     echo -n "[+] Installing freeRADIUS... "
-    apt --no-install-recommends install freeradius freeradius-common freeradius-mysql -y >/dev/null 2>&1 & print_spinner $!
+    apt --no-install-recommends install freeradius freeradius-common freeradius-mysql -y >/dev/null 2>&1 &
+    print_spinner $!
+    wait $!
     if [ $? -ne 0 ]; then
         print_red "KO"
         echo "[!] Failed to install freeRADIUS. Aborting." >&2
@@ -232,9 +240,9 @@ freeradius_enable_restart() {
 daloradius_install_dep() {
     echo -n "[+] Installing daloRADIUS dependencies... "
     apt --no-install-recommends install apache2 php libapache2-mod-php php-mysql php-zip php-mbstring php-common php-curl \
-                                        php-gd php-db php-mail php-mail-mime freeradius-utils git rsyslog -y >/dev/null 2>&1 & \
+                                        php-gd php-db php-mail php-mail-mime freeradius-utils git rsyslog -y >/dev/null 2>&1 &
     print_spinner $!
-
+    wait $!
     if [ $? -ne 0 ]; then
         print_red "KO"
         print_red "[!] Failed to install daloRADIUS dependencies. Aborting." >&2
@@ -267,7 +275,9 @@ daloradius_installation() {
             exit 1
         fi
 
-        git clone https://github.com/lirantal/daloradius.git "${DALORADIUS_ROOT_DIRECTORY}" >/dev/null 2>&1 & print_spinner $!
+        git clone https://github.com/lirantal/daloradius.git "${DALORADIUS_ROOT_DIRECTORY}" >/dev/null 2>&1 &
+        print_spinner $!
+        wait $!
         if [ $? -ne 0 ]; then
             print_red "KO"
             print_red "[!] Failed to clone daloRADIUS repository. Aborting." >&2
@@ -325,9 +335,9 @@ daloradius_setup_required_files() {
       sed -Ei "s/^.*CONFIG_DB_PORT'\].*$/\$configValues['CONFIG_DB_PORT'] = '${DB_PORT}';/" "${DALORADIUS_CONF_FILE}" >/dev/null 2>&1 && \
       sed -Ei "s/^.*CONFIG_DB_USER'\].*$/\$configValues['CONFIG_DB_USER'] = '${DB_USER}';/" "${DALORADIUS_CONF_FILE}" >/dev/null 2>&1 && \
       sed -Ei "s/^.*CONFIG_DB_PASS'\].*$/\$configValues['CONFIG_DB_PASS'] = '${DB_PASS}';/" "${DALORADIUS_CONF_FILE}" >/dev/null 2>&1 && \
-      sed -Ei "s/^.*CONFIG_DB_NAME'\].*$/\$configValues['CONFIG_DB_NAME'] = '${DB_SCHEMA}';/" "${DALORADIUS_CONF_FILE}" >/dev/null 2>&1 ) & \
+      sed -Ei "s/^.*CONFIG_DB_NAME'\].*$/\$configValues['CONFIG_DB_NAME'] = '${DB_SCHEMA}';/" "${DALORADIUS_CONF_FILE}" >/dev/null 2>&1 ) &
     print_spinner $!
-
+    wait $!
     if [ $? -ne 0 ]; then
         print_red "KO"
         print_red "[!] Failed to setup daloRADIUS configuration file. Aborting." >&2
@@ -358,7 +368,9 @@ daloradius_setup_required_files() {
 # Function to disable all Apache sites
 apache_disable_all_sites() {
     echo -n "[+] Disabling all Apache sites... "
-    find /etc/apache2/sites-enabled/ -type l -exec rm "{}" \; >/dev/null 2>&1 & print_spinner $!
+    find /etc/apache2/sites-enabled/ -type l -exec rm "{}" \; >/dev/null 2>&1 &
+    print_spinner $!
+    wait $!
     if [ $? -ne 0 ]; then
         print_red "KO"
         print_red "[!] Failed to disable all Apache sites. Aborting." >&2
@@ -499,14 +511,18 @@ daloradius_load_sql_schema() {
     DB_DIR="${DALORADIUS_ROOT_DIRECTORY}/contrib/db"
     echo -n "[+] Loading daloRADIUS SQL schema into MariaDB... "
 
-    mariadb --defaults-extra-file="${MARIADB_CLIENT_FILENAME}" < "${DB_DIR}/fr3-mariadb-freeradius.sql" >/dev/null 2>&1 & print_spinner $!
+    mariadb --defaults-extra-file="${MARIADB_CLIENT_FILENAME}" < "${DB_DIR}/fr3-mariadb-freeradius.sql" >/dev/null 2>&1 &
+    print_spinner $!
+    wait $!
     if [ $? -ne 0 ]; then
         print_red "KO"
         print_red "[!] Failed to load freeRADIUS SQL schema into MariaDB. Aborting." >&2
         exit 1
     fi
 
-    mariadb --defaults-extra-file="${MARIADB_CLIENT_FILENAME}" < "${DB_DIR}/mariadb-daloradius.sql" >/dev/null 2>&1 & print_spinner $!
+    mariadb --defaults-extra-file="${MARIADB_CLIENT_FILENAME}" < "${DB_DIR}/mariadb-daloradius.sql" >/dev/null 2>&1 &
+    print_spinner $!
+    wait $!
     if [ $? -ne 0 ]; then
         print_red "KO"
         print_red "[!] Failed to load daloRADIUS SQL schema into MariaDB. Aborting." >&2


### PR DESCRIPTION
# Fix background process error detection in `setup/install.sh`

## Description

The install script runs several commands in the background (with `&`) to show a spinner while they execute. The issue is that `$?` after `print_spinner` returns the exit code of the spinner itself (always 0), not the actual background command. So if `apt install`, `git clone`, `mariadb`, etc. fail, the script just ignores it and keeps going.

Fixed by adding `wait $!` after each `print_spinner` call to properly capture the background process exit code.

## Changes

For each occurrence (10 total), the pattern was changed from:

```diff
- command >/dev/null 2>&1 & print_spinner $!
- if [ $? -ne 0 ]; then
+ command >/dev/null 2>&1 &
+ print_spinner $!
+ wait $!
+ if [ $? -ne 0 ]; then
```

## Testing

Tested on a fresh Debian 13 VM by disabling `sources.list` to force `apt install` to fail:

**Before fix** — failure goes unnoticed, script continues:
```
root@debian:~# wget -qO - https://raw.githubusercontent.com/lirantal/daloradius/master/setup/install.sh | bash
[+] Updating system package lists... OK
[+] Upgrading system packages... OK
[+] Installing MariaDB... OK        ← should be KO
[+] Securing MariaDB... KO
[!] Failed to secure MariaDB. Aborting.
```

**After fix** — failure is properly detected:
```
root@debian:~# wget -qO - https://raw.githubusercontent.com/retho-p/daloradius/master/setup/install.sh | bash
[+] Updating system package lists... OK
[+] Upgrading system packages... OK
[+] Installing MariaDB... KO
[!] Failed to install MariaDB. Aborting.
```

**Full successful run** after re-enabling `sources.list`:
```
root@debian:~# wget -qO - https://raw.githubusercontent.com/retho-p/daloradius/master/setup/install.sh | bash
[+] Updating system package lists... OK
[+] Upgrading system packages... OK
[+] Installing MariaDB... OK
[+] Securing MariaDB... OK
[+] Initializing MariaDB database and user... OK
[+] Initializing MariaDB configuration... OK
[+] Installing daloRADIUS dependencies... OK
[+] Downloading and setting up daloRADIUS... OK
[+] Creating required directories for daloRADIUS... OK
[+] Setting up daloRADIUS... OK
[+] Loading daloRADIUS SQL schema into MariaDB... OK
[+] Installing freeRADIUS... OK
[+] Setting up freeRADIUS SQL module... OK
[+] Enabling and restarting freeRADIUS... OK
[+] Disabling all Apache sites... OK
[+] Setting up Apache environment variables for daloRADIUS... OK
[+] Setting up Apache ports for daloRADIUS... OK
[+] Setting up Apache site for operators... OK
[+] Setting up Apache site for users... OK
[+] Enabling and restarting Apache... OK
[+] daloRADIUS has been installed.
```
