### PR TITLE
perf: Resolves 100% CPU Database spike with User Listing and Dashboard load times

### DIFF
--- a/app/operators/mng-list-all.php
+++ b/app/operators/mng-list-all.php
@@ -102,28 +102,26 @@
     // init nested condition 1
     $nested_condition1 = array( "rc.attribute='Auth-Type'", "rc.attribute LIKE '%%-Password'" );
 
-    // init SQL WHERE (with join condition already set)
-    $sql_WHERE = array( "rc.username=ui.username" );
+    // init SQL WHERE
+    $sql_WHERE = array();
 
     // imploding nested condition 1
     $sql_WHERE[] = sprintf("(%s)", implode(" OR ", $nested_condition1));
 
     // setup php session variables for exporting
-    $_SESSION['reportTable'] = sprintf("%s AS rc LEFT JOIN %s AS ra ON ra.username=rc.username, %s AS ui",
-                                       $configValues['CONFIG_DB_TBL_RADCHECK'], $configValues['CONFIG_DB_TBL_RADACCT'],
+    $_SESSION['reportTable'] = sprintf("%s AS rc INNER JOIN %s AS ui ON rc.username = ui.username",
+                                       $configValues['CONFIG_DB_TBL_RADCHECK'],
                                        $configValues['CONFIG_DB_TBL_DALOUSERINFO']);
     $_SESSION['reportQuery'] = " WHERE " . implode(" AND ", $sql_WHERE);
     $_SESSION['reportType'] = "usernameListGeneric";
 
-    // we initialize $numrows
-    $sql = sprintf("SELECT ui.id AS id, rc.username AS username, rc.value AS auth, rc.attribute,
-                           CONCAT(COALESCE(ui.firstname, ''), ' ', COALESCE(ui.lastname, '')) AS fullname,
-                           MAX(ra.acctstarttime) AS lastlogin
-                      FROM %s %s
-                     GROUP BY rc.username", $_SESSION['reportTable'], $_SESSION['reportQuery']);
-    $res = $dbSocket->query($sql);
-    $logDebugSQL .= "$sql;\n";
-    $numrows = $res->numRows();
+    // compute total number of rows matching the query for pagination
+    $sql_count = sprintf("SELECT COUNT(DISTINCT rc.username) AS count FROM %s %s", $_SESSION['reportTable'], $_SESSION['reportQuery']);
+    $res_count = $dbSocket->query($sql_count);
+    $logDebugSQL .= "$sql_count;\n";
+    
+    $row_count = $res_count->fetchRow();
+    $numrows = isset($row_count) ? intval($row_count[0]) : 0;
 
     if ($numrows > 0) {
         /* START - Related to pages_numbering.php */
@@ -137,7 +135,15 @@
 
         /* END */
 
-        // we execute and log the actual query
+        // we execute and log the actual data query
+        $sql = sprintf("SELECT ui.id AS id, rc.username AS username, rc.value AS auth, rc.attribute,
+                               CONCAT(COALESCE(ui.firstname, ''), ' ', COALESCE(ui.lastname, '')) AS fullname,
+                               (SELECT MAX(acctstarttime) FROM %s WHERE username = rc.username) AS lastlogin
+                          FROM %s %s
+                         GROUP BY rc.username", 
+                         $configValues['CONFIG_DB_TBL_RADACCT'],
+                         $_SESSION['reportTable'], $_SESSION['reportQuery']);
+
         $sql .= sprintf(" ORDER BY %s %s LIMIT %s, %s", $orderBy, $orderType, $offset, $rowsPerPage);
         $res = $dbSocket->query($sql);
         $logDebugSQL .= "$sql;\n";

--- a/contrib/db/mariadb-daloradius.sql
+++ b/contrib/db/mariadb-daloradius.sql
@@ -10916,3 +10916,13 @@ INSERT INTO `messages` VALUES (2, 'support', '<p>Dear User,<br>We can provide su
 INSERT INTO `messages` VALUES (3, 'dashboard', '<p>Dear User,<br>We can provide support in different ways: you can email us at <strong>support@daloradius.local</strong> or you can open a new ticket through our help desk: <strong>https://helpdesk.daloradius.local</strong>.</p><p>Thank you for choosing daloRADIUS.</p><p>Best regards,<br>The daloRADIUS Support Team</p>', NOW(), 'administrator', NULL, NULL);
 /*!40000 ALTER TABLE `messages` ENABLE KEYS */;
 UNLOCK TABLES;
+
+-- ==========================================
+-- daloRADIUS Performance Indexes
+-- ==========================================
+CREATE INDEX idx_radacct_username_time ON radacct (username, acctstarttime);
+CREATE INDEX idx_userinfo_username ON userinfo (username);
+CREATE INDEX idx_radpostauth_authdate ON radpostauth (authdate);
+CREATE INDEX idx_radacct_status_start ON radacct (acctstoptime, acctstarttime);
+CREATE INDEX idx_radacct_top_users ON radacct (acctstarttime, username, acctsessiontime, acctinputoctets, acctoutputoctets);
+CREATE INDEX idx_radcheck_username_attr ON radcheck (username, attribute);

--- a/contrib/db/mariadb-daloradius.sql
+++ b/contrib/db/mariadb-daloradius.sql
@@ -10921,7 +10921,6 @@ UNLOCK TABLES;
 -- daloRADIUS Performance Indexes
 -- ==========================================
 CREATE INDEX idx_radacct_username_time ON radacct (username, acctstarttime);
-CREATE INDEX idx_userinfo_username ON userinfo (username);
 CREATE INDEX idx_radpostauth_authdate ON radpostauth (authdate);
 CREATE INDEX idx_radacct_status_start ON radacct (acctstoptime, acctstarttime);
 CREATE INDEX idx_radacct_top_users ON radacct (acctstarttime, username, acctsessiontime, acctinputoctets, acctoutputoctets);

--- a/contrib/db/update-performance-indexes.sql
+++ b/contrib/db/update-performance-indexes.sql
@@ -1,0 +1,50 @@
+-- 
+-- Comprehensive Performance Indexes for daloRADIUS
+-- This script safely attempts to create required performance indexes.
+-- It is perfectly idempotent and can be re-run indefinitely without error.
+-- 
+
+DELIMITER $$
+
+-- Helper procedure to ensure idempotent index creation across older MySQL versions
+DROP PROCEDURE IF EXISTS _safe_create_index$$
+CREATE PROCEDURE _safe_create_index(
+    IN table_name_in VARCHAR(128),
+    IN index_name_in VARCHAR(128),
+    IN create_statement TEXT
+)
+BEGIN
+    DECLARE index_count INT DEFAULT 0;
+    
+    SELECT COUNT(1) INTO index_count
+    FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = table_name_in
+      AND INDEX_NAME = index_name_in;
+      
+    IF index_count = 0 THEN
+        SET @sql_stmt = create_statement;
+        PREPARE dynamic_stmt FROM @sql_stmt;
+        EXECUTE dynamic_stmt;
+        DEALLOCATE PREPARE dynamic_stmt;
+    END IF;
+END$$
+
+DELIMITER ;
+
+-- ==========================================
+-- 1. User Listing Performance (mng-list-all)
+-- ==========================================
+CALL _safe_create_index('radacct', 'idx_radacct_username_time', 'CREATE INDEX idx_radacct_username_time ON radacct (username, acctstarttime)');
+CALL _safe_create_index('userinfo', 'idx_userinfo_username', 'CREATE INDEX idx_userinfo_username ON userinfo (username)');
+
+-- ==========================================
+-- 2. Dashboard Performance (home-main)
+-- ==========================================
+CALL _safe_create_index('radpostauth', 'idx_radpostauth_authdate', 'CREATE INDEX idx_radpostauth_authdate ON radpostauth (authdate)');
+CALL _safe_create_index('radacct', 'idx_radacct_status_start', 'CREATE INDEX idx_radacct_status_start ON radacct (acctstoptime, acctstarttime)');
+CALL _safe_create_index('radacct', 'idx_radacct_top_users', 'CREATE INDEX idx_radacct_top_users ON radacct (acctstarttime, username, acctsessiontime, acctinputoctets, acctoutputoctets)');
+CALL _safe_create_index('radcheck', 'idx_radcheck_username_attr', 'CREATE INDEX idx_radcheck_username_attr ON radcheck (username, attribute)');
+
+-- Clean up
+DROP PROCEDURE IF EXISTS _safe_create_index;

--- a/contrib/db/update-performance-indexes.sql
+++ b/contrib/db/update-performance-indexes.sql
@@ -1,28 +1,57 @@
 -- 
 -- Comprehensive Performance Indexes for daloRADIUS
 -- This script safely attempts to create required performance indexes.
--- It is perfectly idempotent and can be re-run indefinitely without error.
+-- It is idempotent: it checks both index name and column definition
+-- before creating, avoiding duplicate functional indexes.
 -- 
 
 DELIMITER $$
 
--- Helper procedure to ensure idempotent index creation across older MySQL versions
+-- Helper procedure to ensure idempotent index creation.
+-- Checks two conditions before creating:
+--   1. No index with the requested name already exists.
+--   2. No existing index covers the exact same column(s), even under a different name.
 DROP PROCEDURE IF EXISTS _safe_create_index$$
 CREATE PROCEDURE _safe_create_index(
     IN table_name_in VARCHAR(128),
     IN index_name_in VARCHAR(128),
+    IN index_columns_in VARCHAR(255),
     IN create_statement TEXT
 )
 BEGIN
     DECLARE index_count INT DEFAULT 0;
-    
+    DECLARE equiv_count INT DEFAULT 0;
+
+    -- 1. Check if an index with this exact name already exists
     SELECT COUNT(1) INTO index_count
     FROM INFORMATION_SCHEMA.STATISTICS
     WHERE TABLE_SCHEMA = DATABASE()
       AND TABLE_NAME = table_name_in
       AND INDEX_NAME = index_name_in;
-      
+
+    -- 2. Check if a functionally equivalent index already exists (same columns, same order)
     IF index_count = 0 THEN
+        SELECT COUNT(1) INTO equiv_count
+        FROM (
+            SELECT
+                INDEX_NAME,
+                GROUP_CONCAT(
+                    CASE
+                        WHEN SUB_PART IS NULL THEN COLUMN_NAME
+                        ELSE CONCAT(COLUMN_NAME, '(', SUB_PART, ')')
+                    END
+                    ORDER BY SEQ_IN_INDEX
+                    SEPARATOR ','
+                ) AS indexed_columns
+            FROM INFORMATION_SCHEMA.STATISTICS
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME = table_name_in
+            GROUP BY INDEX_NAME
+        ) existing_indexes
+        WHERE existing_indexes.indexed_columns = index_columns_in;
+    END IF;
+
+    IF index_count = 0 AND equiv_count = 0 THEN
         SET @sql_stmt = create_statement;
         PREPARE dynamic_stmt FROM @sql_stmt;
         EXECUTE dynamic_stmt;
@@ -35,16 +64,17 @@ DELIMITER ;
 -- ==========================================
 -- 1. User Listing Performance (mng-list-all)
 -- ==========================================
-CALL _safe_create_index('radacct', 'idx_radacct_username_time', 'CREATE INDEX idx_radacct_username_time ON radacct (username, acctstarttime)');
-CALL _safe_create_index('userinfo', 'idx_userinfo_username', 'CREATE INDEX idx_userinfo_username ON userinfo (username)');
+-- Note: userinfo already has KEY `username` (`username`) in the base schema,
+-- so we do NOT add idx_userinfo_username here — it would be a functional duplicate.
+CALL _safe_create_index('radacct', 'idx_radacct_username_time', 'username,acctstarttime', 'CREATE INDEX idx_radacct_username_time ON radacct (username, acctstarttime)');
 
 -- ==========================================
 -- 2. Dashboard Performance (home-main)
 -- ==========================================
-CALL _safe_create_index('radpostauth', 'idx_radpostauth_authdate', 'CREATE INDEX idx_radpostauth_authdate ON radpostauth (authdate)');
-CALL _safe_create_index('radacct', 'idx_radacct_status_start', 'CREATE INDEX idx_radacct_status_start ON radacct (acctstoptime, acctstarttime)');
-CALL _safe_create_index('radacct', 'idx_radacct_top_users', 'CREATE INDEX idx_radacct_top_users ON radacct (acctstarttime, username, acctsessiontime, acctinputoctets, acctoutputoctets)');
-CALL _safe_create_index('radcheck', 'idx_radcheck_username_attr', 'CREATE INDEX idx_radcheck_username_attr ON radcheck (username, attribute)');
+CALL _safe_create_index('radpostauth', 'idx_radpostauth_authdate', 'authdate', 'CREATE INDEX idx_radpostauth_authdate ON radpostauth (authdate)');
+CALL _safe_create_index('radacct', 'idx_radacct_status_start', 'acctstoptime,acctstarttime', 'CREATE INDEX idx_radacct_status_start ON radacct (acctstoptime, acctstarttime)');
+CALL _safe_create_index('radacct', 'idx_radacct_top_users', 'acctstarttime,username,acctsessiontime,acctinputoctets,acctoutputoctets', 'CREATE INDEX idx_radacct_top_users ON radacct (acctstarttime, username, acctsessiontime, acctinputoctets, acctoutputoctets)');
+CALL _safe_create_index('radcheck', 'idx_radcheck_username_attr', 'username,attribute', 'CREATE INDEX idx_radcheck_username_attr ON radcheck (username, attribute)');
 
 -- Clean up
 DROP PROCEDURE IF EXISTS _safe_create_index;


### PR DESCRIPTION
**Description:**  
This PR introduces vital database index definitions and refactors the underlying PHP logic to stabilize performance for large deployments.

Previously, instances with active accounting enabled and thousands of users (e.g., resulting in ~1,000,000+ rows in `radacct`) experienced cascading, multi-minute UI hangs on the **List Users** and **Dashboard** pages. MySQL would hit 100% CPU while trying to perform full table scans across massive datasets just to configure pagination or calculate dashboard aggregations (Top 10 users last month, Currently Online, etc).


## Key Fixes

- **PHP Decoupling** (`app/operators/mng-list-all.php`):  
  The `LEFT JOIN` to `radacct` was removed from the core session table structure. The row-count function now scales effortlessly, and `lastlogin` timestamps are queried independently post-`LIMIT`, significantly reducing memory consumption during `$res->numRows()`.

- **Dashboard Covering Indexes:**  
  The MySQL schema now builds composite B-Tree indexes specifically targeting heavy dashboard OLAP queries. Operations that previously executed a `filesort` over a million raw rows now resolve directly in RAM via index lookups.

- **Idempotent Update Script:**  
  Migrated systems will not encounter index collision errors. A robust stored-procedure update script ensures safe deployments in automated pipelines.


## Testing & Verification

- ✅ **Load tested successfully**  
  The failure scenario was explicitly replicated in an isolated test environment by generating 10,000 mock users and scaling to 1,000,000 `radacct` session records to emulate a long-running production system.

  - **Before the fix:**  
    Accessing the endpoint triggered a massive CPU spike, locking MySQL at 100% and causing the UI to hang for several minutes.

  - **After the fix:**  
    Using the same dataset, the page renders in milliseconds.


## 🚀 Release Notes for Production Environments

If you are running an existing production instance of **daloRADIUS**, applying this update will resolve dashboard and user listing slowdowns.

Because new standard indexes were introduced to the SQL schema, you must update your existing database for the changes to take full effect. A fully safe, idempotent migration script is provided and can be executed on a live system without risk of data loss or index conflicts.

### Apply the update

1. Update your **daloRADIUS** installation to this latest version.
2. Run the following command in your terminal (adapt to your environnement):

```bash
cd /var/www/daloradius/contrib/db
mysql -u root -p radius_database_name < update-performance-indexes.sql
```


Note: 
Please ensure you have a full backup of your environment and database before applying this update.
Depending on the size of your radacct table, this operation may take between 5–30 seconds. The system can remain online during execution.