### PR TITLE
fix: huntgroup list column name order

### DIFF
--- a/app/operators/mng-rad-hunt-list.php
+++ b/app/operators/mng-rad-hunt-list.php
@@ -41,9 +41,9 @@
 
     $cols = array(
                     "id" => t('all','HgID'),
+                    "groupname" => t('all','HgGroupName'),
                     "nasipaddress" => t('all','HgIPHost'),
                     "nasportid" => t('all','HgPortId'),
-                    "groupname" => t('all','HgGroupName'),
                  );
     $colspan = count($cols);
     $half_colspan = intval($colspan / 2);


### PR DESCRIPTION
### Problem
Just a minor thing...
Huntgroup List column name order is wrong

### FIX
Put column head of "Groupname" after "ID"