### PR TITLE
Refactor NAS Management: Enforce strict validation and update NAS types list

### DIFF
--- a/app/common/includes/validation.php
+++ b/app/common/includes/validation.php
@@ -133,8 +133,10 @@ $valid_db_engines = array(
 
 // values taken from an instance of freeradius 3.0.21
 $valid_nastypes = array(
-                         "other", "cisco", "computone", "livingston", "juniper", "max40xx", "multitech",
-                         "netserver", "pathras", "patton", "portslave", "tc", "usrhiper"
+                         "livingston", "cisco", "cvx", "juniper", "multitech", "computone", "max40xx",
+                         "ascend", "portslave", "tc", "pathras", "pr3000", "pr4000", "patton", "digitro",
+                         "usrhiper", "netserver", "versanet", "bay", "cisco_l2tp", "mikrotik", "mikrotik_snmp",
+                         "redback", "dot1x", "other"
                        );
 
 // accounting custom-query options list

--- a/app/operators/lang/en.php
+++ b/app/operators/lang/en.php
@@ -1360,11 +1360,15 @@ $l['helpPage']['mngradippool'] .= $l['helpPage']['mngradippoolnew'] . $l['helpPa
                                 . $l['helpPage']['mngradippooledit'] . $l['helpPage']['mngradippooldel'];
 
 // nas help pages
-$l['helpPage']['mngradnas'] = "";
+$l['helpPage']['mngradnas'] = <<<EOF
+<h1 class="fs-5">NAS Management</h1>
+<p>A Network Access Server (NAS) acts as a gateway to guard access to a network. In a FreeRADIUS environment, the NAS is the physical or virtual device (such as a router, switch, VPN gateway, or wireless access point) that sends RADIUS authentication, authorization, and accounting requests to the RADIUS server.</p>
+<p>Managing NAS entries is a critical security requirement. FreeRADIUS must be explicitly configured with the IP address (or hostname) and a shared secret for each NAS device. Without this configuration, the RADIUS server will silently ignore any incoming requests from that device.</p>
+EOF;
 $l['helpPage']['mngradnasdel'] = "To remove a nas ip/host entry from the database you must provide the ip/host of the account";
-$l['helpPage']['mngradnasnew'] = "";
+$l['helpPage']['mngradnasnew'] = "You may fill below details for a new NAS device addition to the database.";
 $l['helpPage']['mngradnaslist'] = "";
-$l['helpPage']['mngradnasedit'] = "";
+$l['helpPage']['mngradnasedit'] = "You may edit below details for the NAS device.";
 
 // huntgroup help pages
 $l['helpPage']['mngradhunt'] = <<<EOF

--- a/app/operators/mng-rad-nas-edit.php
+++ b/app/operators/mng-rad-nas-edit.php
@@ -69,8 +69,25 @@
             $secret = (array_key_exists('secret', $_POST) && !empty(str_replace("%", "", trim($_POST['secret']))))
                     ? str_replace("%", "", trim($_POST['secret'])) : "";
     
+            // allow the current DB type to pass validation even if it is a
+            // legacy/custom value not present in $valid_nastypes, so that
+            // re-submitting the edit form does not silently overwrite it
+            $allowed_types = $valid_nastypes;
+            if (!empty($nasname)) {
+                $sql_cur = sprintf("SELECT type FROM %s WHERE nasname='%s' LIMIT 1",
+                                   $configValues['CONFIG_DB_TBL_RADNAS'],
+                                   $dbSocket->escapeSimple($nasname));
+                $res_cur = $dbSocket->query($sql_cur);
+                $logDebugSQL .= "$sql_cur;\n";
+                $row_cur = $res_cur->fetchrow();
+                if ($row_cur && !empty($row_cur[0])) {
+                    $allowed_types[] = $row_cur[0];
+                    $allowed_types = array_unique($allowed_types);
+                }
+            }
+
             $type = (array_key_exists('type', $_POST) && isset($_POST['type']) &&
-                     in_array($_POST['type'], $valid_nastypes)) ? $_POST['type'] : "other";
+                     in_array($_POST['type'], $allowed_types)) ? $_POST['type'] : "other";
             
             $shortname = (array_key_exists('shortname', $_POST) && !empty(str_replace("%", "", trim($_POST['shortname']))))
                        ? str_replace("%", "", trim($_POST['shortname'])) : "";
@@ -183,13 +200,30 @@
                                         "tooltipText" => "Enter the shared secret used for RADIUS communication."
                                      );
                                      
