### PR TITLE
Modernize Docker development stack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,9 @@
 # Run the container:
 # 1. docker run -p 80:80 -p 8000:8000 -d lirantal/daloradius
 
-FROM debian:11-slim
-MAINTAINER Liran Tal <liran.tal@gmail.com>
-
-LABEL Description="daloRADIUS Official Docker based on Debian 11 and PHP7." \
+FROM debian:13-slim
+LABEL maintainer="Liran Tal <liran.tal@gmail.com>"
+LABEL Description="daloRADIUS Official Docker based on Debian 13 and PHP 8.4." \
 	License="GPLv2" \
 	Usage="docker build . -t lirantal/daloradius && docker run -d -p 80:80 -p 8000:8000 lirantal/daloradius" \
 	Version="2.0beta"

--- a/Dockerfile-freeradius
+++ b/Dockerfile-freeradius
@@ -8,10 +8,9 @@
 # Run the container:
 # 1. docker run -p 80:80 -d lirantal/dalofreeradius
 
-FROM freeradius/freeradius-server:latest
-MAINTAINER Liran Tal <liran.tal@gmail.com>
-
-LABEL Description="freeradius Docker based on Ubuntu 20.04 LTS, optimized for daloRADIUS." \
+FROM freeradius/freeradius-server:3.2.8
+LABEL maintainer="Liran Tal <liran.tal@gmail.com>"
+LABEL Description="FreeRADIUS 3.2.8 Docker image optimized for daloRADIUS." \
 	License="GPLv2" \
 	Usage="docker build -t lirantal/dalofreeradius -f Dockerfile-freeradius && docker run -d -p 80:80 lirantal/dalofreeradius" \
 	Version="1.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,7 @@
-version: "3"
-
 services:
 
   radius-mysql:
-    image: mariadb:10
+    image: mariadb:11.8
     container_name: radius-mysql
     restart: unless-stopped
     environment:
@@ -13,15 +11,23 @@ services:
       - MYSQL_ROOT_PASSWORD=radiusrootdbpw
     volumes:
       - "./data/mysql:/var/lib/mysql"
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
 
   radius:
+    image: lirantal/dalofreeradius
     container_name: radius
     build:
       context: .
       dockerfile: Dockerfile-freeradius
     restart: unless-stopped
-    depends_on: 
-      - radius-mysql
+    depends_on:
+      radius-mysql:
+        condition: service_healthy
     ports:
       - '1812:1812/udp'
       - '1813:1813/udp'
@@ -40,12 +46,15 @@ services:
     #command: -X
 
   radius-web:
+    image: lirantal/daloradius
     build: .
     container_name: radius-web
     restart: unless-stopped
     depends_on:
-      - radius
-      - radius-mysql
+      radius-mysql:
+        condition: service_healthy
+      radius:
+        condition: service_started
     ports:
       - '80:80'
       - '8000:8000'

--- a/init-freeradius.sh
+++ b/init-freeradius.sh
@@ -67,7 +67,7 @@ function init_database {
 echo "Starting freeradius..."
 
 # wait for MySQL-Server to be ready
-while ! mysqladmin ping -h"$MYSQL_HOST" --silent; do
+while ! mysqladmin ping -h"$MYSQL_HOST" -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" --silent; do
 	echo "Waiting for mysql ($MYSQL_HOST)..."
 	sleep 20
 done

--- a/init.sh
+++ b/init.sh
@@ -36,9 +36,9 @@ function init_daloradius {
 }
 
 function init_database {
-    mysql -u root -p"$MYSQL_ROOT_PASSWORD" -e "CREATE DATABASE $MYSQL_DATABASE;"
-    mysql -u root -p"$MYSQL_ROOT_PASSWORD" -e "CREATE USER '$MYSQL_USER'@'localhost' IDENTIFIED BY '$MYSQL_PASSWORD';"
-    mysql -u root -p"$MYSQL_ROOT_PASSWORD" -e "GRANT ALL PRIVILEGES ON $MYSQL_DATABASE.* TO '$MYSQL_USER'@'localhost'";
+    # The official MariaDB container creates MYSQL_DATABASE/MYSQL_USER during startup.
+    # Import the daloRADIUS schema with the application user instead of trying to
+    # create local users/databases from the web container.
     mysql -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" < $DALORADIUS_PATH/contrib/db/mariadb-daloradius.sql
     echo "Database initialization for daloRADIUS completed."
 }
@@ -60,7 +60,7 @@ fi
 
 # wait for MySQL-Server to be ready
 echo -n "Waiting for mysql ($MYSQL_HOST)..."
-while ! mysqladmin ping -h"$MYSQL_HOST" -p"$MYSQL_PASSWORD" --silent; do
+while ! mysqladmin ping -h"$MYSQL_HOST" -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" --silent; do
     sleep 20
 done
 echo "ok"


### PR DESCRIPTION
## Summary

This PR modernizes the Docker stack used to run daloRADIUS with FreeRADIUS and MariaDB.

Changes include:

- Update the daloRADIUS web image base from Debian 11 to Debian 13
- Update the web stack to the Debian-provided PHP 8.4 packages
- Replace deprecated Dockerfile `MAINTAINER` instructions with `LABEL maintainer`
- Pin the FreeRADIUS base image to `freeradius/freeradius-server:3.2.8` instead of using `latest`
- Update MariaDB from `mariadb:10` to `mariadb:11.8`
- Add a MariaDB healthcheck
- Make the application services wait for MariaDB to become healthy before starting
- Avoid root database access from application containers during initialization
- Use the MariaDB-created application user to import the daloRADIUS schema
- Use authenticated `mysqladmin ping` checks in init scripts

The existing user-facing container names and image names are preserved.

## Testing

Validated with a full clean rebuild from scratch:

```bash
docker compose -f docker-compose.yml down --volumes --remove-orphans
rm -rf data
mkdir -p data
docker compose -f docker-compose.yml config --quiet
docker compose -f docker-compose.yml up -d --build
docker compose -f docker-compose.yml ps
```

Result:

```text
radius-mysql   mariadb:11.8              Up / healthy
radius         lirantal/dalofreeradius   Up
radius-web     lirantal/daloradius       Up
```

Verified versions:

```text
Debian 13.4
PHP 8.4.16
Apache 2.4.67
FreeRADIUS 3.2.8
MariaDB 11.8.6
```

HTTP checks on both exposed web ports returned the expected redirect:

```text
HTTP/1.1 302 Found
Location: home-main.php
```

Checked:

```text
http://127.0.0.1/
http://127.0.0.1:8000/
```

A recent log scan found no obvious startup errors.
