### PR TITLE
Fix: Allow all printable characters in passwords during CSV import

### DIFF
--- a/app/common/includes/validation.php
+++ b/app/common/includes/validation.php
@@ -44,7 +44,7 @@ define("PINCODE_REGEX", '/^[a-zA-Z0-9]+$/');
 define("LOOSE_IP_REGEX", '/^(((2(5[0-5]|[0-4][0-9]))|1[0-9]{2}|[1-9]?[0-9])\.?){1,4}$/');
 
 define("FIRST_LAST_NAME_REGEX", '/^[ \-\p{L}0-9]+$/u');
-define("SAFE_PASSWORD_REGEX", '/^[^\x00-\x1F\x7F]+$/');
+define("SAFE_PASSWORD_REGEX", '/^\P{C}+$/u');
 define("EMAIL_LIKE_USERNAME_REGEX", '/^[A-Za-z0-9][A-Za-z0-9_.-]*(?:@[A-Za-z0-9.-]+\.[A-Za-z]{2,})?$/');
 define("LOG_FILEPATH_REGEX", '/^(\/[a-zA-Z0-9]+)+(\.log)?$/');
 


### PR DESCRIPTION
### Problem

When importing users via CSV (`mng-import-users.php`), passwords containing common characters such as `/`, `~`, `%`, `|`, `\`, `'`, `"`, spaces, and others are **silently rejected**. The affected users are skipped with no error message or log entry, making the issue very difficult to diagnose.

This is caused by `SAFE_PASSWORD_REGEX` in `validation.php`, which uses a restrictive character whitelist:

```php
// Before
define("SAFE_PASSWORD_REGEX", '/^[\w!@#$^&*()\-_=+{};:.<>]+$/');
```

For example, a user with password `staff/001` or `2024/ABC/789` will be silently dropped during import.

### Root Cause Analysis

The regex was introduced as a defensive security measure during the codebase refactoring, but it is **unnecessarily restrictive** for the following reasons:

1. **SQL injection is already handled** — `insert_single_attribute()` uses `$dbSocket->escapeSimple()` on all values before insertion
2. **Hashing functions accept any input** — `md5()`, `sha1()`, `crypt()`, `mhash()` all handle arbitrary characters
3. **CSV parsing is unaffected** — `str_getcsv()` handles `/` and other characters correctly
4. **FreeRADIUS has no character restrictions** on password attribute values
5. **Inconsistent with other forms** — `mng-new.php` and `mng-batch-add.php` apply **no regex validation** on passwords at all

### Fix

Replace the whitelist approach with a blacklist that only rejects ASCII control characters (`0x00`–`0x1F` and `0x7F`), which are the only characters truly invalid in a password:

```php
// After
define("SAFE_PASSWORD_REGEX", '/^[^\x00-\x1F\x7F]+$/');
```

### Testing

Import the following CSV data via **Management → Import Users**:

```
slashuser1,staff/001,slash@test.com,John,Doe
slashuser2,2024/ABC/789,multi@test.com,Jane,Smith
spaceuser,my password,space@test.com,Bob,Wilson
tildeuser,pass~word,tilde@test.com,Alice,Brown
normaluser,simple123,normal@test.com,Test,User
```

- **Before fix**: only `normaluser` is imported (1/5)
- **After fix**: all 5 users are imported successfully

### Files Changed

- `app/common/includes/validation.php` — Updated `SAFE_PASSWORD_REGEX` definition

Fixes #628, #619 and #569
