### PR TITLE
chore: configure FreeRADIUS noresetcounter for Max-All-Session support

### DIFF
--- a/doc/install/INSTALL.debian.md
+++ b/doc/install/INSTALL.debian.md
@@ -106,6 +106,24 @@ To finalize the installation of FreeRADIUS, enable the SQL module by creating a 
 ln -s /etc/freeradius/3.0/mods-available/sql /etc/freeradius/3.0/mods-enabled/
 ```
 
+To enforce total session-time limits such as `Max-All-Session`, also enable the SQL counter module:
+```bash
+sed -Ei 's/^[\t\s#]*dialect\s+=\s+.*$/\tdialect = "mysql"/g' /etc/freeradius/3.0/mods-available/sqlcounter
+ln -s /etc/freeradius/3.0/mods-available/sqlcounter /etc/freeradius/3.0/mods-enabled/
+```
+
+Then add the `noresetcounter` SQL counter to the `authorize` section in `/etc/freeradius/3.0/sites-available/default`, immediately after `-sql`:
+```text
+authorize {
+    ...
+    -sql
+    noresetcounter
+    ...
+}
+```
+
+This lets FreeRADIUS compare the user's accumulated accounting time with daloRADIUS check attributes such as `Max-All-Session`.
+
 To complete the installation, enable and restart the FreeRADIUS service using the following commands:
 ```bash
 systemctl enable freeradius

