### PR TITLE
fix: harden operator security controls

### DIFF
--- a/app/operators/config-operators-edit.php
+++ b/app/operators/config-operators-edit.php
@@ -91,17 +91,26 @@
                 $messenger2 = (array_key_exists('messenger2', $_POST) && isset($_POST['messenger2'])) ? trim($_POST['messenger2']) : "";
                 $notes = (array_key_exists('notes', $_POST) && isset($_POST['notes'])) ? trim($_POST['notes']) : "";
                 
+                if (empty($operator_password)) {
+                    $sql = sprintf("SELECT password FROM %s WHERE id=%d",
+                                   $configValues['CONFIG_DB_TBL_DALOOPERATORS'], $curr_operator_id);
+                    $operator_password_hash = $dbSocket->getOne($sql);
+                    $logDebugSQL .= "$sql;\n";
+                } else {
+                    $operator_password_hash = password_hash($operator_password, PASSWORD_DEFAULT);
+                }
+
                 // update operator data into the database
                 $sql = sprintf("UPDATE %s SET password='%s', firstname='%s', lastname='%s', title='%s', department='%s',
                                               company='%s', phone1='%s', phone2='%s', email1='%s', email2='%s', messenger1='%s',
                                               messenger2='%s', updatedate='%s', updateby='%s'
                                  WHERE username='%s'",
-                               $configValues['CONFIG_DB_TBL_DALOOPERATORS'], $dbSocket->escapeSimple($operator_password),
+                               $configValues['CONFIG_DB_TBL_DALOOPERATORS'], $dbSocket->escapeSimple($operator_password_hash),
                                $dbSocket->escapeSimple($firstname), $dbSocket->escapeSimple($lastname), $dbSocket->escapeSimple($title),
                                $dbSocket->escapeSimple($department), $dbSocket->escapeSimple($company), $dbSocket->escapeSimple($phone1),
                                $dbSocket->escapeSimple($phone2), $dbSocket->escapeSimple($email1), $dbSocket->escapeSimple($email2),
                                $dbSocket->escapeSimple($messenger1), $dbSocket->escapeSimple($messenger2), $current_datetime,
-                               $currBy, $dbSocket->escapeSimple($operator_username));
+                               $dbSocket->escapeSimple($currBy), $dbSocket->escapeSimple($operator_username));
                 $res = $dbSocket->query($sql);
                 $logDebugSQL .= "$sql;\n";
 
@@ -228,7 +237,7 @@
                                         "name" => "operator_password",
                                         "caption" => t('all','Password'),
                                         "type" => $hiddenPassword,
-                                        "value" => ((isset($operator_password)) ? $operator_password : ""),
+                                        "value" => "",
                                         "random" => true
                                      );
                                   

--- a/app/operators/config-operators-new.php
+++ b/app/operators/config-operators-new.php
@@ -85,14 +85,22 @@
                     $current_datetime = date('Y-m-d H:i:s');
                     $currBy = $_SESSION['operator_user'];
 
-                    // insert username and password of operator into the database
+                    $operator_password_hash = password_hash($operator_password, PASSWORD_DEFAULT);
+
+                    // insert username and hashed password of operator into the database
                     $sql = sprintf("INSERT INTO %s (id, username, password, firstname, lastname, title, department, company,
                                                     phone1, phone2, email1, email2, messenger1, messenger2, notes, creationdate,
                                                     creationby, updatedate, updateby)
                                             VALUES (0, '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s',
                                                     '%s', '%s', '%s', '%s', NULL, NULL)", $configValues['CONFIG_DB_TBL_DALOOPERATORS'],
-                                   $operator_username, $operator_password, $firstname, $lastname, $title, $department, $company,
-                                   $phone1, $phone2, $email1, $email2, $messenger1, $messenger2, $notes, $current_datetime, $currBy);
+                                   $dbSocket->escapeSimple($operator_username), $dbSocket->escapeSimple($operator_password_hash),
+                                   $dbSocket->escapeSimple($firstname), $dbSocket->escapeSimple($lastname),
+                                   $dbSocket->escapeSimple($title), $dbSocket->escapeSimple($department),
+                                   $dbSocket->escapeSimple($company), $dbSocket->escapeSimple($phone1),
+                                   $dbSocket->escapeSimple($phone2), $dbSocket->escapeSimple($email1),
+                                   $dbSocket->escapeSimple($email2), $dbSocket->escapeSimple($messenger1),
+                                   $dbSocket->escapeSimple($messenger2), $dbSocket->escapeSimple($notes),
+                                   $current_datetime, $dbSocket->escapeSimple($currBy));
                     $res = $dbSocket->query($sql);
                     $logDebugSQL .= "$sql;\n";
 

