### PR TITLE
fix: enforce group NAS restrictions in FreeRADIUS

### DIFF
--- a/doc/install/INSTALL.debian.md
+++ b/doc/install/INSTALL.debian.md
@@ -124,6 +124,36 @@ authorize {
 
 This lets FreeRADIUS compare the user's accumulated accounting time with daloRADIUS check attributes such as `Max-All-Session`.
 
+To enforce daloRADIUS profile/group NAS restrictions configured as `radgroupcheck` rows, also add the following policy immediately after `noresetcounter` in the same `authorize` section:
+
+```text
+authorize {
+    ...
+    -sql
+    noresetcounter
+
+    # daloRADIUS group NAS restriction policy
+    # Enforce radgroupcheck NAS-IP-Address == restrictions as an
+    # authentication deny rule for users assigned to SQL groups.
+    if (&request:NAS-IP-Address) {
+        if ("%{sql:SELECT COUNT(*) FROM radusergroup ug JOIN radgroupcheck gc ON gc.groupname = ug.groupname WHERE ug.username = '%{User-Name}' AND gc.attribute = 'NAS-IP-Address' AND gc.op = '=='}" != "0") {
+            if ("%{sql:SELECT COUNT(*) FROM radusergroup ug JOIN radgroupcheck gc ON gc.groupname = ug.groupname WHERE ug.username = '%{User-Name}' AND gc.attribute = 'NAS-IP-Address' AND gc.op = '==' AND gc.value = '%{NAS-IP-Address}'}" == "0") {
+                reject
+            }
+        }
+    }
+    ...
+}
+```
+
+Without this explicit policy, FreeRADIUS uses `radgroupcheck` mainly to decide whether a group's reply items apply. A user that already authenticates through `radcheck` can therefore be accepted even when a profile-level `NAS-IP-Address == ...` group check does not match. The policy above treats group-level `NAS-IP-Address == ...` rows as an allow-list: if a user is assigned to one or more groups with those rows, the request is rejected unless the request's `NAS-IP-Address` matches at least one allowed value.
+
+After editing the FreeRADIUS site, validate the configuration before restarting:
+
+```bash
+freeradius -C
+```
+
 To complete the installation, enable and restart the FreeRADIUS service using the following commands:
 ```bash
 systemctl enable freeradius

--- a/init-freeradius.sh
+++ b/init-freeradius.sh
@@ -74,6 +74,45 @@ function enable_noresetcounter {
 	mv /tmp/freeradius-default $RADIUS_PATH/sites-available/default
 }
 
+
+function enable_group_nas_restrictions {
+	# Enforce daloRADIUS group/profile NAS restrictions stored in radgroupcheck.
+	# FreeRADIUS uses radgroupcheck to decide whether group reply items apply; it
+	# does not automatically reject a user who already authenticated via radcheck.
+	# This policy rejects users when their SQL group has NAS-IP-Address == rows
+	# and the request NAS-IP-Address does not match any of those allowed values.
+	if grep -q "daloRADIUS group NAS restriction policy" $RADIUS_PATH/sites-available/default; then
+		return
+	fi
+
+	if ! awk '
+		BEGIN { added = 0 }
+		{
+			print
+			if (!added && /^[[:space:]]*noresetcounter[[:space:]]*$/) {
+				print ""
+				print "\t\t# daloRADIUS group NAS restriction policy"
+				print "\t\t# Enforce radgroupcheck NAS-IP-Address == restrictions as an"
+				print "\t\t# authentication deny rule for users assigned to SQL groups."
+				print "\t\tif (&request:NAS-IP-Address) {"
+				print "\t\t\tif (\"%{sql:SELECT COUNT(*) FROM radusergroup ug JOIN radgroupcheck gc ON gc.groupname = ug.groupname WHERE ug.username = '\''%{User-Name}'\'' AND gc.attribute = '\''NAS-IP-Address'\'' AND gc.op = '\''=='\''}\" != \"0\") {"
+				print "\t\t\t\tif (\"%{sql:SELECT COUNT(*) FROM radusergroup ug JOIN radgroupcheck gc ON gc.groupname = ug.groupname WHERE ug.username = '\''%{User-Name}'\'' AND gc.attribute = '\''NAS-IP-Address'\'' AND gc.op = '\''=='\'' AND gc.value = '\''%{NAS-IP-Address}'\''}\" == \"0\") {"
+				print "\t\t\t\t\treject"
+				print "\t\t\t\t}"
+				print "\t\t\t}"
+				print "\t\t}"
+				added = 1
+			}
+		}
+		END { exit added ? 0 : 1 }
+	' $RADIUS_PATH/sites-available/default > /tmp/freeradius-default; then
+		rm -f /tmp/freeradius-default
+		echo "Failed to add daloRADIUS group NAS restriction policy to FreeRADIUS authorize section."
+		exit 1
+	fi
+	mv /tmp/freeradius-default $RADIUS_PATH/sites-available/default
+}
+
 function ensure_daloradius_schema {
 	mysql -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" <<'EOSQL'
 CREATE TABLE IF NOT EXISTS `radhuntgroup` (
@@ -136,6 +175,10 @@ fi
 # lock-file and reinitialization paths.
 if test -L "$RADIUS_PATH/mods-enabled/sqlcounter"; then
 	enable_noresetcounter
+fi
+
+if test -L "$RADIUS_PATH/mods-enabled/sql"; then
+	enable_group_nas_restrictions
 fi
 
 DB_LOCK=/data/.db_init_done

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -271,6 +271,47 @@ freeradius_setup_sqlcounter_mod() {
     print_green "OK"
 }
 
+
+# Function to enforce daloRADIUS group/profile NAS restrictions in freeRADIUS
+freeradius_setup_group_nas_restrictions() {
+    echo -n "[+] Setting up freeRADIUS group NAS restriction policy... "
+
+    if grep -q "daloRADIUS group NAS restriction policy" "${FREERADIUS_DEFAULT_SITE_PATH}"; then
+        print_green "OK"
+        return
+    fi
+
+    if ! awk '
+        BEGIN { added = 0 }
+        {
+            print
+            if (!added && /^[[:space:]]*noresetcounter[[:space:]]*$/) {
+                print ""
+                print "\t\t# daloRADIUS group NAS restriction policy"
+                print "\t\t# Enforce radgroupcheck NAS-IP-Address == restrictions as an"
+                print "\t\t# authentication deny rule for users assigned to SQL groups."
+                print "\t\tif (&request:NAS-IP-Address) {"
+                print "\t\t\tif (\"%{sql:SELECT COUNT(*) FROM radusergroup ug JOIN radgroupcheck gc ON gc.groupname = ug.groupname WHERE ug.username = '\''%{User-Name}'\'' AND gc.attribute = '\''NAS-IP-Address'\'' AND gc.op = '\''=='\''}\" != \"0\") {"
+                print "\t\t\t\tif (\"%{sql:SELECT COUNT(*) FROM radusergroup ug JOIN radgroupcheck gc ON gc.groupname = ug.groupname WHERE ug.username = '\''%{User-Name}'\'' AND gc.attribute = '\''NAS-IP-Address'\'' AND gc.op = '\''=='\'' AND gc.value = '\''%{NAS-IP-Address}'\''}\" == \"0\") {"
+                print "\t\t\t\t\treject"
+                print "\t\t\t\t}"
+                print "\t\t\t}"
+                print "\t\t}"
+                added = 1
+            }
+        }
+        END { exit added ? 0 : 1 }
+    ' "${FREERADIUS_DEFAULT_SITE_PATH}" > /tmp/freeradius-default; then
+        rm -f /tmp/freeradius-default
+        print_red "KO"
+        echo "[!] Failed to add daloRADIUS group NAS restriction policy to freeRADIUS authorize section. Aborting." >&2
+        exit 1
+    fi
+
+    mv /tmp/freeradius-default "${FREERADIUS_DEFAULT_SITE_PATH}"
+    print_green "OK"
+}
+
 # Function to restart freeRADIUS service
 freeradius_enable_restart() {
     echo -n "[+] Enabling and restarting freeRADIUS... "
@@ -622,6 +663,7 @@ main() {
     freeradius_install
     freeradius_setup_sql_mod
     freeradius_setup_sqlcounter_mod
+    freeradius_setup_group_nas_restrictions
     freeradius_enable_restart
 
     apache_disable_all_sites


### PR DESCRIPTION
# Summary

Fixes group/profile-level NAS restrictions stored in `radgroupcheck` not being enforced during FreeRADIUS authentication.

Previously, a user-level `NAS-IP-Address == ...` check in `radcheck` correctly rejected authentication from a non-matching NAS, but the same restriction configured at the group/profile level in `radgroupcheck` did not cause authentication to fail. As a result, users could still authenticate from NAS devices that should not have been allowed by their assigned profile.

This change adds an explicit FreeRADIUS `authorize` policy that enforces group-level `NAS-IP-Address == ...` restrictions as an authentication deny rule.

# Changes

- Add Docker initialization support in `init-freeradius.sh`
  - Inserts an idempotent FreeRADIUS policy into the default site.
  - Enforces `radgroupcheck` rows where:
    - `attribute = 'NAS-IP-Address'`
    - `op = '=='`

- Add non-Docker installer support in `setup/install.sh`
  - Installs the same policy for Debian/manual-style deployments using the installer.

- Update Debian installation documentation
  - Documents the equivalent manual FreeRADIUS configuration.
  - Explains why `radgroupcheck` entries alone do not automatically reject already-authenticated users.
  - Adds validation guidance using `freeradius -C`.

# Behavior

The new policy treats group-level NAS restrictions as an allow-list:

- If a user belongs to a group/profile with one or more `NAS-IP-Address == ...` checks, the request NAS IP must match at least one of those values.
- If the user belongs to no group/profile with a `NAS-IP-Address == ...` restriction, authentication behavior is unchanged.
- Existing user-level NAS restrictions continue to work as before.

Only explicit equality checks are enforced in this change:

```text
NAS-IP-Address == <value>
```

Other operators are intentionally left unchanged to avoid introducing ambiguous behavior.

# Validation

Tested with the Docker lab and FreeRADIUS authentication requests.

Validation commands:

```bash
bash -n setup/install.sh
git diff --check
docker compose -f docker-compose.yml up -d --build
freeradius -C
```

Authentication test matrix:

```text
user-level non-matching NAS   -> Access-Reject
group-level matching NAS      -> Access-Accept
group-level non-matching NAS  -> Access-Reject
group with no NAS restriction -> Access-Accept
```

This confirms the issue is fixed while preserving unrestricted group/profile behavior.

Fixes #618.