--- a/init-freeradius.sh
+++ b/init-freeradius.sh
@@ -17,6 +17,7 @@ function init_freeradius {
 	ln -s $RADIUS_PATH/mods-available/sql $RADIUS_PATH/mods-enabled/sql
 	ln -s $RADIUS_PATH/mods-available/sqlcounter $RADIUS_PATH/mods-enabled/sqlcounter
 	ln -s $RADIUS_PATH/mods-available/sqlippool $RADIUS_PATH/mods-enabled/sqlippool
+	enable_noresetcounter
 	sed -i 's|instantiate {|instantiate {\nsql|' $RADIUS_PATH/radiusd.conf # mods-enabled does not ensure the right order
 
 	# Enable used tunnel for unifi
@@ -44,6 +45,33 @@ function init_freeradius {
 		sed -i 's|testing123|'$DEFAULT_CLIENT_SECRET'|' $RADIUS_PATH/mods-available/sql
 	fi
 	echo "freeradius initialization completed."
+}
+
+function enable_noresetcounter {
+	# Enforce Max-All-Session limits through FreeRADIUS sqlcounter.
+	# The sqlcounter module must run in authorize; enabling mods-enabled/sqlcounter alone is not enough.
+	if grep -q "^[[:space:]]*noresetcounter[[:space:]]*$" $RADIUS_PATH/sites-available/default; then
+		return
+	fi
+
+	if ! awk '
+		BEGIN { in_authorize = 0; added = 0 }
+		/^authorize[[:space:]]*[{]/ { in_authorize = 1 }
+		in_authorize && !added && /^[[:space:]]*-sql$/ {
+			print
+			print "\tnoresetcounter"
+			added = 1
+			next
+		}
+		/^authenticate[[:space:]]*[{]/ { in_authorize = 0 }
+		{ print }
+		END { exit added ? 0 : 1 }
+	' $RADIUS_PATH/sites-available/default > /tmp/freeradius-default; then
+		rm -f /tmp/freeradius-default
+		echo "Failed to add noresetcounter to FreeRADIUS authorize section."
+		exit 1
+	fi
+	mv /tmp/freeradius-default $RADIUS_PATH/sites-available/default
 }
 
 function ensure_daloradius_schema {
@@ -91,6 +119,7 @@ if test -f "$INIT_LOCK"; then
 	# Lock file exists, but verify that FreeRADIUS is actually configured
 	# This handles the case where containers are recreated but volumes persist
 	if test -L "$RADIUS_PATH/mods-enabled/sql" && grep -q "rlm_sql_mysql" "$RADIUS_PATH/mods-available/sql" 2>/dev/null; then
+		enable_noresetcounter
 		echo "Init lock file exists and FreeRADIUS is properly configured, skipping initial setup."
 	else
 		echo "Init lock file exists but FreeRADIUS configuration is missing, reinitializing..."
@@ -101,6 +130,12 @@ if test -f "$INIT_LOCK"; then
 else
 	init_freeradius
 	date > $INIT_LOCK
+fi
+
+# Ensure Max-All-Session is enforced before FreeRADIUS starts, including after
+# lock-file and reinitialization paths.
+if test -L "$RADIUS_PATH/mods-enabled/sqlcounter"; then
+	enable_noresetcounter
 fi
 
 DB_LOCK=/data/.db_init_done

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -27,6 +27,8 @@ DALORADIUS_ROOT_DIRECTORY=/var/www/daloradius
 DALORADIUS_CONF_FILE="${DALORADIUS_ROOT_DIRECTORY}/app/common/includes/daloradius.conf.php"
 DALORADIUS_SERVER_ADMIN=admin@daloradius.local
 FREERADIUS_SQL_MOD_PATH="/etc/freeradius/3.0/mods-available/sql"
+FREERADIUS_SQLCOUNTER_MOD_PATH="/etc/freeradius/3.0/mods-available/sqlcounter"
+FREERADIUS_DEFAULT_SITE_PATH="/etc/freeradius/3.0/sites-available/default"
 
 # Function to print an OK message in green
 print_green() {
@@ -222,6 +224,50 @@ freeradius_setup_sql_mod() {
         echo "[!] Failed to set up freeRADIUS SQL module. Aborting." >&2
         exit 1
     fi
+    print_green "OK"
+}
+
+
+# Function to set up freeRADIUS SQL counter module for Max-All-Session enforcement
+freeradius_setup_sqlcounter_mod() {
+    echo -n "[+] Setting up freeRADIUS SQL counter module... "
+
+    if ! sed -Ei 's/^[[:space:]#]*dialect[[:space:]]+=[[:space:]]+.*$/	dialect = "mysql"/g' "${FREERADIUS_SQLCOUNTER_MOD_PATH}" >/dev/null 2>&1; then
+        print_red "KO"
+        echo "[!] Failed to configure freeRADIUS SQL counter module. Aborting." >&2
+        exit 1
+    fi
+
+    if [ ! -e /etc/freeradius/3.0/mods-enabled/sqlcounter ]; then
+        if ! ln -s "${FREERADIUS_SQLCOUNTER_MOD_PATH}" /etc/freeradius/3.0/mods-enabled/ >/dev/null 2>&1; then
+            print_red "KO"
+            echo "[!] Failed to enable freeRADIUS SQL counter module. Aborting." >&2
+            exit 1
+        fi
+    fi
+
+    if ! grep -q "^[[:space:]]*noresetcounter[[:space:]]*$" "${FREERADIUS_DEFAULT_SITE_PATH}"; then
+        if ! awk '
+            BEGIN { in_authorize = 0; added = 0 }
+            /^authorize[[:space:]]*[{]/ { in_authorize = 1 }
+            in_authorize && !added && /^[[:space:]]*-sql$/ {
+                print
+                print "	noresetcounter"
+                added = 1
+                next
+            }
+            /^authenticate[[:space:]]*[{]/ { in_authorize = 0 }
+            { print }
+            END { exit added ? 0 : 1 }
+        ' "${FREERADIUS_DEFAULT_SITE_PATH}" > /tmp/freeradius-default; then
+            rm -f /tmp/freeradius-default
+            print_red "KO"
+            echo "[!] Failed to add noresetcounter to freeRADIUS authorize section. Aborting." >&2
+            exit 1
+        fi
+        mv /tmp/freeradius-default "${FREERADIUS_DEFAULT_SITE_PATH}"
+    fi
+
     print_green "OK"
 }
 
@@ -575,6 +621,7 @@ main() {
 
     freeradius_install
     freeradius_setup_sql_mod
+    freeradius_setup_sqlcounter_mod
     freeradius_enable_restart
 
     apache_disable_all_sites


### PR DESCRIPTION
# Summary

This PR updates the FreeRADIUS configuration generated by the daloRADIUS setup paths so that `Max-All-Session` can be enforced when it is configured for a user or group.

`Max-All-Session` is evaluated by FreeRADIUS through the `sqlcounter` module, specifically the `noresetcounter` instance. Enabling or installing `sqlcounter` alone is not enough: `noresetcounter` must also be called from the FreeRADIUS `authorize` section after SQL has loaded the user check items.

This change adds that configuration in the Docker, manual, and script-based install paths.

# Why this is needed

daloRADIUS can manage RADIUS attributes such as `Max-All-Session`, but enforcement is performed by FreeRADIUS.

Without calling `noresetcounter` during authorization, a user may have `Max-All-Session` configured and accounting data showing that the limit has already been exceeded, while FreeRADIUS still returns `Access-Accept`.

With this configuration in place, FreeRADIUS rejects authentication once the accumulated session time exceeds the configured limit.

# Changes

- Configure the FreeRADIUS `authorize` section to call `noresetcounter`.
- Insert `noresetcounter` after `-sql`, so SQL-backed check items are available before the counter runs.
- Apply the configuration consistently across:
  - Docker setup
  - manual installation documentation/configuration
  - script-based installation
- Keep the change idempotent so repeated setup runs do not duplicate the entry.

# Behavior impact

This does not change daloRADIUS application logic. It enables the relevant FreeRADIUS configuration required for `Max-All-Session` to work.

For deployments that do not use `Max-All-Session`, this should not change authentication decisions.

For deployments that already have `Max-All-Session` values configured but did not previously have `noresetcounter` enabled, this change may start enforcing those limits as intended.


# Validation

Install.sh script tested successfully
docker installation tested successfully 

Tested with a user configured with:

```text
Cleartext-Password := password
Max-All-Session := 60
```

and existing accounting data showing more than 60 seconds of prior usage.

Before this configuration, authentication returned:

```text
Received Access-Accept
```

After this configuration, FreeRADIUS correctly returned:

```text
Received Access-Reject
Reply-Message = "Your maximum never usage time has been reached"
```


# Notes

Proper enforcement depends on the NAS sending accounting packets so that consumed session time is recorded in `radacct`.