### PR TITLE
Fix: resolve proxy/realm management bugs (#522)

### DIFF
--- a/app/operators/mng-rad-proxys-new.php
+++ b/app/operators/mng-rad-proxys-new.php
@@ -146,6 +146,14 @@
     
     if (!isset($successMsg)) {
         
+        // ensure form variables are initialized (they may not be set on initial
+        // GET requests or when POST validation fails before reaching their assignment)
+        $proxyname = (isset($proxyname)) ? $proxyname : "";
+        $retry_delay = (isset($retry_delay)) ? $retry_delay : "";
+        $retry_count = (isset($retry_count)) ? $retry_count : "";
+        $dead_time = (isset($dead_time)) ? $dead_time : "";
+        $default_fallback = (isset($default_fallback)) ? $default_fallback : "";
+        
         // descriptors 0
         $input_descriptors0 = array();
 

--- a/app/operators/mng-rad-realms-edit.php
+++ b/app/operators/mng-rad-realms-edit.php
@@ -50,7 +50,7 @@
                    ? str_replace("%", "", trim($_REQUEST['realmname'])) : "";
     }
 
-    $exists = in_array($realmname, array_keys($valid_realmnames));
+    $exists = in_array($realmname, $valid_realmnames);
 
     
     if (!$exists) {

--- a/app/operators/mng-rad-realms-new.php
+++ b/app/operators/mng-rad-realms-new.php
@@ -168,7 +168,7 @@
                                         'name' => 'realmname',
                                         'caption' => t('all','RealmName'),
                                         'type' => 'text',
-                                        'value' => $realmname,
+                                        'value' => ((isset($realmname)) ? $realmname : ""),
                                         'required' => true,
                                         'tooltipText' => t('Tooltip','realmNameTooltip'),
                                      );

--- a/doc/setup/freeradius-proxy-permissions.md
+++ b/doc/setup/freeradius-proxy-permissions.md
@@ -1,0 +1,44 @@
+# Configuring FreeRADIUS proxy.conf Permissions
+
+When managing Realms and Proxies via the daloRADIUS web interface, you may encounter an error stating that the file `/etc/freeradius/3.0/proxy.conf` is not writable. 
+
+While the proxy/realm entry is saved correctly to the database, daloRADIUS requires permission to write the configuration to the actual FreeRADIUS configuration file so the RADIUS server can use it.
+
+## The Secure Solution (ACLs)
+
+It is highly discouraged to use `chmod 777` or to add the web server user (`www-data`) to the `freerad` group. Doing so grants excessive privileges to the web server and creates significant security risks.
+
+The recommended, secure approach is to use POSIX Access Control Lists (ACLs). This grants the web server precise read and write permissions to **only** the specific file it needs, without changing the file's primary owner.
+
+### Step-by-Step Configuration
+
+Run the following commands as `root` (or using `sudo`). *Note: Adjust the path if your FreeRADIUS version is different (e.g., `/etc/freeradius/3.0/`).*
+
+1. **Install the ACL package** (if not already installed):
+   ```bash
+   apt update
+   apt install acl
+   ```
+
+2. **Grant the web server traversal access to the directories**:
+   The web server needs to be able to traverse the directories to reach the file. We grant execute (`x`) permission to others, which allows the web server to enter the directory without allowing it to read/list the directory contents.
+   ```bash
+   chmod o+x /etc/freeradius
+   chmod o+x /etc/freeradius/3.0
+   ```
+
+3. **Grant the web server Read/Write access to proxy.conf**:
+   Use `setfacl` to give the `www-data` user read and write permissions on the file itself.
+   ```bash
+   setfacl -m u:www-data:rw /etc/freeradius/3.0/proxy.conf
+   ```
+
+4. **Verify the permissions**:
+   You can verify that the ACLs were applied correctly using `getfacl`:
+   ```bash
+   getfacl /etc/freeradius/3.0/proxy.conf
+   ```
+   You should see `user:www-data:rw-` in the output.
+
+---
+**Note on Package Upgrades:** If the `freeradius` package is updated via your OS package manager, the file permissions might be reset. If the "not writable" error returns after a system update, simply re-run step 3.


### PR DESCRIPTION
- mng-rad-proxys-new.php & mng-rad-realms-new.php: Initialize missing form variables to prevent "Undefined variable" PHP warnings on GET requests or validation failures.
- mng-rad-realms-edit.php: Fix the "invalid realm item" error by removing an incorrect array_keys() wrapper in the realm existence validation check.
- docs: Add doc/setup/freeradius-proxy-permissions.md documenting the secure ACL method for granting the web server write access to FreeRADIUS config files.