--- a/app/operators/dologin.php
+++ b/app/operators/dologin.php
@@ -59,28 +59,40 @@ if (array_key_exists('csrf_token', $_POST) && isset($_POST['csrf_token']) &&
     include('../common/includes/db_open.php');
     
     $operator_user = $dbSocket->escapeSimple($_POST['operator_user']);
-    $operator_pass = $dbSocket->escapeSimple($_POST['operator_pass']);
-    
-    $sqlFormat = "select * from %s where username='%s' and password='%s'";
-    $sql = sprintf($sqlFormat, $configValues['CONFIG_DB_TBL_DALOOPERATORS'], $operator_user, $operator_pass);
+    $operator_pass = $_POST['operator_pass'];
+
+    $sqlFormat = "select * from %s where username='%s'";
+    $sql = sprintf($sqlFormat, $configValues['CONFIG_DB_TBL_DALOOPERATORS'], $operator_user);
     $res = $dbSocket->query($sql);
     $numRows = $res->numRows();
     
     // we only accept ONE AND ONLY ONE RECORD as result
     if ($numRows === 1) {
         $row = $res->fetchRow(DB_FETCHMODE_ASSOC);
-        $operator_id = $row['id'];
-        
-        $_SESSION['daloradius_logged_in'] = true;
-        $_SESSION['operator_user'] = $operator_user;
-        $_SESSION['operator_id'] = $operator_id;
-        
-        // lets update the lastlogin time for this operator
-        $now = date("Y-m-d H:i:s");
-        $sqlFormat = "update %s set lastlogin='%s' where username='%s'";
-        $sql = sprintf($sqlFormat, $configValues['CONFIG_DB_TBL_DALOOPERATORS'], $now, $operator_user);
-        $res = $dbSocket->query($sql);
+        $stored_password = $row['password'];
+        $verified = password_verify($operator_pass, $stored_password);
+        $legacy_verified = (!$verified && hash_equals($stored_password, $operator_pass));
 
+        if ($verified || $legacy_verified) {
+            $operator_id = $row['id'];
+
+            $_SESSION['daloradius_logged_in'] = true;
+            $_SESSION['operator_user'] = $operator_user;
+            $_SESSION['operator_id'] = $operator_id;
+
+            // lets update the lastlogin time for this operator
+            $now = date("Y-m-d H:i:s");
+            $sqlFormat = "update %s set lastlogin='%s' where username='%s'";
+            $sql = sprintf($sqlFormat, $configValues['CONFIG_DB_TBL_DALOOPERATORS'], $now, $operator_user);
+            $res = $dbSocket->query($sql);
+
+            if ($legacy_verified || password_needs_rehash($stored_password, PASSWORD_DEFAULT)) {
+                $operator_pass_hash = $dbSocket->escapeSimple(password_hash($operator_pass, PASSWORD_DEFAULT));
+                $sqlFormat = "update %s set password='%s' where username='%s'";
+                $sql = sprintf($sqlFormat, $configValues['CONFIG_DB_TBL_DALOOPERATORS'], $operator_pass_hash, $operator_user);
+                $res = $dbSocket->query($sql);
+            }
+        }
     }
     
     // close connection to db before redirecting

--- a/app/operators/library/ajax/attributes.php
+++ b/app/operators/library/ajax/attributes.php
@@ -25,6 +25,9 @@
 
 include_once implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', '..', '..', 'common', 'includes', 'config_read.php' ]);
 include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'checklogin.php' ]);
+$operator_perm_file = 'mng_rad_attributes_list';
+$operator_perm_deny_http_status = 403;
+include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'check_operator_perm.php' ]);
 include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LANG'], 'main.php' ]);
 include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'validation.php' ]);
 

--- a/app/operators/library/ajax/hotspot_info.php
+++ b/app/operators/library/ajax/hotspot_info.php
@@ -22,6 +22,9 @@
  */
 
 include('../checklogin.php');
+$operator_perm_file = 'acct_hotspot_accounting';
+$operator_perm_deny_http_status = 403;
+include('../check_operator_perm.php');
 
 
 // username and divContainer are required

--- a/app/operators/library/ajax/json_api.php
+++ b/app/operators/library/ajax/json_api.php
@@ -22,6 +22,9 @@
  */
 
 include('../checklogin.php');
