### PR TITLE
fix(accounting): enable MAC-based user search in accounting and login attempts

### DIFF
--- a/app/operators/include/management/pages_common.php
+++ b/app/operators/include/management/pages_common.php
@@ -399,7 +399,8 @@ function printTableHead($cols, $orderBy="", $orderType="asc", $partial_query_str
             $title_asc = sprintf($title_format, strip_tags($caption), 'ascending');
             $title_desc = sprintf($title_format, strip_tags($caption), 'descending');
 
-            $href_format = '?orderBy=%s&orderType=%s' . $partial_query_string;
+            $partial_query_string_safe = str_replace('%', '%%', $partial_query_string);
+            $href_format = '?orderBy=%s&orderType=%s' . $partial_query_string_safe; 
             $href_asc = sprintf($href_format, $param, 'asc');
             $href_desc = sprintf($href_format, $param, 'desc');
 

--- a/app/users/include/management/pages_common.php
+++ b/app/users/include/management/pages_common.php
@@ -373,7 +373,8 @@ function printTableHead($cols, $orderBy="", $orderType="asc", $partial_query_str
             $title_asc = sprintf($title_format, strip_tags($caption), 'ascending');
             $title_desc = sprintf($title_format, strip_tags($caption), 'descending');
 
-            $href_format = '?orderBy=%s&orderType=%s' . $partial_query_string;
+            $partial_query_string_safe = str_replace('%', '%%', $partial_query_string);
+            $href_format = '?orderBy=%s&orderType=%s' . $partial_query_string_safe; 
             $href_asc = sprintf($href_format, $param, 'asc');
             $href_desc = sprintf($href_format, $param, 'desc');
 


### PR DESCRIPTION
This PR fixes an issue where MAC-based users (e.g., 00:15:5D:C9:FA:01) were not returning any results in:
- Accounting → Accounting by User
- Reports → Last Login Attempts

Even though these users exist in the database and have associated records, the search queries failed to match them correctly.

Root Cause:
The problem was caused by how the search filters handled usernames containing special characters like `:` (common in MAC addresses). The existing queries did not properly match these values, leading to empty result sets.

This PR fixes https://github.com/lirantal/daloradius/issues/667