+        // preserve legacy/custom NAS type values loaded from DB
+        $nastype_options = $valid_nastypes;
+        $nastype_selected = (isset($type) && $type !== "") ? $type : "other";
+        $nastype_tooltip = "Select the NAS vendor type from the predefined list.";
+
+        if ($nastype_selected !== "other" && !in_array($nastype_selected, $valid_nastypes)) {
+            // DB contains a type not in the standard list — build an associative
+            // options map so the legacy value is shown and stays selected
+            $nastype_options = array();
+            $nastype_options[$nastype_selected] = $nastype_selected . " (legacy)";
+            foreach ($valid_nastypes as $nt) {
+                $nastype_options[$nt] = $nt;
+            }
+            $nastype_tooltip = "The current type is not in the standard list. "
+                             . "It will be preserved unless you select a different value.";
+        }
+
         $input_descriptors0[] = array(
                                         "name" => "type",
                                         "caption" => t('all','NasType'),
                                         "type" => "select",
-                                        "options" => $valid_nastypes,
-                                        "selected_value" => ((isset($type)) ? $type : "other"),
-                                        "tooltipText" => "Select the NAS vendor type from the predefined list."
+                                        "options" => $nastype_options,
+                                        "selected_value" => $nastype_selected,
+                                        "tooltipText" => $nastype_tooltip
                                      );
                                      
         $input_descriptors0[] = array(

--- a/app/operators/mng-rad-nas-edit.php
+++ b/app/operators/mng-rad-nas-edit.php
@@ -70,7 +70,7 @@
                     ? str_replace("%", "", trim($_POST['secret'])) : "";
     
             $type = (array_key_exists('type', $_POST) && isset($_POST['type']) &&
-                     in_array($_POST['type'], $valid_nastypes)) ? $_POST['type'] : $valid_nastypes[0];
+                     in_array($_POST['type'], $valid_nastypes)) ? $_POST['type'] : "other";
             
             $shortname = (array_key_exists('shortname', $_POST) && !empty(str_replace("%", "", trim($_POST['shortname']))))
                        ? str_replace("%", "", trim($_POST['shortname'])) : "";
@@ -171,29 +171,33 @@
                                         "caption" => t('all','NasIPHost'),
                                         "type" => "text",
                                         "value" => ((isset($nasname)) ? $nasname : ""),
-                                        "disabled" => true
+                                        "disabled" => true,
+                                        "tooltipText" => "Enter the IP address or hostname of the NAS device."
                                      );
                                      
         $input_descriptors0[] = array(
                                         "name" => "secret",
                                         "caption" => t('all','NasSecret'),
                                         "type" => "text",
-                                        "value" => ((isset($secret)) ? $secret : "")
+                                        "value" => ((isset($secret)) ? $secret : ""),
+                                        "tooltipText" => "Enter the shared secret used for RADIUS communication."
                                      );
                                      
         $input_descriptors0[] = array(
                                         "name" => "type",
                                         "caption" => t('all','NasType'),
-                                        "type" => "text",
-                                        "datalist" => $valid_nastypes,
-                                        "value" => ((isset($type)) ? $type : $valid_nastypes[0])
+                                        "type" => "select",
+                                        "options" => $valid_nastypes,
+                                        "selected_value" => ((isset($type)) ? $type : "other"),
+                                        "tooltipText" => "Select the NAS vendor type from the predefined list."
                                      );
                                      
         $input_descriptors0[] = array(
                                         "name" => "shortname",
                                         "caption" => t('all','NasShortname'),
                                         "type" => "text",
-                                        "value" => ((isset($shortname)) ? $shortname : "")
+                                        "value" => ((isset($shortname)) ? $shortname : ""),
+                                        "tooltipText" => "A friendly short name to identify this NAS."
                                      );
 
         
@@ -213,21 +217,24 @@
                                         "name" => "community",
                                         "caption" => t('all','NasCommunity'),
                                         "type" => "text",
-                                        "value" => ((isset($community)) ? $community : "")
+                                        "value" => ((isset($community)) ? $community : ""),
+                                        "tooltipText" => "SNMP community string for querying the NAS (optional)."
                                      );
                                      
         $input_descriptors1[] = array(
                                         "name" => "server",
                                         "caption" => t('all','NasVirtualServer'),
                                         "type" => "text",
-                                        "value" => ((isset($server)) ? $server : "")
+                                        "value" => ((isset($server)) ? $server : ""),
+                                        "tooltipText" => "FreeRADIUS virtual server to process requests from this NAS (optional)."
                                      );
                                      
         $input_descriptors1[] = array(
                                         "name" => "description",
                                         "caption" => t('all','NasDescription'),
                                         "type" => "textarea",
-                                        "content" => ((isset($description)) ? $description : "")
+                                        "content" => ((isset($description)) ? $description : ""),
+                                        "tooltipText" => "Additional details or notes about this NAS device."
                                      );
 
         $input_descriptors2 = array();

