### PR TITLE
Feat/import compatible user csv export

### DIFF
--- a/app/operators/include/management/fileExport.php
+++ b/app/operators/include/management/fileExport.php
@@ -116,28 +116,70 @@ switch ($reportType) {
         break;
 
     case "usernameListGeneric":
-        // we use this associative array for generating both,
-        // Output Header and SQL selected fields
+        // Export users in the same field order accepted by mng-import-users.php.
+        // Required (5): username, password, email, firstname, lastname
+        // Optional (15): framedipaddress, expiration, department, company, mobilephone,
+        //                workphone, homephone, address, city, state, country, zip,
+        //                sessiontimeout, idletimeout, maxdailysession
         $cols = array(
-                        "Id" => "ui.id",
-                        "Fullname" => "CONCAT(COALESCE(ui.firstname, ''), ' ', COALESCE(ui.lastname, '')) AS fullname",
-                        "Username" => "rc.username",
-                        "Attribute" => "rc.attribute",
-                        "Auth" => "rc.value"
+                        "username" => "rc.username AS username",
+                        "password" => "COALESCE(MAX(CASE WHEN rc_export.attribute LIKE '%%-Password' THEN rc_export.value END), "
+                                    . "MAX(CASE WHEN rc_export.attribute='Auth-Type' THEN rc_export.value END), '') AS password",
+                        "email" => "COALESCE(MAX(ui.email), '') AS email",
+                        "firstname" => "COALESCE(MAX(ui.firstname), '') AS firstname",
+                        "lastname" => "COALESCE(MAX(ui.lastname), '') AS lastname",
+                        "framedipaddress" => "COALESCE(MAX(CASE WHEN rr_export.attribute='Framed-IP-Address' THEN rr_export.value END), '') "
+                                           . "AS framedipaddress",
+                        "expiration" => "COALESCE(MAX(CASE WHEN rc_export.attribute='Expiration' THEN rc_export.value END), '') AS expiration",
+                        "department" => "COALESCE(MAX(ui.department), '') AS department",
+                        "company" => "COALESCE(MAX(ui.company), '') AS company",
+                        "mobilephone" => "COALESCE(MAX(ui.mobilephone), '') AS mobilephone",
+                        "workphone" => "COALESCE(MAX(ui.workphone), '') AS workphone",
+                        "homephone" => "COALESCE(MAX(ui.homephone), '') AS homephone",
+                        "address" => "COALESCE(MAX(ui.address), '') AS address",
+                        "city" => "COALESCE(MAX(ui.city), '') AS city",
+                        "state" => "COALESCE(MAX(ui.state), '') AS state",
+                        "country" => "COALESCE(MAX(ui.country), '') AS country",
+                        "zip" => "COALESCE(MAX(ui.zip), '') AS zip",
+                        "sessiontimeout" => "COALESCE(MAX(CASE WHEN rr_export.attribute='Session-Timeout' THEN rr_export.value END), '') "
+                                          . "AS sessiontimeout",
+                        "idletimeout" => "COALESCE(MAX(CASE WHEN rr_export.attribute='Idle-Timeout' THEN rr_export.value END), '') "
+                                       . "AS idletimeout",
+                        "maxdailysession" => "COALESCE(MAX(CASE WHEN rc_export.attribute='Max-Daily-Session' THEN rc_export.value END), '') "
+                                           . "AS maxdailysession"
                      );
-        
+
         $selected_fields = implode(", ", array_values($cols));
-        $sql = sprintf("SELECT %s FROM %s %s ORDER BY %s ASC",
-                       $selected_fields, $reportTable, $reportQuery, array_values($cols)[0]);
+        $sql = sprintf("SELECT %s FROM %s LEFT JOIN %s AS rc_export ON rc_export.username=rc.username "
+                     . "LEFT JOIN %s AS rr_export ON rr_export.username=rc.username %s "
+                     . "GROUP BY rc.username ORDER BY rc.username ASC",
+                       $selected_fields, $reportTable, $configValues['CONFIG_DB_TBL_RADCHECK'],
+                       $configValues['CONFIG_DB_TBL_RADREPLY'], $reportQuery);
         $res = $dbSocket->query($sql);
-        
-        // this is the output header
-        $output = implode(", ", array_keys($cols)) . "\n";
-        
-        // this is the remaining part of the output content
-        while($row = $res->fetchRow()) {
-            $output .= implode(",", $row) . "\n";
+
+        $csv = fopen('php://temp', 'r+');
+        fputcsv($csv, array_keys($cols), ',', '"', '');
+
+        while ($row = $res->fetchRow(DB_FETCHMODE_ASSOC)) {
+            // mng-import-users.php expects expiration as YYYY-MM-DD, while FreeRADIUS stores it as "d M Y".
+            if (!empty($row['expiration'])) {
+                $expiration = DateTime::createFromFormat('d M Y', $row['expiration']);
+                if ($expiration !== false) {
+                    $row['expiration'] = $expiration->format('Y-m-d');
+                }
+            }
+
+            $fields = array();
+            foreach (array_keys($cols) as $field) {
+                $fields[] = $row[$field] ?? '';
+            }
+
+            fputcsv($csv, $fields, ',', '"', '');
         }
+
+        rewind($csv);
+        $output = stream_get_contents($csv);
+        fclose($csv);
 
         break;
 

--- a/app/operators/include/management/fileExport.php
+++ b/app/operators/include/management/fileExport.php
@@ -33,7 +33,7 @@ $reportFormat = (array_key_exists('reportFormat', $_GET) && isset($_GET['reportF
 
 // this are all the report types this script can generate
 $types = array(
-                "accountingGeneric", "usernameListGeneric", "reportsOnlineUsers", "reportsLastConnectionAttempts",
+                "accountingGeneric", "usernameListGeneric", "usernameListByGroup", "reportsOnlineUsers", "reportsLastConnectionAttempts",
                 "TopUsers", "reportsPlansUsage", "reportsBatchActiveUsers", "reportsBatchList",
                 "reportsBatchTotalUsers", "reportsInvoiceList"
               );
@@ -58,10 +58,10 @@ if (!$found) {
 }
 
 // reportQuery adds the WHERE fields for page-specific reports
-$reportQuery = $_SESSION['reportQuery'];
+$reportQuery = $_SESSION['reportQuery'] ?? "";
 
 // get table name (radacct/radcheck/etc)
-$reportTable = $_SESSION['reportTable'];
+$reportTable = $_SESSION['reportTable'] ?? "";
 
 // the following two functions tell the browser what file, size, etc. it should expect
 function exportCSVFile($output) {
@@ -116,11 +116,26 @@ switch ($reportType) {
         break;
 
     case "usernameListGeneric":
+    case "usernameListByGroup":
         // Export users in the same field order accepted by mng-import-users.php.
         // Required (5): username, password, email, firstname, lastname
         // Optional (15): framedipaddress, expiration, department, company, mobilephone,
         //                workphone, homephone, address, city, state, country, zip,
         //                sessiontimeout, idletimeout, maxdailysession
+        if ($reportType === "usernameListByGroup") {
+            if (!array_key_exists('groupname', $_GET) || empty(trim($_GET['groupname']))) {
+                break;
+            }
+
+            $groupname = trim($_GET['groupname']);
+            $reportTable = sprintf("%s AS rug INNER JOIN %s AS rc ON rc.username = rug.username "
+                                . "LEFT JOIN %s AS ui ON rc.username = ui.username",
+                                   $configValues['CONFIG_DB_TBL_RADUSERGROUP'],
+                                   $configValues['CONFIG_DB_TBL_RADCHECK'],
+                                   $configValues['CONFIG_DB_TBL_DALOUSERINFO']);
+            $reportQuery = sprintf(" WHERE rug.groupname='%s'", $dbSocket->escapeSimple($groupname));
+        }
+
         $cols = array(
                         "username" => "rc.username AS username",
                         "password" => "COALESCE(MAX(CASE WHEN rc_export.attribute LIKE '%%-Password' THEN rc_export.value END), "

--- a/app/operators/mng-rad-profiles-list.php
+++ b/app/operators/mng-rad-profiles-list.php
@@ -158,6 +158,7 @@
                                 'actions' => array(),
                             );
             $tooltip['actions'][] = array( 'href' => sprintf('mng-rad-profiles-edit.php?profile_name=%s', urlencode($groupname), ), 'label' => t('button','EditProfile'), );
+            $tooltip['actions'][] = array( 'href' => sprintf('include/management/fileExport.php?reportType=usernameListByGroup&reportFormat=csv&groupname=%s', urlencode($groupname), ), 'label' => 'Export Users CSV', );
             $tooltip['actions'][] = array( 'href' => sprintf('mng-rad-profiles-del.php?profile_name=%s', urlencode($groupname), ), 'label' => t('button','RemoveProfile'), );
         
             // create tooltip


### PR DESCRIPTION
# Summary

This updates the user CSV export flow so exported users can be re-imported using the current CSV import format.

The change also adds profile/group-specific user export support from the Profiles list page.

# Changes

- Updates the existing user CSV export to emit the same field layout accepted by `mng-import-users.php`.
- Adds support for exporting users filtered by Group/Profile through a new `usernameListByGroup` report type.
- Adds an `Export Users CSV` action to each profile row on the Profiles list page.
- Keeps Group/Profile as an export filter only; it is not added as an extra CSV column, preserving import compatibility.
- Uses `fputcsv()` for proper CSV escaping/quoting.
- Converts exported `Expiration` values from FreeRADIUS format to import-compatible `YYYY-MM-DD`.

# Exported CSV fields

```csv
username,password,email,firstname,lastname,framedipaddress,expiration,department,company,mobilephone,workphone,homephone,address,city,state,country,zip,sessiontimeout,idletimeout,maxdailysession
```

# Notes

The export gathers user data from:

- `radcheck`
- `radreply`
- `userinfo`
- `radusergroup` when filtering by Group/Profile

The profile/group-specific export uses the same CSV layout as the all-users export, so the resulting file can be passed back to the import flow without changing the column structure.

# Validation

Tested in the Docker development environment.

- PHP syntax check passed for:
  - `app/operators/mng-rad-profiles-list.php`
- Verified the existing all-users CSV export still works.
- Verified profile-specific export from the Profiles list page:
  - expected CSV header
  - only users from the selected profile are included
  - users from other profiles are excluded
  - `Expiration` exports as `YYYY-MM-DD`

Example profile-filtered export result:

```csv
username,password,email,firstname,lastname,framedipaddress,expiration,department,company,mobilephone,workphone,homephone,address,city,state,country,zip,sessiontimeout,idletimeout,maxdailysession
issue425alpha1,alpha1pass,issue425alpha1@example.com,Alpha,One,10.42.51.11,2026-12-31,QA,"Alpha, Inc.",+1001,+2001,+3001,"1 Alpha Road",Paris,IDF,France,75001,3600,600,86400
issue425alpha2,alpha2pass,issue425alpha2@example.com,Alpha,Two,10.42.51.12,2027-01-15,QA,"Alpha Labs",+1002,+2002,+3002,"2 Alpha Road",Lyon,ARA,France,69001,1800,300,43200
```

Closes #425.