+$operator_perm_file = 'mng_search';
+$operator_perm_deny_http_status = 403;
+include('../check_operator_perm.php');
 
 // datatype => allowed actions
 $whitelist = array();

--- a/app/operators/library/ajax/user_actions.php
+++ b/app/operators/library/ajax/user_actions.php
@@ -79,6 +79,23 @@ if (array_key_exists('username', $_GET) && isset($_GET['username']) &&
         $action = 'userEnable';
     }
 
+    switch ($action) {
+        case 'userDisable':
+        case 'userEnable':
+        case 'userMail':
+        case 'refillSessionTime':
+        case 'refillSessionTraffic':
+            $operator_perm_file = 'mng_edit';
+            break;
+
+        default:
+            $operator_perm_file = 'mng_search';
+            break;
+    }
+
+    $operator_perm_deny_http_status = 403;
+    include_once('../check_operator_perm.php');
+
     include('../../../common/includes/db_open.php');
     include_once('../../include/management/pages_common.php');
 

--- a/app/operators/library/ajax/user_info.php
+++ b/app/operators/library/ajax/user_info.php
@@ -22,6 +22,9 @@
  */
 
 include('../checklogin.php');
+$operator_perm_file = 'acct_username';
+$operator_perm_deny_http_status = 403;
+include('../check_operator_perm.php');
 
 
 // username and divContainer are required

--- a/app/operators/library/ajax/vendor_attribute_info.php
+++ b/app/operators/library/ajax/vendor_attribute_info.php
@@ -22,6 +22,9 @@
  */
 
 include('../checklogin.php');
+$operator_perm_file = 'mng_rad_attributes_list';
+$operator_perm_deny_http_status = 403;
+include('../check_operator_perm.php');
 
 
 // attribute and divContainer are required

--- a/app/operators/library/check_operator_perm.php
+++ b/app/operators/library/check_operator_perm.php
@@ -33,19 +33,29 @@ if (strpos($_SERVER['PHP_SELF'], '/library/check_operator_perm.php') !== false) 
 // we replace every instance of the - symbol with _ and we completely
 // remove the .php extension
 // this formatting is done to match the exact entry for the page as it
-// appears in the operators_acl table
-$file = str_replace("-", "_", basename($_SERVER['SCRIPT_NAME'], ".php"));
+// appears in the operators_acl table.
+//
+// AJAX endpoints may serve as helpers for existing ACL-protected pages, so
+// they can set $operator_perm_file before including this file.
+$file = (isset($operator_perm_file) && !empty($operator_perm_file))
+      ? $operator_perm_file
+      : str_replace("-", "_", basename($_SERVER['SCRIPT_NAME'], ".php"));
 
-include('../common/includes/db_open.php');
+include(implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', '..', 'common', 'includes', 'db_open.php' ]));
 
 $sql = sprintf("SELECT access FROM %s WHERE operator_id=%d AND file='%s'",
                $configValues['CONFIG_DB_TBL_DALOOPERATORS_ACL'], $_SESSION['operator_id'], $file);
 $access = intval($dbSocket->getOne($sql)) === 1;
 
-include('../common/includes/db_close.php');
+include(implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', '..', 'common', 'includes', 'db_close.php' ]));
 
 // we finally check if the access to the requested page could be granted
 if (!$access) {
+    if (isset($operator_perm_deny_http_status)) {
+        http_response_code(intval($operator_perm_deny_http_status));
+        exit;
+    }
+
     header('Location: home-error.php');
     exit;
 }


### PR DESCRIPTION
# Summary

This patch hardens operator security controls by addressing three reported issues in  #653 :

- Escapes all operator creation `INSERT` values to prevent SQL injection.
- Adds ACL authorization checks to operator AJAX endpoints.
- Stores operator passwords with `password_hash()` and verifies them with `password_verify()`.

# Details

- Operator creation now escapes all interpolated fields and hashes the password before storing it.
- Operator edit now hashes changed passwords and preserves the existing password when the field is left blank.
- Operator login now:
  - fetches by username;
  - verifies hashed passwords with `password_verify()`;
  - supports legacy plaintext passwords once;
  - upgrades legacy plaintext passwords to hashes after successful login.
- AJAX endpoints now map to existing ACL permissions and return HTTP `403` when unauthorized.

# Validation

- Ran PHP syntax checks for changed operator and AJAX files inside the Docker web container.
- Verified existing operator login still succeeds after password-hash migration.
- Verified operator creation stores SQLi payloads literally rather than executing them.
- Verified a no-ACL operator receives `403` from protected AJAX endpoints.

Resolves #653

Resolves #524