--- a/app/operators/mng-rad-nas-new.php
+++ b/app/operators/mng-rad-nas-new.php
@@ -47,7 +47,7 @@
             $nasname_enc = (!empty($nasname)) ? htmlspecialchars($nasname, ENT_QUOTES, 'UTF-8') : "";
             
             $nastype = (array_key_exists('nastype', $_POST) && isset($_POST['nastype']) &&
-                        in_array($_POST['nastype'], $valid_nastypes)) ? $_POST['nastype'] : $valid_nastypes[0];
+                        in_array($_POST['nastype'], $valid_nastypes)) ? $_POST['nastype'] : "other";
             
             $shortname = (array_key_exists('shortname', $_POST) && !empty(str_replace("%", "", trim($_POST['shortname']))))
                        ? str_replace("%", "", trim($_POST['shortname'])) : "";
@@ -132,29 +132,33 @@
                                         "name" => "nasname",
                                         "caption" => t('all','NasIPHost'),
                                         "type" => "text",
-                                        "value" => ((isset($nasname)) ? $nasname : "")
+                                        "value" => ((isset($nasname)) ? $nasname : ""),
+                                        "tooltipText" => "Enter the IP address or hostname of the NAS device."
                                      );
                                      
         $input_descriptors0[] = array(
                                         "name" => "nassecret",
                                         "caption" => t('all','NasSecret'),
                                         "type" => "text",
-                                        "value" => ((isset($nassecret)) ? $nassecret : "")
+                                        "value" => ((isset($nassecret)) ? $nassecret : ""),
+                                        "tooltipText" => "Enter the shared secret used for RADIUS communication."
                                      );
                                      
         $input_descriptors0[] = array(
                                         "name" => "nastype",
                                         "caption" => t('all','NasType'),
-                                        "type" => "text",
-                                        "datalist" => $valid_nastypes,
-                                        "value" => ((isset($nastype)) ? $nastype : $valid_nastypes[0])
+                                        "type" => "select",
+                                        "options" => $valid_nastypes,
+                                        "selected_value" => ((isset($nastype)) ? $nastype : "other"),
+                                        "tooltipText" => "Select the NAS vendor type from the predefined list."
                                      );
                                      
         $input_descriptors0[] = array(
                                         "name" => "shortname",
                                         "caption" => t('all','NasShortname'),
                                         "type" => "text",
-                                        "value" => ((isset($shortname)) ? $shortname : "")
+                                        "value" => ((isset($shortname)) ? $shortname : ""),
+                                        "tooltipText" => "A friendly short name to identify this NAS."
                                      );
 
         
@@ -174,21 +178,24 @@
                                         "name" => "nascommunity",
                                         "caption" => t('all','NasCommunity'),
                                         "type" => "text",
-                                        "value" => ((isset($nascommunity)) ? $nascommunity : "")
+                                        "value" => ((isset($nascommunity)) ? $nascommunity : ""),
+                                        "tooltipText" => "SNMP community string for querying the NAS (optional)."
                                      );
                                      
         $input_descriptors1[] = array(
                                         "name" => "nasvirtualserver",
                                         "caption" => t('all','NasVirtualServer'),
                                         "type" => "text",
-                                        "value" => ((isset($nasvirtualserver)) ? $nasvirtualserver : "")
+                                        "value" => ((isset($nasvirtualserver)) ? $nasvirtualserver : ""),
+                                        "tooltipText" => "FreeRADIUS virtual server to process requests from this NAS (optional)."
                                      );
                                      
         $input_descriptors1[] = array(
                                         "name" => "nasdescription",
                                         "caption" => t('all','NasDescription'),
                                         "type" => "textarea",
-                                        "content" => ((isset($nasdescription)) ? $nasdescription : "")
+                                        "content" => ((isset($nasdescription)) ? $nasdescription : ""),
+                                        "tooltipText" => "Additional details or notes about this NAS device."
                                      );
 
         $input_descriptors2 = array();


### PR DESCRIPTION
## Description
This Pull Request improves the NAS management forms by updating the valid NAS types list and ensuring strict validation.

## Changes
- Updated the `$valid_nastypes` array in `validation.php` to use the official FreeRADIUS 3.x list.
- Changed the "NAS Type" input to a native HTML `<select>` dropdown in `mng-rad-nas-new.php` and `mng-rad-nas-edit.php`.
- Added contextual tooltips (`tooltipText`) to all fields in the NAS creation and editing forms.
- Enabled help modals for `mngradnasnew` and `mngradnasedit` by adding help texts in `lang/en.php`.