### PR TITLE
fix: create radhuntgroup table in Docker init

### DIFF
--- a/init-freeradius.sh
+++ b/init-freeradius.sh
@@ -46,9 +46,23 @@ function init_freeradius {
 	echo "freeradius initialization completed."
 }
 
+function ensure_daloradius_schema {
+	mysql -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" <<'EOSQL'
+CREATE TABLE IF NOT EXISTS `radhuntgroup` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `groupname` varchar(64) NOT NULL DEFAULT '',
+  `nasipaddress` varchar(15) NOT NULL DEFAULT '',
+  `nasportid` varchar(15) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `nasipaddress` (`nasipaddress`)
+);
+EOSQL
+}
+
 function init_database {
 	mysql -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" < $RADIUS_PATH/mods-config/sql/main/mysql/schema.sql
 	mysql -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" < $RADIUS_PATH/mods-config/sql/ippool/mysql/schema.sql
+	ensure_daloradius_schema
 
 	# Insert a client for the current subnet (to allow daloradius to perform checks)
 	IP=`ifconfig eth0 | awk '/inet/{ print $2;} '` # does also work: $IP=`hostname -I | awk '{print $1}'`
@@ -92,6 +106,7 @@ fi
 DB_LOCK=/data/.db_init_done
 if test -f "$DB_LOCK"; then
 	echo "Database lock file exists, skipping initial setup of mysql database."
+	ensure_daloradius_schema
 else
 	init_database
 	date > $DB_LOCK


### PR DESCRIPTION
# Summary

Fixes a Docker installation schema mismatch where the HuntGroups management page fails because the `radhuntgroup` table is missing.

Docker mode currently imports the stock FreeRADIUS MySQL schemas plus the daloRADIUS application schema, but it does not import `contrib/db/fr3-mariadb-freeradius.sql`. That leaves Docker installs without the `radhuntgroup` table expected by the daloRADIUS UI.

This change adds a small Docker init step that ensures the `radhuntgroup` table exists.

# What changed

- Adds `ensure_daloradius_schema` to `init-freeradius.sh`.
- Creates `radhuntgroup` with the same structure already present in `contrib/db/fr3-mariadb-freeradius.sql`.
- Runs the schema assurance:
  - during fresh FreeRADIUS database initialization;
  - and when the DB init lock already exists, so existing Docker installs are repaired automatically.

# Validation

Tested in Docker mode:

```text
DB Error: no such table
Table 'radius.radhuntgroup' doesn't exist
```

- Rebuilt/restarted the Docker `radius` container.
- Confirmed `radhuntgroup` was created in MariaDB.
- Confirmed the page loads without the database error.

# Related issue

Fixes #633