### PR TITLE
fix(docker): harden deployment and legacy imports

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@
 *.db
 *.log
 *.sql
+*.sql.gz
 data/
 internal_data/
 var/log/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.github
+.planning
+.idea
+.DS_Store
+.env
+.env.*
+*.db
+*.log
+*.sql
+data/
+internal_data/
+var/log/
+var/backup/
+app/common/includes/daloradius.conf.php
+app/common/library/htmlpurifier/HTMLPurifier/DefinitionCache/Serializer/HTML/

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Copy this file to .env, uncomment the required variables, and replace every CHANGE_ME_... value before running Docker Compose.
+# Choose FREERADIUS_SQL_TLS=require when database TLS is configured, or disabled for local/non-TLS Compose setups.
+# MYSQL_PASSWORD=CHANGE_ME_RADIUS_DB_PASSWORD
+# MYSQL_ROOT_PASSWORD=CHANGE_ME_ROOT_DB_PASSWORD
+# DEFAULT_CLIENT_SECRET=CHANGE_ME_RADIUS_SHARED_SECRET
+# DALORADIUS_ADMIN_PASSWORD=CHANGE_ME_ADMIN_PASSWORD
+
+# FREERADIUS_SQL_TLS=disabled
+
+# Optional: bind the operators UI to a specific host and port.
+# DALORADIUS_OPERATORS_BIND=127.0.0.1:8000

--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,10 @@
 
 # Optional: bind the operators UI to a specific host and port.
 # DALORADIUS_OPERATORS_BIND=127.0.0.1:8000
+
+# Optional: override container timezone and daloRADIUS mail settings.
+# TZ=Europe/Vienna
+# MAIL_SMTPADDR=127.0.0.1
+# MAIL_PORT=25
+# MAIL_FROM=root@daloradius.xdsl.by
+# MAIL_AUTH=

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 *.db
 invoice_preview.html
 .DS_Store
+.env
+.env.*
+!.env.example
 data/
 internal_data/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ RUN mkdir /data
 COPY app /var/www/daloradius/app
 COPY contrib /var/www/daloradius/contrib
 COPY init.sh /var/www/daloradius/init.sh
+RUN sed -i 's/\r$//' /var/www/daloradius/init.sh
 
 #RUN touch /var/www/html/library/daloradius.conf.php
 RUN chown -R www-data:www-data /var/www/daloradius

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,8 @@ RUN apt-get update \
   wget \
   && rm -rf /var/lib/apt/lists/*
 
-ADD contrib/docker/operators.conf /etc/apache2/sites-available/operators.conf
-ADD contrib/docker/users.conf /etc/apache2/sites-available/users.conf
+COPY contrib/docker/operators.conf /etc/apache2/sites-available/operators.conf
+COPY contrib/docker/users.conf /etc/apache2/sites-available/users.conf
 RUN a2dissite 000-default.conf && \
     a2ensite users.conf operators.conf && \
     sed -i 's/Listen 80/Listen 80\nListen 8000/' /etc/apache2/ports.conf
@@ -58,7 +58,9 @@ RUN a2dissite 000-default.conf && \
 # Create directories
 # /data should be mounted as volume to avoid recreation of database entries
 RUN mkdir /data
-ADD . /var/www/daloradius
+COPY app /var/www/daloradius/app
+COPY contrib /var/www/daloradius/contrib
+COPY init.sh /var/www/daloradius/init.sh
 
 #RUN touch /var/www/html/library/daloradius.conf.php
 RUN chown -R www-data:www-data /var/www/daloradius

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN apt-get update \
 
 COPY contrib/docker/operators.conf /etc/apache2/sites-available/operators.conf
 COPY contrib/docker/users.conf /etc/apache2/sites-available/users.conf
+COPY scripts/docker/hash-imported-passwords.php /usr/local/bin/daloradius-hash-imported-passwords.php
 RUN a2dissite 000-default.conf && \
     a2ensite users.conf operators.conf && \
     sed -i 's/Listen 80/Listen 80\nListen 8000/' /etc/apache2/ports.conf
@@ -59,6 +60,8 @@ RUN rm -rf /var/www/daloradius/app/operators/static /var/www/daloradius/app/user
   && ln -s ../common/static /var/www/daloradius/app/operators/static \
   && ln -s ../common/static /var/www/daloradius/app/users/static
 RUN sed -i 's/\r$//' /var/www/daloradius/init.sh
+RUN sed -i 's/\r$//' /usr/local/bin/daloradius-hash-imported-passwords.php \
+  && chmod 0755 /usr/local/bin/daloradius-hash-imported-passwords.php
 
 #RUN touch /var/www/html/library/daloradius.conf.php
 RUN chown -R www-data:www-data /var/www/daloradius

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,10 @@ LABEL Description="daloRADIUS Official Docker based on Debian 13 and PHP 8.4." \
 	Usage="docker build . -t lirantal/daloradius && docker run -d -p 80:80 -p 8000:8000 lirantal/daloradius" \
 	Version="2.0beta"
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # default timezone
-ENV TZ Europe/Vienna
+ENV TZ=Europe/Vienna
 
 # PHP install
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # Run the container:
 # 1. docker run -p 80:80 -p 8000:8000 -d lirantal/daloradius
 
-FROM debian:13-slim
+FROM debian:13-slim@sha256:109e2c65005bf160609e4ba6acf7783752f8502ad218e298253428690b9eaa4b
 LABEL maintainer="Liran Tal <liran.tal@gmail.com>"
 LABEL Description="daloRADIUS Official Docker based on Debian 13 and PHP 8.4." \
 	License="GPLv2" \
@@ -24,29 +24,23 @@ ENV TZ Europe/Vienna
 RUN apt-get update \
   && apt-get install --yes --no-install-recommends \
   ca-certificates \
-  apt-utils \
   freeradius-utils \
   tzdata \
   apache2 \
   libapache2-mod-php \
   cron \
-  net-tools \
   php \
   php-common \
   php-gd \
   php-cli \
   php-curl \
   php-mail \
-  php-dev \
   php-mail-mime \
   php-mbstring \
   php-db \
   php-mysql \
   php-zip \
   mariadb-client \
-  default-libmysqlclient-dev \
-  unzip \
-  wget \
   && rm -rf /var/lib/apt/lists/*
 
 COPY contrib/docker/operators.conf /etc/apache2/sites-available/operators.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,8 +67,13 @@ RUN chown -R www-data:www-data /var/www/daloradius
 RUN rm -rf /var/www/html
 #
 # Create daloRADIUS Log file
-RUN touch /tmp/daloradius.log && chown -R www-data:www-data /tmp/daloradius.log
+RUN mkdir -p /var/www/daloradius/var/log \
+  && touch /var/www/daloradius/var/log/daloradius.log \
+  && chown -R www-data:www-data /var/www/daloradius/var
 RUN mkdir -p /var/log/apache2/daloradius && chown -R www-data:www-data /var/log/apache2/daloradius
+RUN printf '%s\n' "System logs are not available inside this container. Use docker logs daloradius-radius-web-1." > /var/log/syslog \
+  && printf '%s\n' "Boot logs are not available inside this container. Use docker logs daloradius-radius-web-1." > /var/log/boot.log \
+  && chmod 0644 /var/log/syslog /var/log/boot.log
 RUN echo "Mutex posixsem" >> /etc/apache2/apache2.conf
 
 ## Expose Web port for daloRADIUS

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,9 @@ RUN mkdir /data
 COPY app /var/www/daloradius/app
 COPY contrib /var/www/daloradius/contrib
 COPY init.sh /var/www/daloradius/init.sh
+RUN rm -rf /var/www/daloradius/app/operators/static /var/www/daloradius/app/users/static \
+  && ln -s ../common/static /var/www/daloradius/app/operators/static \
+  && ln -s ../common/static /var/www/daloradius/app/users/static
 RUN sed -i 's/\r$//' /var/www/daloradius/init.sh
 
 #RUN touch /var/www/html/library/daloradius.conf.php

--- a/Dockerfile-freeradius
+++ b/Dockerfile-freeradius
@@ -37,7 +37,8 @@ WORKDIR /app
 COPY ./init-freeradius.sh /app
 
 # Make init.sh script executable
-RUN chmod +x /app/init-freeradius.sh
+RUN sed -i 's/\r$//' /app/init-freeradius.sh \
+	&& chmod +x /app/init-freeradius.sh
 
 # Expose FreeRADIUS Ports
 EXPOSE 1812 1813

--- a/Dockerfile-freeradius
+++ b/Dockerfile-freeradius
@@ -6,13 +6,13 @@
 # 2. docker build -t lirantal/daloradius -f Dockerfile-freeradius
 #
 # Run the container:
-# 1. docker run -p 80:80 -d lirantal/dalofreeradius
+# 1. docker run -p 1812:1812/udp -p 1813:1813/udp -d lirantal/dalofreeradius
 
-FROM freeradius/freeradius-server:3.2.8
+FROM freeradius/freeradius-server:3.2.8@sha256:af6fd34a5b7826b6245008732f43fbc0432eb23d23e5de7106371b2941e70a4b
 LABEL maintainer="Liran Tal <liran.tal@gmail.com>"
 LABEL Description="FreeRADIUS 3.2.8 Docker image optimized for daloRADIUS." \
 	License="GPLv2" \
-	Usage="docker build -t lirantal/dalofreeradius -f Dockerfile-freeradius && docker run -d -p 80:80 lirantal/dalofreeradius" \
+	Usage="docker build -t lirantal/dalofreeradius -f Dockerfile-freeradius && docker run -d -p 1812:1812/udp -p 1813:1813/udp lirantal/dalofreeradius" \
 	Version="1.0"
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -22,14 +22,10 @@ ENV TZ Europe/Vienna
 
 RUN apt-get update \
 	&& apt-get install --yes --no-install-recommends \
-		apt-utils \
 		ipcalc \
 		tzdata \
 		net-tools \
 		mariadb-client \
-		libmysqlclient-dev \
-		unzip \
-		wget \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Create directories

--- a/Dockerfile-freeradius
+++ b/Dockerfile-freeradius
@@ -47,5 +47,4 @@ RUN chmod +x /app/init-freeradius.sh
 EXPOSE 1812 1813
 
 # Run the script which executes freeradius in foreground
-CMD ["/app/init-freeradius.sh"]
 ENTRYPOINT ["/app/init-freeradius.sh"]

--- a/Dockerfile-freeradius
+++ b/Dockerfile-freeradius
@@ -34,7 +34,7 @@ RUN mkdir /app /data
 WORKDIR /app
 
 # Copy init script to image
-ADD ./init-freeradius.sh /app
+COPY ./init-freeradius.sh /app
 
 # Make init.sh script executable
 RUN chmod +x /app/init-freeradius.sh

--- a/Dockerfile-freeradius
+++ b/Dockerfile-freeradius
@@ -15,10 +15,10 @@ LABEL Description="FreeRADIUS 3.2.8 Docker image optimized for daloRADIUS." \
 	Usage="docker build -t lirantal/dalofreeradius -f Dockerfile-freeradius && docker run -d -p 1812:1812/udp -p 1813:1813/udp lirantal/dalofreeradius" \
 	Version="1.0"
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 # default timezone
-ENV TZ Europe/Vienna
+ENV TZ=Europe/Vienna
 
 RUN apt-get update \
 	&& apt-get install --yes --no-install-recommends \

--- a/Dockerfile-standalone
+++ b/Dockerfile-standalone
@@ -1,6 +1,6 @@
 FROM php:8.4-apache@sha256:5489a66a463f350f77045ec0ec313dcbc4a5b78f32040b946cf694c9d5c7689d
 
-ENV TZ UTC
+ENV TZ=UTC
 
 RUN apt-get update \
  && apt-get -y install --no-install-recommends \

--- a/Dockerfile-standalone
+++ b/Dockerfile-standalone
@@ -31,5 +31,6 @@ COPY app/ /var/www/html/daloradius
 COPY app/common/includes/daloradius.conf.php.sample /var/www/html/daloradius/common/includes/daloradius.conf.php
 COPY contrib/scripts/apache-config.sh /usr/local/bin/apache-config.sh
 
-RUN chmod +x /usr/local/bin/apache-config.sh \
+RUN sed -i 's/\r$//' /usr/local/bin/apache-config.sh \
+ && chmod +x /usr/local/bin/apache-config.sh \
  && sh /usr/local/bin/apache-config.sh

--- a/Dockerfile-standalone
+++ b/Dockerfile-standalone
@@ -1,4 +1,4 @@
-FROM php:8.4-apache
+FROM php:8.4-apache@sha256:5489a66a463f350f77045ec0ec313dcbc4a5b78f32040b946cf694c9d5c7689d
 
 ENV TZ UTC
 

--- a/Dockerfile-standalone
+++ b/Dockerfile-standalone
@@ -1,18 +1,15 @@
-FROM alpine AS source
-
-RUN apk add git
-
-WORKDIR /tmp/
-
-RUN git clone https://github.com/lirantal/daloradius.git /tmp/daloradius
-
-
-FROM php:7-apache
+FROM php:8.4-apache
 
 ENV TZ UTC
 
-RUN apt-get update && apt-get -y upgrade \
- && apt-get -y install libpng-dev libjpeg62-turbo-dev libfreetype6-dev libwebp-dev libmariadb-dev --no-install-recommends \
+RUN apt-get update \
+ && apt-get -y install --no-install-recommends \
+      ca-certificates \
+      libpng-dev \
+      libjpeg62-turbo-dev \
+      libfreetype6-dev \
+      libwebp-dev \
+      libmariadb-dev \
  && rm -rf /var/lib/apt/lists/* \
  && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
  && update-ca-certificates -f
@@ -21,18 +18,18 @@ RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
  && docker-php-ext-configure pdo_mysql \
  && docker-php-ext-configure mysqli \
  && docker-php-ext-install \
-                       gd \
-                pdo_mysql \
-                   mysqli
+      gd \
+      pdo_mysql \
+      mysqli
+
 RUN pear channel-update pear.php.net \
  && pear install -a -f DB \
  && pear install -a -f Mail \
  && pear install -a -f Mail_Mime
 
-COPY --from=source /tmp/daloradius/app/ /var/www/html/daloradius
-COPY --from=source /tmp/daloradius/app/common/includes/daloradius.conf.php.sample /var/www/html/daloradius/common/includes/daloradius.conf.php
-
-COPY --from=source /tmp/daloradius/contrib/scripts/apache-config.sh /usr/local/bin
+COPY app/ /var/www/html/daloradius
+COPY app/common/includes/daloradius.conf.php.sample /var/www/html/daloradius/common/includes/daloradius.conf.php
+COPY contrib/scripts/apache-config.sh /usr/local/bin/apache-config.sh
 
 RUN chmod +x /usr/local/bin/apache-config.sh \
-&& sh /usr/local/bin/apache-config.sh
+ && sh /usr/local/bin/apache-config.sh

--- a/README.docker-standalone.md
+++ b/README.docker-standalone.md
@@ -6,23 +6,16 @@
 
 ## how to run
 
-1. run prebuilt image
-2. build the image first
+Build the image from the checked-out repository, then run it with an explicit daloRADIUS configuration file.
 
 ### preparing daloradius.conf.php
 
 you can edit sample config <https://github.com/lirantal/daloradius/blob/master/app/common/includes/daloradius.conf.php.sample> and then mount it in container or you can just run container, edit mounted config and re-run container
 
-## prebuilt image
-
-```bash
-docker run --name daloradius-standalone -v /path/to/daloradius.conf.php:/var/www/html/daloradius/common/includes/daloradius.conf.php -p 80:80 -p 8000:8000 -d dormancygrace/daloradius
-```
-
 ## build image
 
 ```bash
-docker build -t daloradius-standalone -f Dockerfile-standalone
+docker build -t daloradius-standalone -f Dockerfile-standalone .
 ```
 
 ```bash

--- a/README.docker-standalone.md
+++ b/README.docker-standalone.md
@@ -1,23 +1,155 @@
-# run daloradius as a standalone container
-## prerequisite
+# Docker usage
 
-1. mysql server and freeradius (in docker or on-premise) server that has been configured properly
-2. docker runtime
+The recommended Docker setup for local or self-contained deployments is the full Compose stack in `docker-compose.yml`. It starts three services:
 
-## how to run
+- `radius-mysql`: MariaDB database for daloRADIUS and FreeRADIUS.
+- `radius`: FreeRADIUS server.
+- `radius-web`: daloRADIUS web interfaces.
 
-Build the image from the checked-out repository, then run it with an explicit daloRADIUS configuration file.
+Use the standalone web image only when you already have an external database and FreeRADIUS server configured.
 
-### preparing daloradius.conf.php
+## Full Compose stack
 
-you can edit sample config <https://github.com/lirantal/daloradius/blob/master/app/common/includes/daloradius.conf.php.sample> and then mount it in container or you can just run container, edit mounted config and re-run container
+### Prerequisites
 
-## build image
+- Docker with the Compose plugin.
+- Available host ports `80`, `1812/udp`, and `1813/udp`.
+- Available host bind `127.0.0.1:8000` unless you override `DALORADIUS_OPERATORS_BIND`.
+
+### Prepare environment
+
+Copy the commented template, uncomment the required variables, and replace every `CHANGE_ME_...` value before starting the stack:
+
+```bash
+cp .env.example .env
+```
+
+Required variables:
+
+- `MYSQL_PASSWORD`
+- `MYSQL_ROOT_PASSWORD`
+- `DEFAULT_CLIENT_SECRET`
+- `DALORADIUS_ADMIN_PASSWORD`
+- `FREERADIUS_SQL_TLS`
+
+For local or non-TLS Compose setups, set:
+
+```dotenv
+FREERADIUS_SQL_TLS=disabled
+```
+
+Use `FREERADIUS_SQL_TLS=require` only when database TLS is configured.
+
+The operators UI bind is optional and defaults to localhost:
+
+```dotenv
+DALORADIUS_OPERATORS_BIND=127.0.0.1:8000
+```
+
+### Validate configuration
+
+Validate the Compose configuration and required environment variables:
+
+```bash
+docker compose config
+```
+
+If a required variable is missing, Compose exits with an error that names it.
+
+### Start the stack
+
+Build images and start the services:
+
+```bash
+docker compose up -d --build
+```
+
+Check service state:
+
+```bash
+docker compose ps
+```
+
+### Access services
+
+- Users UI: `http://localhost/`
+- Operators UI: `http://127.0.0.1:8000/`, unless `DALORADIUS_OPERATORS_BIND` is overridden.
+- RADIUS authentication: host UDP port `1812`
+- RADIUS accounting: host UDP port `1813`
+
+MySQL port `3306` is internal to the Compose network and is not published to the host.
+
+### Logs
+
+Container logs:
+
+```bash
+docker compose logs radius-web
+docker compose logs radius
+docker compose logs radius-mysql
+```
+
+Follow logs:
+
+```bash
+docker compose logs -f radius-web radius radius-mysql
+```
+
+Useful application log paths inside the containers:
+
+- FreeRADIUS: `/var/log/freeradius/radius.log`
+- daloRADIUS: `/var/www/daloradius/var/log/daloradius.log`
+
+The Compose stack shares the FreeRADIUS log directory through the `radius_logs` volume. Host syslog and boot logs shown by the web container are placeholder files; use `docker compose logs radius-web` for container-level output.
+
+### Stop and rebuild
+
+Stop the stack without deleting volumes:
+
+```bash
+docker compose down
+```
+
+Rebuild images after Dockerfile or dependency changes:
+
+```bash
+docker compose build --pull
+docker compose up -d
+```
+
+To remove containers and named volumes, including database and persisted application data:
+
+```bash
+docker compose down -v
+```
+
+### Volumes
+
+The Compose stack uses these named volumes:
+
+- `radius_mysql`
+- `radius_freeradius_data`
+- `radius_daloradius_data`
+- `radius_logs`
+
+## Standalone web image
+
+`Dockerfile-standalone` builds only the daloRADIUS web application image. It does not start MariaDB or FreeRADIUS. Use it when those services are already deployed and the daloRADIUS database schema and RADIUS integration are configured externally.
+
+Build the image:
 
 ```bash
 docker build -t daloradius-standalone -f Dockerfile-standalone .
 ```
 
+Create a `daloradius.conf.php` for your external database and RADIUS settings, then mount it into the container. Path values in the mounted config should match the standalone container layout, such as `/var/www/html/daloradius/...`.
+
 ```bash
-docker run --name daloradius-standalone -v /path/to/daloradius.conf.php:/var/www/html/daloradius/common/includes/daloradius.conf.php -p 80:80 -p 8000:8000 -d daloradius-standalone
+docker run --name daloradius-standalone \
+  -v /path/to/daloradius.conf.php:/var/www/html/daloradius/common/includes/daloradius.conf.php:ro \
+  -p 80:80 \
+  -p 127.0.0.1:8000:8000 \
+  -d daloradius-standalone
 ```
+
+The standalone image expects the mounted configuration at `/var/www/html/daloradius/common/includes/daloradius.conf.php`.

--- a/README.docker-standalone.md
+++ b/README.docker-standalone.md
@@ -66,6 +66,69 @@ docker compose config
 
 If a required variable is missing, Compose exits with an error that names it.
 
+### Import an existing database backup
+
+When importing a database from a previous non-Docker daloRADIUS or FreeRADIUS instance, import the dump before starting `radius` and `radius-web`. Legacy dumps can contain older table definitions, so run the post-import migrations before starting the full stack.
+
+Example for `backup_radius_14-05-2026.sql.gz`:
+
+```powershell
+.\scripts\docker\import-backup.ps1 -DumpPath .\backup_radius_14-05-2026.sql.gz
+```
+
+Linux equivalent:
+
+```bash
+bash scripts/docker/import-backup.sh ./backup_radius_14-05-2026.sql.gz
+```
+
+The runners live at `scripts/docker/import-backup.ps1` and `scripts/docker/import-backup.sh`. They perform this sequence:
+
+- validates `.env` through `docker compose config --quiet`
+- validates the dump with `gzip -t`
+- starts only `radius-mysql`
+- imports the dump into the `radius` database
+- applies SQL files from `docker/post-import-migrations`
+- builds `radius-web` and hashes imported operator passwords
+- validates required tables and critical schema widths
+- starts the complete stack
+
+#### Post-import migrations
+
+Post-import migrations handle schema drift from older dumps. The current required migration widens `operators.password` to `VARCHAR(95)` because current daloRADIUS operator passwords are stored with PHP `password_hash()` values. Older dumps may define that column as `VARCHAR(32)`, which prevents `radius-web` from setting `DALORADIUS_ADMIN_PASSWORD`.
+
+After SQL migrations, the runner converts only daloRADIUS operator passwords. Legacy non-hash operator values are hashed with PHP `password_hash()`. If an `administrator` operator exists, its password is set from `DALORADIUS_ADMIN_PASSWORD` in `.env`. This step does not rewrite daloRADIUS user portal passwords or FreeRADIUS `radcheck` authentication attributes.
+
+Manual equivalent:
+
+```powershell
+$mariadb = @'
+set -eu
+defaults_file="$(mktemp)"
+cleanup() {
+    rm -f "$defaults_file"
+}
+trap cleanup EXIT
+{
+    printf "[client]\n"
+    printf "user=radius\n"
+    printf "password=%s\n" "$MYSQL_PASSWORD"
+} > "$defaults_file"
+chmod 600 "$defaults_file"
+mariadb --defaults-extra-file="$defaults_file" --batch --skip-column-names radius
+'@
+
+docker compose stop radius radius-web
+docker compose up -d radius-mysql
+gzip -cd .\backup_radius_14-05-2026.sql.gz | docker compose exec -T radius-mysql sh -lc $mariadb
+Get-Content -Raw .\docker\post-import-migrations\001-operators-password-width.sql | docker compose exec -T radius-mysql sh -lc $mariadb
+docker compose build radius-web
+docker compose run --rm --no-deps --entrypoint php radius-web /usr/local/bin/daloradius-hash-imported-passwords.php
+docker compose up -d --build
+```
+
+The MariaDB command uses a temporary client defaults file inside the database container so `MYSQL_PASSWORD` is not passed as a process argument.
+
 ### Start the stack
 
 Build images and start the services:

--- a/README.docker-standalone.md
+++ b/README.docker-standalone.md
@@ -46,6 +46,16 @@ The operators UI bind is optional and defaults to localhost:
 DALORADIUS_OPERATORS_BIND=127.0.0.1:8000
 ```
 
+Optional timezone and mail settings can also be set in `.env`:
+
+```dotenv
+TZ=Europe/Vienna
+MAIL_SMTPADDR=127.0.0.1
+MAIL_PORT=25
+MAIL_FROM=root@daloradius.xdsl.by
+MAIL_AUTH=
+```
+
 ### Validate configuration
 
 Validate the Compose configuration and required environment variables:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ If you encounter any issues during the installation or have any questions, feel 
 
 The documentation for daloRADIUS is available in Markdown format and can be found in the `doc` folder of this repository.
 
+For Docker usage, including the recommended Compose stack and standalone web image, see [README.docker-standalone.md](README.docker-standalone.md).
+
 ## Contributors
 
 Special thanks to these wonderful people for their contributions to daloRADIUS...

--- a/app/operators/config-operators-edit.php
+++ b/app/operators/config-operators-edit.php
@@ -33,6 +33,7 @@
     $logDebugSQL = "";
     
     include_once('../common/includes/config_read.php');
+    include_once('library/operator_passwords.php');
     
     include('../common/includes/db_open.php');
 
@@ -90,13 +91,17 @@
                 $messenger1 = (array_key_exists('messenger1', $_POST) && isset($_POST['messenger1'])) ? trim($_POST['messenger1']) : "";
                 $messenger2 = (array_key_exists('messenger2', $_POST) && isset($_POST['messenger2'])) ? trim($_POST['messenger2']) : "";
                 $notes = (array_key_exists('notes', $_POST) && isset($_POST['notes'])) ? trim($_POST['notes']) : "";
+                $passwordSql = "";
+                if (!empty($operator_password)) {
+                    $passwordSql = sprintf("password='%s', ", $dbSocket->escapeSimple(operator_password_hash($operator_password)));
+                }
                 
                 // update operator data into the database
-                $sql = sprintf("UPDATE %s SET password='%s', firstname='%s', lastname='%s', title='%s', department='%s',
+                $sql = sprintf("UPDATE %s SET %s firstname='%s', lastname='%s', title='%s', department='%s',
                                               company='%s', phone1='%s', phone2='%s', email1='%s', email2='%s', messenger1='%s',
                                               messenger2='%s', updatedate='%s', updateby='%s'
                                  WHERE username='%s'",
-                               $configValues['CONFIG_DB_TBL_DALOOPERATORS'], $dbSocket->escapeSimple($operator_password),
+                               $configValues['CONFIG_DB_TBL_DALOOPERATORS'], $passwordSql,
                                $dbSocket->escapeSimple($firstname), $dbSocket->escapeSimple($lastname), $dbSocket->escapeSimple($title),
                                $dbSocket->escapeSimple($department), $dbSocket->escapeSimple($company), $dbSocket->escapeSimple($phone1),
                                $dbSocket->escapeSimple($phone2), $dbSocket->escapeSimple($email1), $dbSocket->escapeSimple($email2),
@@ -173,6 +178,7 @@
                 $operator_email1, $operator_email2, $operator_messenger1, $operator_messenger2, $operator_notes,
                 $operator_lastlogin, $operator_creationdate, $operator_creationby, $operator_updatedate, $operator_updateby
             ) = $res->fetchRow();
+        $operator_password = "";
     }
 
     include('../common/includes/db_close.php');
@@ -228,7 +234,7 @@
                                         "name" => "operator_password",
                                         "caption" => t('all','Password'),
                                         "type" => $hiddenPassword,
-                                        "value" => ((isset($operator_password)) ? $operator_password : ""),
+                                        "value" => "",
                                         "random" => true
                                      );
                                   

--- a/app/operators/config-operators-new.php
+++ b/app/operators/config-operators-new.php
@@ -26,6 +26,7 @@
 
     include('library/check_operator_perm.php');
     include_once('../common/includes/config_read.php');
+    include_once('library/operator_passwords.php');
 
     include_once("lang/main.php");
     include_once("../common/includes/validation.php");
@@ -84,6 +85,7 @@
                 } else {
                     $current_datetime = date('Y-m-d H:i:s');
                     $currBy = $_SESSION['operator_user'];
+                    $operator_password_hash = operator_password_hash($operator_password);
 
                     // insert username and password of operator into the database
                     $sql = sprintf("INSERT INTO %s (id, username, password, firstname, lastname, title, department, company,
@@ -91,7 +93,7 @@
                                                     creationby, updatedate, updateby)
                                             VALUES (0, '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s',
                                                     '%s', '%s', '%s', '%s', NULL, NULL)", $configValues['CONFIG_DB_TBL_DALOOPERATORS'],
-                                   $operator_username, $operator_password, $firstname, $lastname, $title, $department, $company,
+                                   $operator_username, $dbSocket->escapeSimple($operator_password_hash), $firstname, $lastname, $title, $department, $company,
                                    $phone1, $phone2, $email1, $email2, $messenger1, $messenger2, $notes, $current_datetime, $currBy);
                     $res = $dbSocket->query($sql);
                     $logDebugSQL .= "$sql;\n";

--- a/app/operators/dologin.php
+++ b/app/operators/dologin.php
@@ -25,6 +25,7 @@
  */
 
 include('library/sessions.php');
+include_once('library/operator_passwords.php');
 include_once('../common/includes/config_read.php');
 
 dalo_session_start();
@@ -59,27 +60,37 @@ if (array_key_exists('csrf_token', $_POST) && isset($_POST['csrf_token']) &&
     include('../common/includes/db_open.php');
     
     $operator_user = $dbSocket->escapeSimple($_POST['operator_user']);
-    $operator_pass = $dbSocket->escapeSimple($_POST['operator_pass']);
+    $operator_pass = $_POST['operator_pass'];
     
-    $sqlFormat = "select * from %s where username='%s' and password='%s'";
-    $sql = sprintf($sqlFormat, $configValues['CONFIG_DB_TBL_DALOOPERATORS'], $operator_user, $operator_pass);
+    $sqlFormat = "select * from %s where username='%s'";
+    $sql = sprintf($sqlFormat, $configValues['CONFIG_DB_TBL_DALOOPERATORS'], $operator_user);
     $res = $dbSocket->query($sql);
     $numRows = $res->numRows();
     
     // we only accept ONE AND ONLY ONE RECORD as result
     if ($numRows === 1) {
         $row = $res->fetchRow(DB_FETCHMODE_ASSOC);
-        $operator_id = $row['id'];
-        
-        $_SESSION['daloradius_logged_in'] = true;
-        $_SESSION['operator_user'] = $operator_user;
-        $_SESSION['operator_id'] = $operator_id;
-        
-        // lets update the lastlogin time for this operator
-        $now = date("Y-m-d H:i:s");
-        $sqlFormat = "update %s set lastlogin='%s' where username='%s'";
-        $sql = sprintf($sqlFormat, $configValues['CONFIG_DB_TBL_DALOOPERATORS'], $now, $operator_user);
-        $res = $dbSocket->query($sql);
+
+        if (operator_password_verify($operator_pass, $row['password'])) {
+            $operator_id = $row['id'];
+            
+            $_SESSION['daloradius_logged_in'] = true;
+            $_SESSION['operator_user'] = $operator_user;
+            $_SESSION['operator_id'] = $operator_id;
+            
+            // lets update the lastlogin time for this operator
+            $now = date("Y-m-d H:i:s");
+            $sqlFormat = "update %s set lastlogin='%s' where username='%s'";
+            $sql = sprintf($sqlFormat, $configValues['CONFIG_DB_TBL_DALOOPERATORS'], $now, $operator_user);
+            $res = $dbSocket->query($sql);
+
+            if (operator_password_needs_rehash($row['password'])) {
+                $password_hash = $dbSocket->escapeSimple(operator_password_hash($operator_pass));
+                $sqlFormat = "update %s set password='%s' where username='%s'";
+                $sql = sprintf($sqlFormat, $configValues['CONFIG_DB_TBL_DALOOPERATORS'], $password_hash, $operator_user);
+                $res = $dbSocket->query($sql);
+            }
+        }
 
     }
     

--- a/app/operators/library/operator_passwords.php
+++ b/app/operators/library/operator_passwords.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ *********************************************************************************************************
+ * daloRADIUS - RADIUS Web Platform
+ * Copyright (C) 2007 - Liran Tal <liran@lirantal.com> All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ *********************************************************************************************************
+ */
+
+function operator_password_hash($password)
+{
+    return password_hash($password, PASSWORD_DEFAULT);
+}
+
+function operator_password_is_hash($storedPassword)
+{
+    $info = password_get_info($storedPassword);
+    return intval($info['algo']) !== 0;
+}
+
+function operator_password_verify($password, $storedPassword)
+{
+    if (operator_password_is_hash($storedPassword)) {
+        return password_verify($password, $storedPassword);
+    }
+
+    return hash_equals($storedPassword, $password);
+}
+
+function operator_password_needs_rehash($storedPassword)
+{
+    return !operator_password_is_hash($storedPassword) || password_needs_rehash($storedPassword, PASSWORD_DEFAULT);
+}
+
+?>

--- a/contrib/db/mariadb-daloradius.sql
+++ b/contrib/db/mariadb-daloradius.sql
@@ -10291,7 +10291,7 @@ SET character_set_client = @saved_cs_client;
 
 LOCK TABLES `operators` WRITE;
 /*!40000 ALTER TABLE `operators` DISABLE KEYS */;
-INSERT INTO `operators` VALUES (1,'administrator','radius','','','','','','','','','','','','',NULL,CURRENT_TIMESTAMP,'admin',NULL,NULL);
+INSERT INTO `operators` VALUES (1,'administrator','!disabled!','','','','','','','','','','','','',NULL,CURRENT_TIMESTAMP,'admin',NULL,NULL);
 /*!40000 ALTER TABLE `operators` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/contrib/docker/operators.conf
+++ b/contrib/docker/operators.conf
@@ -11,6 +11,6 @@
     <Directory /var/www/daloradius>
         Require all denied
     </Directory>
-    ErrorLog ${APACHE_LOG_DIR}/daloradius/operators-error.log
-    CustomLog ${APACHE_LOG_DIR}/daloradius/operators-access.log combined
+    ErrorLog /proc/self/fd/2
+    CustomLog /proc/self/fd/1 combined
 </VirtualHost>

--- a/contrib/docker/users.conf
+++ b/contrib/docker/users.conf
@@ -11,6 +11,6 @@
     <Directory /var/www/daloradius>
         Require all denied
     </Directory>
-    ErrorLog ${APACHE_LOG_DIR}/daloradius/users-error.log
-    CustomLog ${APACHE_LOG_DIR}/daloradius/users-access.log combined
+    ErrorLog /proc/self/fd/2
+    CustomLog /proc/self/fd/1 combined
 </VirtualHost>

--- a/doc/setup/docker-operations.md
+++ b/doc/setup/docker-operations.md
@@ -1,0 +1,375 @@
+# Docker operations runbook
+
+This runbook covers two supported Docker startup paths:
+
+- start a clean daloRADIUS and FreeRADIUS stack without importing an existing database;
+- rebuild a clean stack and import an existing MariaDB dump before starting the full application.
+
+Run every command from the repository root.
+
+## Prerequisites
+
+- Docker Engine or Docker Desktop with Docker Compose v2.
+- A project `.env` file created from `.env.example`.
+- `gzip` in `PATH` when importing `.sql.gz` dumps.
+- A database dump available locally when using the import workflow.
+
+Create `.env`:
+
+On Linux:
+
+```bash
+cp .env.example .env
+```
+
+On Windows:
+
+```powershell
+Copy-Item .env.example .env
+```
+
+
+Edit `.env`, uncomment the required variables, and replace every `CHANGE_ME_...` value:
+
+```dotenv
+MYSQL_PASSWORD=CHANGE_ME_RADIUS_DB_PASSWORD
+MYSQL_ROOT_PASSWORD=CHANGE_ME_ROOT_DB_PASSWORD
+DEFAULT_CLIENT_SECRET=CHANGE_ME_RADIUS_SHARED_SECRET
+DALORADIUS_ADMIN_PASSWORD=CHANGE_ME_ADMIN_PASSWORD
+FREERADIUS_SQL_TLS=disabled
+```
+
+Optional values can be kept at their defaults or customized:
+
+```dotenv
+DALORADIUS_OPERATORS_BIND=127.0.0.1:8000
+TZ=Europe/Vienna
+MAIL_SMTPADDR=127.0.0.1
+MAIL_PORT=25
+MAIL_FROM=root@daloradius.xdsl.by
+MAIL_AUTH=
+```
+
+Validate the Compose configuration before starting the stack:
+
+```powershell
+docker compose config --quiet
+```
+
+## Normal startup without database import
+
+Use this path for a new local instance that should initialize its own database.
+
+1. Confirm `.env` exists and contains all required values.
+
+   On Linux:
+
+   ```bash
+   test -f .env
+   docker compose config --quiet
+   ```
+
+   On Windows:
+
+   ```powershell
+   Test-Path .env
+   docker compose config --quiet
+   ```
+
+
+2. Build and start the full stack.
+
+   ```powershell
+   docker compose up -d --build
+   ```
+
+3. Wait until the services are running and healthy.
+
+   ```powershell
+   docker compose ps
+   ```
+
+   Expected services:
+
+   - `radius-mysql`: healthy MariaDB database;
+   - `radius`: healthy FreeRADIUS service;
+   - `radius-web`: daloRADIUS web service.
+
+4. Open the web interfaces.
+
+   - Operators UI: `http://127.0.0.1:8000/login.php`
+   - Users UI: `http://localhost/`
+
+5. Log in to the operators UI with:
+
+   - username: `administrator`
+   - password: the value configured in `DALORADIUS_ADMIN_PASSWORD`
+
+## Changing the administrator password after initialization
+
+`radius-web` applies `DALORADIUS_ADMIN_PASSWORD` to the `administrator` operator every time the container starts. This means the database password is updated after the first initialization too, as long as `radius-web` is recreated with the new environment value.
+
+After changing `DALORADIUS_ADMIN_PASSWORD` in `.env`, recreate `radius-web`:
+
+```powershell
+docker compose up -d --force-recreate radius-web
+```
+
+Linux:
+
+```bash
+docker compose up -d --force-recreate radius-web
+```
+
+Then log in again with:
+
+- username: `administrator`
+- password: the new `DALORADIUS_ADMIN_PASSWORD` value
+
+A plain container restart is not enough to load a changed `.env` value:
+
+```powershell
+docker compose restart radius-web
+```
+
+That command restarts the existing container with the environment it already had when it was created. Use `docker compose up -d --force-recreate radius-web` when the goal is to apply a changed `.env` value to the database.
+
+6. Inspect logs if a service does not start.
+
+   ```powershell
+   docker compose logs radius-web
+   docker compose logs radius
+   docker compose logs radius-mysql
+   ```
+
+7. Stop the stack without deleting data.
+
+   ```powershell
+   docker compose stop
+   ```
+
+8. Start an existing stack again without rebuilding.
+
+   ```powershell
+   docker compose start
+   ```
+
+9. Delete the stack and all Docker volumes only when you intentionally want to remove the local database and runtime data.
+
+   ```powershell
+   docker compose down -v --remove-orphans
+   ```
+
+## Startup with existing database import
+
+Use this path when migrating a database from a previous non-Docker daloRADIUS or FreeRADIUS instance.
+
+The import workflow must run before `radius` and `radius-web` start against the migrated database. The provided scripts enforce this order:
+
+1. validate `.env` through `docker compose config --quiet`;
+2. validate the compressed dump with `gzip -t`;
+3. start only `radius-mysql`;
+4. import the dump into the `radius` database;
+5. apply SQL migrations from `docker/post-import-migrations`;
+6. build `radius-web`;
+7. convert imported daloRADIUS operator passwords to PHP password hashes;
+8. validate required imported tables and `operators.password`;
+9. start the complete stack.
+
+The password conversion only updates daloRADIUS operators in the `operators` table. It does not rewrite user portal passwords or FreeRADIUS authentication attributes such as `radcheck`.
+
+### Replacing an existing Docker database
+
+To replace an existing database that already lives in the Docker Compose volume, remove the Compose volumes before running the import script:
+
+On Linux:
+
+```bash
+docker compose down -v --remove-orphans
+bash scripts/docker/import-backup.sh ./backup_radius.sql.gz
+```
+
+On Windows:
+```powershell
+docker compose down -v --remove-orphans
+.\scripts\docker\import-backup.ps1 -DumpPath .\backup_radius.sql.gz
+```
+
+
+This is the supported clean replacement path. It deletes the `radius_mysql` volume, recreates an empty Docker database, imports the dump, applies post-import migrations, hashes imported operator passwords, validates the schema, and only then starts the complete stack.
+
+Do not use the import script alone when you need a guaranteed full replacement of the Docker database. If the existing `radius_mysql` volume is kept, the script imports the dump into the current database. Tables included in the dump may be replaced depending on the dump contents, but extra tables or residual state not covered by the dump can remain.
+
+### Clean import on Linux
+
+1. Place the dump in the repository root or note its absolute path.
+
+   Example:
+
+   ```bash
+   test -f ./backup_radius.sql.gz
+   ```
+
+2. Delete any existing Compose stack and volumes.
+
+   This removes the local Docker database.
+
+   ```bash
+   docker compose down -v --remove-orphans
+   ```
+
+3. Run the import script.
+
+   ```bash
+   bash scripts/docker/import-backup.sh ./backup_radius.sql.gz
+   ```
+
+4. Confirm the stack is up.
+
+   ```bash
+   docker compose ps
+   ```
+
+5. Confirm imported operator passwords are already hashed.
+
+   ```bash
+   docker compose run --rm --no-deps --entrypoint php radius-web -r '$pdo=new PDO("mysql:host=".getenv("MYSQL_HOST").";port=".getenv("MYSQL_PORT").";dbname=".getenv("MYSQL_DATABASE").";charset=utf8mb4",getenv("MYSQL_USER"),getenv("MYSQL_PASSWORD"),[PDO::ATTR_ERRMODE=>PDO::ERRMODE_EXCEPTION]); $rows=$pdo->query("SELECT username,password FROM operators")->fetchAll(PDO::FETCH_ASSOC); $non=0; foreach($rows as $r){ $info=password_get_info($r["password"]); if(($info["algo"] ?? 0)===0){ $non++; } } echo "operator_rows=".count($rows)."\nnon_hash_operator_passwords=$non\n";'
+   ```
+
+   Expected result:
+
+   ```text
+   non_hash_operator_passwords=0
+   ```
+
+6. Confirm the `administrator` operator uses the password configured in `.env`.
+
+   ```bash
+   docker compose run --rm --no-deps --entrypoint php radius-web -r '$pdo=new PDO("mysql:host=".getenv("MYSQL_HOST").";port=".getenv("MYSQL_PORT").";dbname=".getenv("MYSQL_DATABASE").";charset=utf8mb4",getenv("MYSQL_USER"),getenv("MYSQL_PASSWORD"),[PDO::ATTR_ERRMODE=>PDO::ERRMODE_EXCEPTION]); $hash=$pdo->query("SELECT password FROM operators WHERE username=\"administrator\"")->fetchColumn(); echo "administrator_env_password_valid=".(password_verify(getenv("DALORADIUS_ADMIN_PASSWORD"),$hash) ? "valid" : "invalid")."\n";'
+   ```
+
+   Expected result:
+
+   ```text
+   administrator_env_password_valid=valid
+   ```
+
+
+
+
+### Clean import on Windows
+
+1. Place the dump in the repository root or note its absolute path.
+
+   Example:
+
+   ```powershell
+   Test-Path .\backup_radius.sql.gz
+   ```
+
+2. Delete any existing Compose stack and volumes.
+
+   This removes the local Docker database.
+
+   ```powershell
+   docker compose down -v --remove-orphans
+   ```
+
+3. Run the import script.
+
+   ```powershell
+   .\scripts\docker\import-backup.ps1 -DumpPath .\backup_radius.sql.gz
+   ```
+
+4. Confirm the stack is up.
+
+   ```powershell
+   docker compose ps
+   ```
+
+5. Confirm imported operator passwords are already hashed.
+
+   ```powershell
+   docker compose run --rm --no-deps --entrypoint php radius-web -r '$pdo=new PDO("mysql:host=".getenv("MYSQL_HOST").";port=".getenv("MYSQL_PORT").";dbname=".getenv("MYSQL_DATABASE").";charset=utf8mb4",getenv("MYSQL_USER"),getenv("MYSQL_PASSWORD"),[PDO::ATTR_ERRMODE=>PDO::ERRMODE_EXCEPTION]); $rows=$pdo->query("SELECT username,password FROM operators")->fetchAll(PDO::FETCH_ASSOC); $non=0; foreach($rows as $r){ $info=password_get_info($r["password"]); if(($info["algo"] ?? 0)===0){ $non++; } } echo "operator_rows=".count($rows)."\nnon_hash_operator_passwords=$non\n";'
+   ```
+
+   Expected result:
+
+   ```text
+   non_hash_operator_passwords=0
+   ```
+
+6. Confirm the `administrator` operator uses the password configured in `.env`.
+
+   ```powershell
+   docker compose run --rm --no-deps --entrypoint php radius-web -r '$pdo=new PDO("mysql:host=".getenv("MYSQL_HOST").";port=".getenv("MYSQL_PORT").";dbname=".getenv("MYSQL_DATABASE").";charset=utf8mb4",getenv("MYSQL_USER"),getenv("MYSQL_PASSWORD"),[PDO::ATTR_ERRMODE=>PDO::ERRMODE_EXCEPTION]); $hash=$pdo->query("SELECT password FROM operators WHERE username=\"administrator\"")->fetchColumn(); echo "administrator_env_password_valid=".(password_verify(getenv("DALORADIUS_ADMIN_PASSWORD"),$hash) ? "valid" : "invalid")."\n";'
+   ```
+
+   Expected result:
+
+   ```text
+   administrator_env_password_valid=valid
+   ```
+
+
+## Post-import checks
+
+Run these checks after either import script finishes.
+
+Confirm service state:
+
+```powershell
+docker compose ps
+```
+
+Confirm `operators.password` can store PHP password hashes:
+
+```powershell
+docker compose run --rm --no-deps --entrypoint php radius-web -r '$pdo=new PDO("mysql:host=".getenv("MYSQL_HOST").";port=".getenv("MYSQL_PORT").";dbname=".getenv("MYSQL_DATABASE").";charset=utf8mb4",getenv("MYSQL_USER"),getenv("MYSQL_PASSWORD"),[PDO::ATTR_ERRMODE=>PDO::ERRMODE_EXCEPTION]); $row=$pdo->query("SELECT CHARACTER_MAXIMUM_LENGTH AS width, IS_NULLABLE AS nullable FROM information_schema.COLUMNS WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME=\"operators\" AND COLUMN_NAME=\"password\"")->fetch(PDO::FETCH_ASSOC); echo "operators_password_width=".$row["width"]."\noperators_password_nullable=".$row["nullable"]."\n";'
+```
+
+Expected result:
+
+```text
+operators_password_width=95
+operators_password_nullable=NO
+```
+
+Confirm the conversion is idempotent:
+
+```powershell
+docker compose run --rm --no-deps --entrypoint php radius-web /usr/local/bin/daloradius-hash-imported-passwords.php
+```
+
+Expected result after a completed import:
+
+```text
+operator_passwords_converted=0
+administrator_password_updated=0
+```
+
+## Troubleshooting
+
+If the dump import fails before the full stack starts, inspect the database service:
+
+```powershell
+docker compose ps
+docker compose logs radius-mysql
+```
+
+If `radius-web` starts but login fails, confirm `administrator` exists and validates against `DALORADIUS_ADMIN_PASSWORD` using the check above.
+
+If a local import needs to be repeated from scratch, remove volumes again before rerunning the import script:
+
+On Linux:
+
+```bash
+docker compose down -v --remove-orphans
+bash scripts/docker/import-backup.sh ./backup_radius.sql.gz
+```
+
+On Windows:
+```powershell
+docker compose down -v --remove-orphans
+.\scripts\docker\import-backup.ps1 -DumpPath .\backup_radius.sql.gz
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       - '1812:1812/udp'
       - '1813:1813/udp'
     environment:
+      - TZ=${TZ:-Europe/Vienna}
       - MYSQL_HOST=radius-mysql
       - MYSQL_PORT=3306
       - MYSQL_DATABASE=radius
@@ -72,6 +73,7 @@ services:
       - '80:80'
       - '${DALORADIUS_OPERATORS_BIND:-127.0.0.1:8000}:8000'
     environment:
+      - TZ=${TZ:-Europe/Vienna}
       - MYSQL_HOST=radius-mysql
       - MYSQL_PORT=3306
       - MYSQL_DATABASE=radius
@@ -81,10 +83,10 @@ services:
       # Optional Settings:
       - DEFAULT_CLIENT_SECRET=${DEFAULT_CLIENT_SECRET:?Set DEFAULT_CLIENT_SECRET}
       - DEFAULT_FREERADIUS_SERVER=radius
-      - MAIL_SMTPADDR=127.0.0.1
-      - MAIL_PORT=25
-      - MAIL_FROM=root@daloradius.xdsl.by
-      - MAIL_AUTH=
+      - MAIL_SMTPADDR=${MAIL_SMTPADDR:-127.0.0.1}
+      - MAIL_PORT=${MAIL_PORT:-25}
+      - MAIL_FROM=${MAIL_FROM:-root@daloradius.xdsl.by}
+      - MAIL_AUTH=${MAIL_AUTH:-}
 
     volumes:
       - radius_daloradius_data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - MYSQL_USER=radius
       - MYSQL_PASSWORD=${MYSQL_PASSWORD:?Set MYSQL_PASSWORD}
       - DEFAULT_CLIENT_SECRET=${DEFAULT_CLIENT_SECRET:?Set DEFAULT_CLIENT_SECRET}
-      - FREERADIUS_SQL_TLS=${FREERADIUS_SQL_TLS:-disabled}
+      - FREERADIUS_SQL_TLS=${FREERADIUS_SQL_TLS:?Set FREERADIUS_SQL_TLS to require or disabled}
     volumes:
       - radius_freeradius_data:/data
       - radius_logs:/var/log/freeradius

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
   radius-mysql:
-    image: mariadb:11.8
+    image: mariadb:11.8@sha256:78a5047d3ba33975f183f183c2464cc7f1eab13ec8667e57cc9a5821d6da7577
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,15 +2,14 @@ services:
 
   radius-mysql:
     image: mariadb:11.8
-    container_name: radius-mysql
     restart: unless-stopped
     environment:
       - MYSQL_DATABASE=radius
       - MYSQL_USER=radius
-      - MYSQL_PASSWORD=radiusdbpw
-      - MYSQL_ROOT_PASSWORD=radiusrootdbpw
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD:?Set MYSQL_PASSWORD}
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:?Set MYSQL_ROOT_PASSWORD}
     volumes:
-      - "./data/mysql:/var/lib/mysql"
+      - radius_mysql:/var/lib/mysql
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       interval: 10s
@@ -19,8 +18,6 @@ services:
       start_period: 30s
 
   radius:
-    image: lirantal/dalofreeradius
-    container_name: radius
     build:
       context: .
       dockerfile: Dockerfile-freeradius
@@ -36,36 +33,41 @@ services:
       - MYSQL_PORT=3306
       - MYSQL_DATABASE=radius
       - MYSQL_USER=radius
-      - MYSQL_PASSWORD=radiusdbpw
-      # Optional settings
-      - DEFAULT_CLIENT_SECRET=testing123
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD:?Set MYSQL_PASSWORD}
+      - DEFAULT_CLIENT_SECRET=${DEFAULT_CLIENT_SECRET:?Set DEFAULT_CLIENT_SECRET}
+      - FREERADIUS_SQL_TLS=${FREERADIUS_SQL_TLS:-disabled}
     volumes:
-      - ./data/freeradius:/data
+      - radius_freeradius_data:/data
       - radius_logs:/var/log/freeradius
+    healthcheck:
+      test: ["CMD-SHELL", "freeradius -C >/dev/null 2>&1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
     # Uncomment below to enable debug logging.
     #command: -X
 
   radius-web:
-    image: lirantal/daloradius
     build: .
-    container_name: radius-web
     restart: unless-stopped
     depends_on:
       radius-mysql:
         condition: service_healthy
       radius:
-        condition: service_started
+        condition: service_healthy
     ports:
       - '80:80'
-      - '8000:8000'
+      - '${DALORADIUS_OPERATORS_BIND:-127.0.0.1:8000}:8000'
     environment:
       - MYSQL_HOST=radius-mysql
       - MYSQL_PORT=3306
       - MYSQL_DATABASE=radius
       - MYSQL_USER=radius
-      - MYSQL_PASSWORD=radiusdbpw
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD:?Set MYSQL_PASSWORD}
+      - DALORADIUS_ADMIN_PASSWORD=${DALORADIUS_ADMIN_PASSWORD:?Set DALORADIUS_ADMIN_PASSWORD}
       # Optional Settings:
-      - DEFAULT_CLIENT_SECRET=testing123
+      - DEFAULT_CLIENT_SECRET=${DEFAULT_CLIENT_SECRET:?Set DEFAULT_CLIENT_SECRET}
       - DEFAULT_FREERADIUS_SERVER=radius
       - MAIL_SMTPADDR=127.0.0.1
       - MAIL_PORT=25
@@ -73,8 +75,11 @@ services:
       - MAIL_AUTH=
 
     volumes:
-      - ./data/daloradius:/data
+      - radius_daloradius_data:/data
       - radius_logs:/var/log/freeradius
 
 volumes:
+  radius_mysql:
+  radius_freeradius_data:
+  radius_daloradius_data:
   radius_logs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,10 @@ services:
   radius-mysql:
     image: mariadb:11.8
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - NET_RAW
     environment:
       - MYSQL_DATABASE=radius
       - MYSQL_USER=radius
@@ -22,6 +26,10 @@ services:
       context: .
       dockerfile: Dockerfile-freeradius
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - NET_RAW
     depends_on:
       radius-mysql:
         condition: service_healthy
@@ -51,6 +59,10 @@ services:
   radius-web:
     build: .
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - NET_RAW
     depends_on:
       radius-mysql:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       - radius_freeradius_data:/data
       - radius_logs:/var/log/freeradius
     healthcheck:
-      test: ["CMD-SHELL", "freeradius -C >/dev/null 2>&1"]
+      test: ["CMD-SHELL", "echo 'FreeRADIUS-Statistics-Type = 1' | radclient -q -r 1 -t 3 127.0.0.1:18121 status adminsecret >/dev/null"]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/docker/post-import-migrations/001-operators-password-width.sql
+++ b/docker/post-import-migrations/001-operators-password-width.sql
@@ -1,0 +1,3 @@
+-- Widen legacy daloRADIUS operator passwords before the Docker init script
+-- writes a PHP password_hash() value for DALORADIUS_ADMIN_PASSWORD.
+ALTER TABLE `operators` MODIFY `password` VARCHAR(95) NOT NULL;

--- a/init-freeradius.sh
+++ b/init-freeradius.sh
@@ -12,6 +12,7 @@ MYSQL_PASSWORD=${MYSQL_PASSWORD:-}
 MYSQL_WAIT_RETRIES=${MYSQL_WAIT_RETRIES:-30}
 MYSQL_WAIT_INTERVAL=${MYSQL_WAIT_INTERVAL:-2}
 INIT_ERROR_LOG=${INIT_ERROR_LOG:-/data/freeradius-init-errors.log}
+TZ=${TZ:-Europe/Vienna}
 DEFAULT_CLIENT_SECRET=${DEFAULT_CLIENT_SECRET:-}
 FREERADIUS_SQL_TLS=${FREERADIUS_SQL_TLS:-require}
 
@@ -108,6 +109,29 @@ function require_mysql_port {
 	fi
 }
 
+function require_timezone {
+	local name="$1"
+	local value="${!name:-}"
+	local zoneinfo_file
+	require_non_empty "$name"
+	reject_crlf "$name"
+	case "$value" in
+		/*|*..*|*//*|*/*/)
+			fail_step "validation" "invalid_timezone_${name}"
+			;;
+	esac
+	if ! [[ "$value" =~ ^[A-Za-z0-9][A-Za-z0-9._+-]*(/[A-Za-z0-9][A-Za-z0-9._+-]*)*$ ]]; then
+		fail_step "validation" "invalid_timezone_${name}"
+	fi
+	if [ "$value" = "UTC" ]; then
+		return
+	fi
+	zoneinfo_file="/usr/share/zoneinfo/$value"
+	if [ ! -f "$zoneinfo_file" ] || [ "$(head -c 4 "$zoneinfo_file" 2>/dev/null)" != "TZif" ]; then
+		fail_step "validation" "invalid_timezone_${name}"
+	fi
+}
+
 function require_sql_identifier {
 	local name="$1"
 	local value="${!name:-}"
@@ -144,6 +168,7 @@ function require_host_token {
 }
 
 function validate_runtime_config {
+	require_timezone "TZ"
 	require_host_token "MYSQL_HOST"
 	require_mysql_port "MYSQL_PORT"
 	require_sql_identifier "MYSQL_DATABASE"

--- a/init-freeradius.sh
+++ b/init-freeradius.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
 # Executable process script for daloRADIUS freeradius docker image:
 # GitHub: git@github.com:lirantal/daloradius.git
+set -euo pipefail
+
 RADIUS_PATH=/etc/freeradius
+MYSQL_HOST=${MYSQL_HOST:-localhost}
+MYSQL_PORT=${MYSQL_PORT:-3306}
+MYSQL_DATABASE=${MYSQL_DATABASE:-radius}
+MYSQL_USER=${MYSQL_USER:-radius}
+MYSQL_PASSWORD=${MYSQL_PASSWORD:-radpass}
+MYSQL_WAIT_RETRIES=${MYSQL_WAIT_RETRIES:-30}
+MYSQL_WAIT_INTERVAL=${MYSQL_WAIT_INTERVAL:-2}
+DEFAULT_CLIENT_SECRET=${DEFAULT_CLIENT_SECRET:-}
 
 function init_freeradius {
 	# Enable SQL in freeradius
@@ -14,9 +24,9 @@ function init_freeradius {
 	sed -i 's|private_key_file = "/etc/ssl/certs/private/client.key"|#private_key_file = "/etc/ssl/certs/private/client.key"|' $RADIUS_PATH/mods-available/sql #disable sql encryption
 	sed -i 's|tls_required = yes|tls_required = no|' $RADIUS_PATH/mods-available/sql #disable sql encryption
 	sed -i 's|#\s*read_clients = yes|read_clients = yes|' $RADIUS_PATH/mods-available/sql
-	ln -s $RADIUS_PATH/mods-available/sql $RADIUS_PATH/mods-enabled/sql
-	ln -s $RADIUS_PATH/mods-available/sqlcounter $RADIUS_PATH/mods-enabled/sqlcounter
-	ln -s $RADIUS_PATH/mods-available/sqlippool $RADIUS_PATH/mods-enabled/sqlippool
+	ln -sf $RADIUS_PATH/mods-available/sql $RADIUS_PATH/mods-enabled/sql
+	ln -sf $RADIUS_PATH/mods-available/sqlcounter $RADIUS_PATH/mods-enabled/sqlcounter
+	ln -sf $RADIUS_PATH/mods-available/sqlippool $RADIUS_PATH/mods-enabled/sqlippool
 	enable_noresetcounter
 	sed -i 's|instantiate {|instantiate {\nsql|' $RADIUS_PATH/radiusd.conf # mods-enabled does not ensure the right order
 
@@ -32,7 +42,7 @@ function init_freeradius {
         $RADIUS_PATH/radiusd.conf
 
 	# Enable status in freeadius
-	ln -s $RADIUS_PATH/sites-available/status $RADIUS_PATH/sites-enabled/status
+	ln -sf $RADIUS_PATH/sites-available/status $RADIUS_PATH/sites-enabled/status
 
 	# Set Database connection
 	sed -i 's|^#\s*server = .*|server = "'$MYSQL_HOST'"|' $RADIUS_PATH/mods-available/sql
@@ -75,7 +85,7 @@ function enable_noresetcounter {
 }
 
 function ensure_daloradius_schema {
-	mysql -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" <<'EOSQL'
+	mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" <<'EOSQL'
 CREATE TABLE IF NOT EXISTS `radhuntgroup` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `groupname` varchar(64) NOT NULL DEFAULT '',
@@ -88,8 +98,8 @@ EOSQL
 }
 
 function init_database {
-	mysql -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" < $RADIUS_PATH/mods-config/sql/main/mysql/schema.sql
-	mysql -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" < $RADIUS_PATH/mods-config/sql/ippool/mysql/schema.sql
+	mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" < $RADIUS_PATH/mods-config/sql/main/mysql/schema.sql
+	mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" < $RADIUS_PATH/mods-config/sql/ippool/mysql/schema.sql
 	ensure_daloradius_schema
 
 	# Insert a client for the current subnet (to allow daloradius to perform checks)
@@ -101,18 +111,33 @@ function init_database {
 		SECRET=$DEFAULT_CLIENT_SECRET
 	fi
 	echo "Adding client for $CIDR with default secret $SECRET"
-	mysql -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" -e "INSERT INTO nas (nasname,shortname,type,ports,secret,server,community,description) VALUES ('$CIDR','DOCKER NET','other',0,'$SECRET',NULL,'','')"
+	mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" -e "INSERT INTO nas (nasname,shortname,type,ports,secret,server,community,description) VALUES ('$CIDR','DOCKER NET','other',0,'$SECRET',NULL,'','')"
 
 	echo "Database initialization for freeradius completed."
+}
+
+function freeradius_schema_ready {
+	mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" \
+		-e "SELECT 1 FROM radcheck LIMIT 1; SELECT 1 FROM nas LIMIT 1;" >/dev/null 2>&1
+}
+
+function wait_for_mysql {
+	local attempt=1
+	while ! mysqladmin ping -h"$MYSQL_HOST" -P"$MYSQL_PORT" -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" --silent; do
+		if [ "$attempt" -ge "$MYSQL_WAIT_RETRIES" ]; then
+			echo "MySQL did not become ready after $MYSQL_WAIT_RETRIES attempts."
+			exit 1
+		fi
+		echo "Waiting for mysql ($MYSQL_HOST)..."
+		attempt=$((attempt + 1))
+		sleep "$MYSQL_WAIT_INTERVAL"
+	done
 }
 
 echo "Starting freeradius..."
 
 # wait for MySQL-Server to be ready
-while ! mysqladmin ping -h"$MYSQL_HOST" -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" --silent; do
-	echo "Waiting for mysql ($MYSQL_HOST)..."
-	sleep 20
-done
+wait_for_mysql
 
 INIT_LOCK=/data/.freeradius_init_done
 if test -f "$INIT_LOCK"; then
@@ -125,11 +150,11 @@ if test -f "$INIT_LOCK"; then
 		echo "Init lock file exists but FreeRADIUS configuration is missing, reinitializing..."
 		rm -f "$INIT_LOCK"
 		init_freeradius
-		date > $INIT_LOCK
+		date > "$INIT_LOCK"
 	fi
 else
 	init_freeradius
-	date > $INIT_LOCK
+	date > "$INIT_LOCK"
 fi
 
 # Ensure Max-All-Session is enforced before FreeRADIUS starts, including after
@@ -139,12 +164,17 @@ if test -L "$RADIUS_PATH/mods-enabled/sqlcounter"; then
 fi
 
 DB_LOCK=/data/.db_init_done
-if test -f "$DB_LOCK"; then
-	echo "Database lock file exists, skipping initial setup of mysql database."
+if freeradius_schema_ready; then
+	echo "Database schema already present, skipping initial setup of mysql database."
+	date > "$DB_LOCK"
 	ensure_daloradius_schema
 else
 	init_database
-	date > $DB_LOCK
+	if ! freeradius_schema_ready; then
+		echo "FreeRADIUS database schema was not found after initialization."
+		exit 1
+	fi
+	date > "$DB_LOCK"
 fi
 
 # make logs directory world readable

--- a/init-freeradius.sh
+++ b/init-freeradius.sh
@@ -12,6 +12,7 @@ MYSQL_PASSWORD=${MYSQL_PASSWORD:-radpass}
 MYSQL_WAIT_RETRIES=${MYSQL_WAIT_RETRIES:-30}
 MYSQL_WAIT_INTERVAL=${MYSQL_WAIT_INTERVAL:-2}
 DEFAULT_CLIENT_SECRET=${DEFAULT_CLIENT_SECRET:-}
+FREERADIUS_SQL_TLS=${FREERADIUS_SQL_TLS:-require}
 MYSQL_DEFAULTS_FILE=$(mktemp)
 
 chmod 600 "$MYSQL_DEFAULTS_FILE"
@@ -53,11 +54,13 @@ function init_freeradius {
 	sed -i 's|driver = "rlm_sql_null"|driver = "rlm_sql_mysql"|' $RADIUS_PATH/mods-available/sql
 	sed -i 's|dialect = "sqlite"|dialect = "mysql"|' $RADIUS_PATH/mods-available/sql
 	sed -i 's|dialect = ${modules.sql.dialect}|dialect = "mysql"|' $RADIUS_PATH/mods-available/sqlcounter # avoid instantiation error
-	sed -i 's|ca_file = "/etc/ssl/certs/my_ca.crt"|#ca_file = "/etc/ssl/certs/my_ca.crt"|' $RADIUS_PATH/mods-available/sql #disable sql encryption
-        sed -i 's|ca_path = "/etc/ssl/certs/"|#ca_path = "/etc/ssl/certs/"|' $RADIUS_PATH/mods-available/sql #disable sql encryption
-	sed -i 's|certificate_file = "/etc/ssl/certs/private/client.crt"|#certificate_file = "/etc/ssl/certs/private/client.crt"|' $RADIUS_PATH/mods-available/sql #disable sql encryption
-	sed -i 's|private_key_file = "/etc/ssl/certs/private/client.key"|#private_key_file = "/etc/ssl/certs/private/client.key"|' $RADIUS_PATH/mods-available/sql #disable sql encryption
-	sed -i 's|tls_required = yes|tls_required = no|' $RADIUS_PATH/mods-available/sql #disable sql encryption
+	if [ "$FREERADIUS_SQL_TLS" = "disabled" ]; then
+		sed -i 's|ca_file = "/etc/ssl/certs/my_ca.crt"|#ca_file = "/etc/ssl/certs/my_ca.crt"|' $RADIUS_PATH/mods-available/sql
+		sed -i 's|ca_path = "/etc/ssl/certs/"|#ca_path = "/etc/ssl/certs/"|' $RADIUS_PATH/mods-available/sql
+		sed -i 's|certificate_file = "/etc/ssl/certs/private/client.crt"|#certificate_file = "/etc/ssl/certs/private/client.crt"|' $RADIUS_PATH/mods-available/sql
+		sed -i 's|private_key_file = "/etc/ssl/certs/private/client.key"|#private_key_file = "/etc/ssl/certs/private/client.key"|' $RADIUS_PATH/mods-available/sql
+		sed -i 's|tls_required = yes|tls_required = no|' $RADIUS_PATH/mods-available/sql
+	fi
 	sed -i 's|#\s*read_clients = yes|read_clients = yes|' $RADIUS_PATH/mods-available/sql
 	ln -sf $RADIUS_PATH/mods-available/sql $RADIUS_PATH/mods-enabled/sql
 	ln -sf $RADIUS_PATH/mods-available/sqlcounter $RADIUS_PATH/mods-enabled/sqlcounter
@@ -210,8 +213,9 @@ else
 	date > "$DB_LOCK"
 fi
 
-# make logs directory world readable
-chmod -R a+rX /var/log/freeradius
+# make logs readable to the shared www-data group without opening them world-wide
+chgrp -R 33 /var/log/freeradius 2>/dev/null || true
+chmod -R u+rwX,g+rX,o-rwx /var/log/freeradius
 
 # start freeradius in foreground mode
 freeradius -f "$@" &
@@ -231,8 +235,11 @@ _term() {
 }
 trap _term INT TERM
 
+set +e
 wait "$RADIUS_PID"
+RADIUS_STATUS=$?
+set -e
 # if freeradius dies, kill the tail and exit with its code
 kill -TERM "$TAIL_PID" 2>/dev/null
-wait "$TAIL_PID"
-exit $?
+wait "$TAIL_PID" 2>/dev/null || true
+exit "$RADIUS_STATUS"

--- a/init-freeradius.sh
+++ b/init-freeradius.sh
@@ -170,6 +170,23 @@ function wait_for_mysql {
 	done
 }
 
+function prepare_freeradius_logs {
+	chown -R freerad:33 /var/log/freeradius
+	find /var/log/freeradius -type d -exec chmod 2750 {} +
+	find /var/log/freeradius -type f -exec chmod 0640 {} +
+}
+
+function wait_for_radius_status {
+	local attempt=1
+	while ! echo 'FreeRADIUS-Statistics-Type = 1' | radclient -q -r 1 -t 3 127.0.0.1:18121 status adminsecret >/dev/null 2>&1; do
+		if [ "$attempt" -ge 30 ]; then
+			return
+		fi
+		attempt=$((attempt + 1))
+		sleep 1
+	done
+}
+
 echo "Starting freeradius..."
 
 # wait for MySQL-Server to be ready
@@ -214,12 +231,14 @@ else
 fi
 
 # make logs readable to the shared www-data group without opening them world-wide
-chgrp -R 33 /var/log/freeradius 2>/dev/null || true
-chmod -R u+rwX,g+rX,o-rwx /var/log/freeradius
+prepare_freeradius_logs
 
 # start freeradius in foreground mode
 freeradius -f "$@" &
 RADIUS_PID=$!
+
+wait_for_radius_status
+prepare_freeradius_logs
 
 tail -F /var/log/freeradius/radius.log &
 TAIL_PID=$!

--- a/init-freeradius.sh
+++ b/init-freeradius.sh
@@ -8,11 +8,109 @@ MYSQL_HOST=${MYSQL_HOST:-localhost}
 MYSQL_PORT=${MYSQL_PORT:-3306}
 MYSQL_DATABASE=${MYSQL_DATABASE:-radius}
 MYSQL_USER=${MYSQL_USER:-radius}
-MYSQL_PASSWORD=${MYSQL_PASSWORD:-radpass}
+MYSQL_PASSWORD=${MYSQL_PASSWORD:-}
 MYSQL_WAIT_RETRIES=${MYSQL_WAIT_RETRIES:-30}
 MYSQL_WAIT_INTERVAL=${MYSQL_WAIT_INTERVAL:-2}
 DEFAULT_CLIENT_SECRET=${DEFAULT_CLIENT_SECRET:-}
 FREERADIUS_SQL_TLS=${FREERADIUS_SQL_TLS:-require}
+
+function require_non_empty {
+	local name="$1"
+	local value="${!name:-}"
+	if [ -z "$value" ]; then
+		echo "$name must be set."
+		exit 1
+	fi
+}
+
+function reject_crlf {
+	local name="$1"
+	local value="${!name:-}"
+	case "$value" in
+		*$'\r'*|*$'\n'*)
+			echo "$name must not contain CR or LF characters."
+			exit 1
+			;;
+	esac
+}
+
+function require_positive_integer {
+	local name="$1"
+	local value="${!name:-}"
+	if ! [[ "$value" =~ ^[1-9][0-9]*$ ]]; then
+		echo "$name must be a positive integer."
+		exit 1
+	fi
+}
+
+function require_mysql_port {
+	local name="$1"
+	local value="${!name:-}"
+	require_positive_integer "$name"
+	if [ "${#value}" -gt 5 ] || { [ "${#value}" -eq 5 ] && [[ "$value" > "65535" ]]; }; then
+		echo "$name must be between 1 and 65535."
+		exit 1
+	fi
+}
+
+function require_sql_identifier {
+	local name="$1"
+	local value="${!name:-}"
+	require_non_empty "$name"
+	if ! [[ "$value" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+		echo "$name must start with a letter or underscore and contain only letters, digits, and underscores."
+		exit 1
+	fi
+}
+
+function require_host_token {
+	local name="$1"
+	local value="${!name:-}"
+	local -a host_labels
+	local label
+	require_non_empty "$name"
+	reject_crlf "$name"
+
+	case "$value" in
+		.*|*.|*..*)
+			echo "$name must not contain leading, trailing, or consecutive dots."
+			exit 1
+			;;
+	esac
+
+	IFS='.' read -r -a host_labels <<< "$value"
+	for label in "${host_labels[@]}"; do
+		if ! [[ "$label" =~ ^[A-Za-z0-9]([A-Za-z0-9_-]*[A-Za-z0-9])?$ ]]; then
+			echo "$name must use dot-separated labels that start and end with a letter or digit."
+			exit 1
+		fi
+	done
+
+	if [ "${#host_labels[@]}" -eq 0 ]; then
+		echo "$name must be a valid host token."
+		exit 1
+	fi
+}
+
+function validate_runtime_config {
+	require_host_token "MYSQL_HOST"
+	require_mysql_port "MYSQL_PORT"
+	require_sql_identifier "MYSQL_DATABASE"
+	require_sql_identifier "MYSQL_USER"
+	require_non_empty "MYSQL_PASSWORD"
+	reject_crlf "MYSQL_PASSWORD"
+	require_positive_integer "MYSQL_WAIT_RETRIES"
+	require_positive_integer "MYSQL_WAIT_INTERVAL"
+	require_non_empty "DEFAULT_CLIENT_SECRET"
+	reject_crlf "DEFAULT_CLIENT_SECRET"
+	if [ "$FREERADIUS_SQL_TLS" != "require" ] && [ "$FREERADIUS_SQL_TLS" != "disabled" ]; then
+		echo "FREERADIUS_SQL_TLS must be either require or disabled."
+		exit 1
+	fi
+}
+
+validate_runtime_config
+
 MYSQL_DEFAULTS_FILE=$(mktemp)
 
 chmod 600 "$MYSQL_DEFAULTS_FILE"
@@ -29,6 +127,10 @@ function escape_sed_replacement {
 	printf '%s' "$1" | sed -e 's/[\/&|\\]/\\&/g'
 }
 
+function freeradius_quote_escape {
+	printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/\$/\\$/g'
+}
+
 function sql_escape {
 	printf '%s' "$1" | sed "s/'/''/g"
 }
@@ -43,7 +145,7 @@ function require_default_client_secret {
 function sql_config_set {
 	local key="$1"
 	local value
-	value=$(escape_sed_replacement "$2")
+	value=$(escape_sed_replacement "$(freeradius_quote_escape "$2")")
 	sed -i "s|^[#[:space:]]*$key[[:space:]]*=.*|$key = \"$value\"|" "$RADIUS_PATH/mods-available/sql"
 }
 
@@ -88,7 +190,7 @@ function init_freeradius {
 	sql_config_set "radius_db" "$MYSQL_DATABASE"
 	sql_config_set "password" "$MYSQL_PASSWORD"
 	sql_config_set "login" "$MYSQL_USER"
-	sed -i "s|testing123|$(escape_sed_replacement "$DEFAULT_CLIENT_SECRET")|" $RADIUS_PATH/mods-available/sql
+	sed -i "s|testing123|$(escape_sed_replacement "$(freeradius_quote_escape "$DEFAULT_CLIENT_SECRET")")|" $RADIUS_PATH/mods-available/sql
 	echo "freeradius initialization completed."
 }
 

--- a/init-freeradius.sh
+++ b/init-freeradius.sh
@@ -140,14 +140,14 @@ function init_database {
 	ensure_daloradius_schema
 
 	# Insert a client for the current subnet (to allow daloradius to perform checks)
-	IP=`ifconfig eth0 | awk '/inet/{ print $2;} '` # does also work: $IP=`hostname -I | awk '{print $1}'`
-	NM=`ifconfig eth0 | awk '/netmask/{ print $4;} '`
-	CIDR=`ipcalc $IP $NM | awk '/Network/{ print $2;} '`
-	SECRET=$DEFAULT_CLIENT_SECRET
-	CIDR_SQL=$(sql_escape "$CIDR")
-	SECRET_SQL=$(sql_escape "$SECRET")
-	echo "Adding client for $CIDR with configured shared secret."
-	mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" -e "INSERT INTO nas (nasname,shortname,type,ports,secret,server,community,description) VALUES ('$CIDR_SQL','DOCKER NET','other',0,'$SECRET_SQL',NULL,'','')"
+	container_ip_address=`ifconfig eth0 | awk '/inet/{ print $2;} '` # does also work: $container_ip_address=`hostname -I | awk '{print $1}'`
+	container_netmask=`ifconfig eth0 | awk '/netmask/{ print $4;} '`
+	container_cidr=`ipcalc $container_ip_address $container_netmask | awk '/Network/{ print $2;} '`
+	client_secret=$DEFAULT_CLIENT_SECRET
+	container_cidr_sql=$(sql_escape "$container_cidr")
+	client_secret_sql=$(sql_escape "$client_secret")
+	echo "Adding client for $container_cidr with configured shared secret."
+	mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" -e "INSERT INTO nas (nasname,shortname,type,ports,secret,server,community,description) VALUES ('$container_cidr_sql','DOCKER NET','other',0,'$client_secret_sql',NULL,'','')"
 
 	echo "Database initialization for freeradius completed."
 }

--- a/init-freeradius.sh
+++ b/init-freeradius.sh
@@ -12,8 +12,43 @@ MYSQL_PASSWORD=${MYSQL_PASSWORD:-radpass}
 MYSQL_WAIT_RETRIES=${MYSQL_WAIT_RETRIES:-30}
 MYSQL_WAIT_INTERVAL=${MYSQL_WAIT_INTERVAL:-2}
 DEFAULT_CLIENT_SECRET=${DEFAULT_CLIENT_SECRET:-}
+MYSQL_DEFAULTS_FILE=$(mktemp)
+
+chmod 600 "$MYSQL_DEFAULTS_FILE"
+cat > "$MYSQL_DEFAULTS_FILE" <<EOF
+[client]
+host=$MYSQL_HOST
+port=$MYSQL_PORT
+user=$MYSQL_USER
+password=$MYSQL_PASSWORD
+EOF
+trap 'rm -f "$MYSQL_DEFAULTS_FILE"' EXIT
+
+function escape_sed_replacement {
+	printf '%s' "$1" | sed -e 's/[\/&|\\]/\\&/g'
+}
+
+function sql_escape {
+	printf '%s' "$1" | sed "s/'/''/g"
+}
+
+function require_default_client_secret {
+	if [ -z "$DEFAULT_CLIENT_SECRET" ]; then
+		echo "DEFAULT_CLIENT_SECRET must be set."
+		exit 1
+	fi
+}
+
+function sql_config_set {
+	local key="$1"
+	local value
+	value=$(escape_sed_replacement "$2")
+	sed -i "s|^[#[:space:]]*$key[[:space:]]*=.*|$key = \"$value\"|" "$RADIUS_PATH/mods-available/sql"
+}
 
 function init_freeradius {
+	require_default_client_secret
+
 	# Enable SQL in freeradius
 	sed -i 's|driver = "rlm_sql_null"|driver = "rlm_sql_mysql"|' $RADIUS_PATH/mods-available/sql
 	sed -i 's|dialect = "sqlite"|dialect = "mysql"|' $RADIUS_PATH/mods-available/sql
@@ -45,15 +80,12 @@ function init_freeradius {
 	ln -sf $RADIUS_PATH/sites-available/status $RADIUS_PATH/sites-enabled/status
 
 	# Set Database connection
-	sed -i 's|^#\s*server = .*|server = "'$MYSQL_HOST'"|' $RADIUS_PATH/mods-available/sql
-	sed -i 's|^#\s*port = .*|port = "'$MYSQL_PORT'"|' $RADIUS_PATH/mods-available/sql
-	sed -i '1,$s/radius_db.*/radius_db="'$MYSQL_DATABASE'"/g' $RADIUS_PATH/mods-available/sql
-	sed -i 's|^#\s*password = .*|password = "'$MYSQL_PASSWORD'"|' $RADIUS_PATH/mods-available/sql
-	sed -i 's|^#\s*login = .*|login = "'$MYSQL_USER'"|' $RADIUS_PATH/mods-available/sql
-
-	if [ -n "$DEFAULT_CLIENT_SECRET" ]; then
-		sed -i 's|testing123|'$DEFAULT_CLIENT_SECRET'|' $RADIUS_PATH/mods-available/sql
-	fi
+	sql_config_set "server" "$MYSQL_HOST"
+	sql_config_set "port" "$MYSQL_PORT"
+	sql_config_set "radius_db" "$MYSQL_DATABASE"
+	sql_config_set "password" "$MYSQL_PASSWORD"
+	sql_config_set "login" "$MYSQL_USER"
+	sed -i "s|testing123|$(escape_sed_replacement "$DEFAULT_CLIENT_SECRET")|" $RADIUS_PATH/mods-available/sql
 	echo "freeradius initialization completed."
 }
 
@@ -85,7 +117,7 @@ function enable_noresetcounter {
 }
 
 function ensure_daloradius_schema {
-	mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" <<'EOSQL'
+	mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" <<'EOSQL'
 CREATE TABLE IF NOT EXISTS `radhuntgroup` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `groupname` varchar(64) NOT NULL DEFAULT '',
@@ -98,32 +130,33 @@ EOSQL
 }
 
 function init_database {
-	mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" < $RADIUS_PATH/mods-config/sql/main/mysql/schema.sql
-	mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" < $RADIUS_PATH/mods-config/sql/ippool/mysql/schema.sql
+	require_default_client_secret
+
+	mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" < $RADIUS_PATH/mods-config/sql/main/mysql/schema.sql
+	mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" < $RADIUS_PATH/mods-config/sql/ippool/mysql/schema.sql
 	ensure_daloradius_schema
 
 	# Insert a client for the current subnet (to allow daloradius to perform checks)
 	IP=`ifconfig eth0 | awk '/inet/{ print $2;} '` # does also work: $IP=`hostname -I | awk '{print $1}'`
 	NM=`ifconfig eth0 | awk '/netmask/{ print $4;} '`
 	CIDR=`ipcalc $IP $NM | awk '/Network/{ print $2;} '`
-	SECRET=testing123
-	if [ -n "$DEFAULT_CLIENT_SECRET" ]; then
-		SECRET=$DEFAULT_CLIENT_SECRET
-	fi
-	echo "Adding client for $CIDR with default secret $SECRET"
-	mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" -e "INSERT INTO nas (nasname,shortname,type,ports,secret,server,community,description) VALUES ('$CIDR','DOCKER NET','other',0,'$SECRET',NULL,'','')"
+	SECRET=$DEFAULT_CLIENT_SECRET
+	CIDR_SQL=$(sql_escape "$CIDR")
+	SECRET_SQL=$(sql_escape "$SECRET")
+	echo "Adding client for $CIDR with configured shared secret."
+	mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" -e "INSERT INTO nas (nasname,shortname,type,ports,secret,server,community,description) VALUES ('$CIDR_SQL','DOCKER NET','other',0,'$SECRET_SQL',NULL,'','')"
 
 	echo "Database initialization for freeradius completed."
 }
 
 function freeradius_schema_ready {
-	mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" \
+	mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" \
 		-e "SELECT 1 FROM radcheck LIMIT 1; SELECT 1 FROM nas LIMIT 1;" >/dev/null 2>&1
 }
 
 function wait_for_mysql {
 	local attempt=1
-	while ! mysqladmin ping -h"$MYSQL_HOST" -P"$MYSQL_PORT" -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" --silent; do
+	while ! mysqladmin --defaults-extra-file="$MYSQL_DEFAULTS_FILE" ping --silent; do
 		if [ "$attempt" -ge "$MYSQL_WAIT_RETRIES" ]; then
 			echo "MySQL did not become ready after $MYSQL_WAIT_RETRIES attempts."
 			exit 1

--- a/init-freeradius.sh
+++ b/init-freeradius.sh
@@ -240,6 +240,8 @@ function init_freeradius {
 	sql_config_set "password" "$MYSQL_PASSWORD"
 	sql_config_set "login" "$MYSQL_USER"
 	run_freeradius_sed "s|testing123|$(escape_sed_replacement "$(freeradius_quote_escape "$DEFAULT_CLIENT_SECRET")")|" "$RADIUS_PATH/mods-available/sql"
+	chown root:freerad "$RADIUS_PATH/mods-available/sql" 2>>"$INIT_ERROR_LOG" || fail_step "freeradius_init" "sql_config_owner_failed"
+	chmod 0640 "$RADIUS_PATH/mods-available/sql" 2>>"$INIT_ERROR_LOG" || fail_step "freeradius_init" "sql_config_mode_failed"
 	log_event "info" "freeradius_init" "success" "freeradius_configured"
 	echo "freeradius initialization completed."
 }

--- a/init-freeradius.sh
+++ b/init-freeradius.sh
@@ -175,6 +175,10 @@ function sql_escape {
 	printf '%s' "$1" | sed "s/'/''/g"
 }
 
+function sql_hex {
+	printf '%s' "$1" | od -An -tx1 -v | tr -d '[:space:]'
+}
+
 function require_default_client_secret {
 	if [ -z "$DEFAULT_CLIENT_SECRET" ]; then
 		fail_step "validation" "missing_required_DEFAULT_CLIENT_SECRET"
@@ -314,11 +318,11 @@ function init_database {
 	discover_container_cidr
 	client_secret=$DEFAULT_CLIENT_SECRET
 	container_cidr_sql=$(sql_escape "$container_cidr")
-	client_secret_sql=$(sql_escape "$client_secret")
+	client_secret_hex=$(sql_hex "$client_secret")
 	echo "Adding client for $container_cidr with configured shared secret."
 	log_event "info" "nas_client_insert" "start" "inserting_docker_client"
 	if mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" 2>>"$INIT_ERROR_LOG" <<EOSQL
-INSERT INTO nas (nasname,shortname,type,ports,secret,server,community,description) VALUES ('$container_cidr_sql','DOCKER NET','other',0,'$client_secret_sql',NULL,'','');
+INSERT INTO nas (nasname,shortname,type,ports,secret,server,community,description) VALUES ('$container_cidr_sql','DOCKER NET','other',0,UNHEX('$client_secret_hex'),NULL,'','');
 EOSQL
 	then
 		log_event "info" "nas_client_insert" "success" "docker_client_inserted"

--- a/init-freeradius.sh
+++ b/init-freeradius.sh
@@ -11,15 +11,73 @@ MYSQL_USER=${MYSQL_USER:-radius}
 MYSQL_PASSWORD=${MYSQL_PASSWORD:-}
 MYSQL_WAIT_RETRIES=${MYSQL_WAIT_RETRIES:-30}
 MYSQL_WAIT_INTERVAL=${MYSQL_WAIT_INTERVAL:-2}
+INIT_ERROR_LOG=${INIT_ERROR_LOG:-/data/freeradius-init-errors.log}
 DEFAULT_CLIENT_SECRET=${DEFAULT_CLIENT_SECRET:-}
 FREERADIUS_SQL_TLS=${FREERADIUS_SQL_TLS:-require}
+
+function log_event {
+	local level="$1"
+	local event="$2"
+	local outcome="$3"
+	local detail="$4"
+	printf 'level=%s component=freeradius-init event=%s outcome=%s detail=%s\n' "$level" "$event" "$outcome" "$detail"
+}
+
+function fail_step {
+	local event="$1"
+	local detail="$2"
+	log_event "error" "$event" "failure" "$detail"
+	exit 1
+}
+
+function setup_error_log {
+	if ! { : > "$INIT_ERROR_LOG"; } 2>/dev/null; then
+		fail_step "error_log_setup" "error_log_create_failed"
+	fi
+	if ! chmod 600 "$INIT_ERROR_LOG" 2>/dev/null; then
+		fail_step "error_log_setup" "error_log_chmod_failed"
+	fi
+}
+
+function setup_mysql_defaults_file {
+	local defaults_file
+	if ! [ -w "$INIT_ERROR_LOG" ]; then
+		fail_step "mysql_defaults_setup" "error_log_unwritable"
+	fi
+	if ! defaults_file="$(mktemp)" 2>>"$INIT_ERROR_LOG"; then
+		fail_step "mysql_defaults_setup" "defaults_file_create_failed"
+	fi
+	MYSQL_DEFAULTS_FILE="$defaults_file"
+	trap 'rm -f "$MYSQL_DEFAULTS_FILE"' EXIT
+	if ! chmod 600 "$MYSQL_DEFAULTS_FILE" 2>>"$INIT_ERROR_LOG"; then
+		fail_step "mysql_defaults_setup" "defaults_file_chmod_failed"
+	fi
+	if ! cat 2>>"$INIT_ERROR_LOG" > "$MYSQL_DEFAULTS_FILE" <<EOF
+[client]
+host=$MYSQL_HOST
+port=$MYSQL_PORT
+user=$MYSQL_USER
+password=$MYSQL_PASSWORD
+EOF
+	then
+		fail_step "mysql_defaults_setup" "defaults_file_write_failed"
+	fi
+}
+
+function write_lock {
+	local lock_path="$1"
+	local event="$2"
+	if ! [ -w "$INIT_ERROR_LOG" ]; then
+		fail_step "$event" "error_log_unwritable"
+	fi
+	date 2>>"$INIT_ERROR_LOG" > "$lock_path" || fail_step "$event" "lock_write_failed"
+}
 
 function require_non_empty {
 	local name="$1"
 	local value="${!name:-}"
 	if [ -z "$value" ]; then
-		echo "$name must be set."
-		exit 1
+		fail_step "validation" "missing_required_${name}"
 	fi
 }
 
@@ -28,8 +86,7 @@ function reject_crlf {
 	local value="${!name:-}"
 	case "$value" in
 		*$'\r'*|*$'\n'*)
-			echo "$name must not contain CR or LF characters."
-			exit 1
+			fail_step "validation" "invalid_crlf_${name}"
 			;;
 	esac
 }
@@ -38,8 +95,7 @@ function require_positive_integer {
 	local name="$1"
 	local value="${!name:-}"
 	if ! [[ "$value" =~ ^[1-9][0-9]*$ ]]; then
-		echo "$name must be a positive integer."
-		exit 1
+		fail_step "validation" "invalid_positive_integer_${name}"
 	fi
 }
 
@@ -48,8 +104,7 @@ function require_mysql_port {
 	local value="${!name:-}"
 	require_positive_integer "$name"
 	if [ "${#value}" -gt 5 ] || { [ "${#value}" -eq 5 ] && [[ "$value" > "65535" ]]; }; then
-		echo "$name must be between 1 and 65535."
-		exit 1
+		fail_step "validation" "invalid_mysql_port_${name}"
 	fi
 }
 
@@ -58,8 +113,7 @@ function require_sql_identifier {
 	local value="${!name:-}"
 	require_non_empty "$name"
 	if ! [[ "$value" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
-		echo "$name must start with a letter or underscore and contain only letters, digits, and underscores."
-		exit 1
+		fail_step "validation" "invalid_sql_identifier_${name}"
 	fi
 }
 
@@ -73,22 +127,19 @@ function require_host_token {
 
 	case "$value" in
 		.*|*.|*..*)
-			echo "$name must not contain leading, trailing, or consecutive dots."
-			exit 1
+			fail_step "validation" "invalid_host_dots_${name}"
 			;;
 	esac
 
 	IFS='.' read -r -a host_labels <<< "$value"
 	for label in "${host_labels[@]}"; do
 		if ! [[ "$label" =~ ^[A-Za-z0-9]([A-Za-z0-9_-]*[A-Za-z0-9])?$ ]]; then
-			echo "$name must use dot-separated labels that start and end with a letter or digit."
-			exit 1
+			fail_step "validation" "invalid_host_label_${name}"
 		fi
 	done
 
 	if [ "${#host_labels[@]}" -eq 0 ]; then
-		echo "$name must be a valid host token."
-		exit 1
+		fail_step "validation" "invalid_host_empty_${name}"
 	fi
 }
 
@@ -104,24 +155,13 @@ function validate_runtime_config {
 	require_non_empty "DEFAULT_CLIENT_SECRET"
 	reject_crlf "DEFAULT_CLIENT_SECRET"
 	if [ "$FREERADIUS_SQL_TLS" != "require" ] && [ "$FREERADIUS_SQL_TLS" != "disabled" ]; then
-		echo "FREERADIUS_SQL_TLS must be either require or disabled."
-		exit 1
+		fail_step "validation" "invalid_FREERADIUS_SQL_TLS"
 	fi
 }
 
+setup_error_log
 validate_runtime_config
-
-MYSQL_DEFAULTS_FILE=$(mktemp)
-
-chmod 600 "$MYSQL_DEFAULTS_FILE"
-cat > "$MYSQL_DEFAULTS_FILE" <<EOF
-[client]
-host=$MYSQL_HOST
-port=$MYSQL_PORT
-user=$MYSQL_USER
-password=$MYSQL_PASSWORD
-EOF
-trap 'rm -f "$MYSQL_DEFAULTS_FILE"' EXIT
+setup_mysql_defaults_file
 
 function escape_sed_replacement {
 	printf '%s' "$1" | sed -e 's/[\/&|\\]/\\&/g'
@@ -137,8 +177,7 @@ function sql_escape {
 
 function require_default_client_secret {
 	if [ -z "$DEFAULT_CLIENT_SECRET" ]; then
-		echo "DEFAULT_CLIENT_SECRET must be set."
-		exit 1
+		fail_step "validation" "missing_required_DEFAULT_CLIENT_SECRET"
 	fi
 }
 
@@ -146,43 +185,53 @@ function sql_config_set {
 	local key="$1"
 	local value
 	value=$(escape_sed_replacement "$(freeradius_quote_escape "$2")")
-	sed -i "s|^[#[:space:]]*$key[[:space:]]*=.*|$key = \"$value\"|" "$RADIUS_PATH/mods-available/sql"
+	sed -i "s|^[#[:space:]]*$key[[:space:]]*=.*|$key = \"$value\"|" "$RADIUS_PATH/mods-available/sql" \
+		2>>"$INIT_ERROR_LOG" || fail_step "freeradius_init" "sql_config_update_failed"
+}
+
+function run_freeradius_sed {
+	sed -i "$@" 2>>"$INIT_ERROR_LOG" || fail_step "freeradius_init" "config_update_failed"
+}
+
+function run_freeradius_link {
+	ln -sf "$@" 2>>"$INIT_ERROR_LOG" || fail_step "freeradius_init" "config_link_failed"
 }
 
 function init_freeradius {
 	require_default_client_secret
+	log_event "info" "freeradius_init" "start" "configuring_freeradius"
 
 	# Enable SQL in freeradius
-	sed -i 's|driver = "rlm_sql_null"|driver = "rlm_sql_mysql"|' $RADIUS_PATH/mods-available/sql
-	sed -i 's|dialect = "sqlite"|dialect = "mysql"|' $RADIUS_PATH/mods-available/sql
-	sed -i 's|dialect = ${modules.sql.dialect}|dialect = "mysql"|' $RADIUS_PATH/mods-available/sqlcounter # avoid instantiation error
+	run_freeradius_sed 's|driver = "rlm_sql_null"|driver = "rlm_sql_mysql"|' "$RADIUS_PATH/mods-available/sql"
+	run_freeradius_sed 's|dialect = "sqlite"|dialect = "mysql"|' "$RADIUS_PATH/mods-available/sql"
+	run_freeradius_sed 's|dialect = ${modules.sql.dialect}|dialect = "mysql"|' "$RADIUS_PATH/mods-available/sqlcounter" # avoid instantiation error
 	if [ "$FREERADIUS_SQL_TLS" = "disabled" ]; then
-		sed -i 's|ca_file = "/etc/ssl/certs/my_ca.crt"|#ca_file = "/etc/ssl/certs/my_ca.crt"|' $RADIUS_PATH/mods-available/sql
-		sed -i 's|ca_path = "/etc/ssl/certs/"|#ca_path = "/etc/ssl/certs/"|' $RADIUS_PATH/mods-available/sql
-		sed -i 's|certificate_file = "/etc/ssl/certs/private/client.crt"|#certificate_file = "/etc/ssl/certs/private/client.crt"|' $RADIUS_PATH/mods-available/sql
-		sed -i 's|private_key_file = "/etc/ssl/certs/private/client.key"|#private_key_file = "/etc/ssl/certs/private/client.key"|' $RADIUS_PATH/mods-available/sql
-		sed -i 's|tls_required = yes|tls_required = no|' $RADIUS_PATH/mods-available/sql
+		run_freeradius_sed 's|ca_file = "/etc/ssl/certs/my_ca.crt"|#ca_file = "/etc/ssl/certs/my_ca.crt"|' "$RADIUS_PATH/mods-available/sql"
+		run_freeradius_sed 's|ca_path = "/etc/ssl/certs/"|#ca_path = "/etc/ssl/certs/"|' "$RADIUS_PATH/mods-available/sql"
+		run_freeradius_sed 's|certificate_file = "/etc/ssl/certs/private/client.crt"|#certificate_file = "/etc/ssl/certs/private/client.crt"|' "$RADIUS_PATH/mods-available/sql"
+		run_freeradius_sed 's|private_key_file = "/etc/ssl/certs/private/client.key"|#private_key_file = "/etc/ssl/certs/private/client.key"|' "$RADIUS_PATH/mods-available/sql"
+		run_freeradius_sed 's|tls_required = yes|tls_required = no|' "$RADIUS_PATH/mods-available/sql"
 	fi
-	sed -i 's|#\s*read_clients = yes|read_clients = yes|' $RADIUS_PATH/mods-available/sql
-	ln -sf $RADIUS_PATH/mods-available/sql $RADIUS_PATH/mods-enabled/sql
-	ln -sf $RADIUS_PATH/mods-available/sqlcounter $RADIUS_PATH/mods-enabled/sqlcounter
-	ln -sf $RADIUS_PATH/mods-available/sqlippool $RADIUS_PATH/mods-enabled/sqlippool
+	run_freeradius_sed 's|#\s*read_clients = yes|read_clients = yes|' "$RADIUS_PATH/mods-available/sql"
+	run_freeradius_link "$RADIUS_PATH/mods-available/sql" "$RADIUS_PATH/mods-enabled/sql"
+	run_freeradius_link "$RADIUS_PATH/mods-available/sqlcounter" "$RADIUS_PATH/mods-enabled/sqlcounter"
+	run_freeradius_link "$RADIUS_PATH/mods-available/sqlippool" "$RADIUS_PATH/mods-enabled/sqlippool"
 	enable_noresetcounter
-	sed -i 's|instantiate {|instantiate {\nsql|' $RADIUS_PATH/radiusd.conf # mods-enabled does not ensure the right order
+	run_freeradius_sed 's|instantiate {|instantiate {\nsql|' "$RADIUS_PATH/radiusd.conf" # mods-enabled does not ensure the right order
 
 	# Enable used tunnel for unifi
-	sed -i 's|use_tunneled_reply = no|use_tunneled_reply = yes|' $RADIUS_PATH/mods-available/eap
+	run_freeradius_sed 's|use_tunneled_reply = no|use_tunneled_reply = yes|' "$RADIUS_PATH/mods-available/eap"
 
         # Log authentication request in radius-log file
-        sed -i 's|auth = no|auth = yes|' $RADIUS_PATH/radiusd.conf
+        run_freeradius_sed 's|auth = no|auth = yes|' "$RADIUS_PATH/radiusd.conf"
         # Sane default log setings for authentication
-        sed -i 's|#\s*msg_goodpass =.*|msg_goodpass = "authenticationtype:\\\"%{control:Auth-Type}\\\";nasipv4address:\\\"%{request:NAS-IP-Address}\\\";nasipv6address:\\\"%{request:NAS-IPv6-Address}\\\";nasid:\\\"%{request:NAS-Identifier}\\\";srcipaddress:\\\"%{request:Packet-Src-IP-Address}\\\";nasport:\\\"%{request:NAS-Port-Id}\\\";nasporttype:\\\"%{request:NAS-Port-Type}\\\";vlan:\\\"%{reply:Tunnel-Private-Group-Id}\\\";calledstationid:\\\"%{request:Called-Station-Id}\\\";callingstationid:\\\"%{request:Calling-Station-Id}\\\";session_timeout:\\\"%{reply:Session-Timeout}\\\""|' \
-        $RADIUS_PATH/radiusd.conf
-        sed -i 's|#\s*msg_badpass =.*|msg_badpass = "authenticationtype:\\\"%{control:Auth-Type}\\\";nasipv4address:\\\"%{request:NAS-IP-Address}\\\";nasipv6address:\\\"%{request:NAS-IPv6-Address}\\\";nasid:\\\"%{request:NAS-Identifier}\\\";srcipaddress:\\\"%{request:Packet-Src-IP-Address}\\\";nasport:\\\"%{request:NAS-Port-Id}\\\";nasporttype:\\\"%{request:NAS-Port-Type}\\\";calledstationid:\\\"%{request:Called-Station-Id}\\\";callingstationid:\\\"%{request:Calling-Station-Id}\\\""|' \
-        $RADIUS_PATH/radiusd.conf
+        run_freeradius_sed 's|#\s*msg_goodpass =.*|msg_goodpass = "authenticationtype:\\\"%{control:Auth-Type}\\\";nasipv4address:\\\"%{request:NAS-IP-Address}\\\";nasipv6address:\\\"%{request:NAS-IPv6-Address}\\\";nasid:\\\"%{request:NAS-Identifier}\\\";srcipaddress:\\\"%{request:Packet-Src-IP-Address}\\\";nasport:\\\"%{request:NAS-Port-Id}\\\";nasporttype:\\\"%{request:NAS-Port-Type}\\\";vlan:\\\"%{reply:Tunnel-Private-Group-Id}\\\";calledstationid:\\\"%{request:Called-Station-Id}\\\";callingstationid:\\\"%{request:Calling-Station-Id}\\\";session_timeout:\\\"%{reply:Session-Timeout}\\\""|' \
+        "$RADIUS_PATH/radiusd.conf"
+        run_freeradius_sed 's|#\s*msg_badpass =.*|msg_badpass = "authenticationtype:\\\"%{control:Auth-Type}\\\";nasipv4address:\\\"%{request:NAS-IP-Address}\\\";nasipv6address:\\\"%{request:NAS-IPv6-Address}\\\";nasid:\\\"%{request:NAS-Identifier}\\\";srcipaddress:\\\"%{request:Packet-Src-IP-Address}\\\";nasport:\\\"%{request:NAS-Port-Id}\\\";nasporttype:\\\"%{request:NAS-Port-Type}\\\";calledstationid:\\\"%{request:Called-Station-Id}\\\";callingstationid:\\\"%{request:Calling-Station-Id}\\\""|' \
+        "$RADIUS_PATH/radiusd.conf"
 
 	# Enable status in freeadius
-	ln -sf $RADIUS_PATH/sites-available/status $RADIUS_PATH/sites-enabled/status
+	run_freeradius_link "$RADIUS_PATH/sites-available/status" "$RADIUS_PATH/sites-enabled/status"
 
 	# Set Database connection
 	sql_config_set "server" "$MYSQL_HOST"
@@ -190,7 +239,8 @@ function init_freeradius {
 	sql_config_set "radius_db" "$MYSQL_DATABASE"
 	sql_config_set "password" "$MYSQL_PASSWORD"
 	sql_config_set "login" "$MYSQL_USER"
-	sed -i "s|testing123|$(escape_sed_replacement "$(freeradius_quote_escape "$DEFAULT_CLIENT_SECRET")")|" $RADIUS_PATH/mods-available/sql
+	run_freeradius_sed "s|testing123|$(escape_sed_replacement "$(freeradius_quote_escape "$DEFAULT_CLIENT_SECRET")")|" "$RADIUS_PATH/mods-available/sql"
+	log_event "info" "freeradius_init" "success" "freeradius_configured"
 	echo "freeradius initialization completed."
 }
 
@@ -213,16 +263,17 @@ function enable_noresetcounter {
 		/^authenticate[[:space:]]*[{]/ { in_authorize = 0 }
 		{ print }
 		END { exit added ? 0 : 1 }
-	' $RADIUS_PATH/sites-available/default > /tmp/freeradius-default; then
+	' "$RADIUS_PATH/sites-available/default" 2>>"$INIT_ERROR_LOG" > /tmp/freeradius-default; then
 		rm -f /tmp/freeradius-default
-		echo "Failed to add noresetcounter to FreeRADIUS authorize section."
-		exit 1
+		fail_step "noresetcounter_config" "noresetcounter_insert_failed"
 	fi
-	mv /tmp/freeradius-default $RADIUS_PATH/sites-available/default
+	mv /tmp/freeradius-default "$RADIUS_PATH/sites-available/default" 2>>"$INIT_ERROR_LOG" \
+		|| fail_step "noresetcounter_config" "noresetcounter_apply_failed"
 }
 
 function ensure_daloradius_schema {
-	mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" <<'EOSQL'
+	log_event "info" "radhuntgroup_schema_ensure" "start" "ensuring_schema"
+	if mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" 2>>"$INIT_ERROR_LOG" <<'EOSQL'
 CREATE TABLE IF NOT EXISTS `radhuntgroup` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `groupname` varchar(64) NOT NULL DEFAULT '',
@@ -232,24 +283,42 @@ CREATE TABLE IF NOT EXISTS `radhuntgroup` (
   KEY `nasipaddress` (`nasipaddress`)
 );
 EOSQL
+	then
+		log_event "info" "radhuntgroup_schema_ensure" "success" "schema_ensured"
+	else
+		fail_step "radhuntgroup_schema_ensure" "schema_ensure_failed"
+	fi
 }
 
 function init_database {
 	require_default_client_secret
 
-	mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" < $RADIUS_PATH/mods-config/sql/main/mysql/schema.sql
-	mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" < $RADIUS_PATH/mods-config/sql/ippool/mysql/schema.sql
+	log_event "info" "freeradius_schema_import" "start" "importing_schema"
+	if mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" < "$RADIUS_PATH/mods-config/sql/main/mysql/schema.sql" 2>>"$INIT_ERROR_LOG"; then
+		log_event "info" "freeradius_schema_import" "success" "schema_imported"
+	else
+		fail_step "freeradius_schema_import" "schema_import_failed"
+	fi
+
+	log_event "info" "ippool_schema_import" "start" "importing_schema"
+	if mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" < "$RADIUS_PATH/mods-config/sql/ippool/mysql/schema.sql" 2>>"$INIT_ERROR_LOG"; then
+		log_event "info" "ippool_schema_import" "success" "schema_imported"
+	else
+		fail_step "ippool_schema_import" "schema_import_failed"
+	fi
 	ensure_daloradius_schema
 
 	# Insert a client for the current subnet (to allow daloradius to perform checks)
-	container_ip_address=`ifconfig eth0 | awk '/inet/{ print $2;} '` # does also work: $container_ip_address=`hostname -I | awk '{print $1}'`
-	container_netmask=`ifconfig eth0 | awk '/netmask/{ print $4;} '`
-	container_cidr=`ipcalc $container_ip_address $container_netmask | awk '/Network/{ print $2;} '`
+	discover_container_cidr
 	client_secret=$DEFAULT_CLIENT_SECRET
 	container_cidr_sql=$(sql_escape "$container_cidr")
 	client_secret_sql=$(sql_escape "$client_secret")
 	echo "Adding client for $container_cidr with configured shared secret."
-	mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" -e "INSERT INTO nas (nasname,shortname,type,ports,secret,server,community,description) VALUES ('$container_cidr_sql','DOCKER NET','other',0,'$client_secret_sql',NULL,'','')"
+	log_event "info" "nas_client_insert" "start" "inserting_docker_client"
+	mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" \
+		-e "INSERT INTO nas (nasname,shortname,type,ports,secret,server,community,description) VALUES ('$container_cidr_sql','DOCKER NET','other',0,'$client_secret_sql',NULL,'','')" \
+		2>>"$INIT_ERROR_LOG" || fail_step "nas_client_insert" "client_insert_failed"
+	log_event "info" "nas_client_insert" "success" "docker_client_inserted"
 
 	echo "Database initialization for freeradius completed."
 }
@@ -260,22 +329,47 @@ function freeradius_schema_ready {
 }
 
 function wait_for_mysql {
+	log_event "info" "mysql_wait" "start" "waiting_for_mysql"
 	local attempt=1
-	while ! mysqladmin --defaults-extra-file="$MYSQL_DEFAULTS_FILE" ping --silent; do
+	while ! mysqladmin --defaults-extra-file="$MYSQL_DEFAULTS_FILE" ping --silent >/dev/null 2>>"$INIT_ERROR_LOG"; do
 		if [ "$attempt" -ge "$MYSQL_WAIT_RETRIES" ]; then
-			echo "MySQL did not become ready after $MYSQL_WAIT_RETRIES attempts."
-			exit 1
+			fail_step "mysql_wait" "mysql_wait_timeout"
 		fi
 		echo "Waiting for mysql ($MYSQL_HOST)..."
 		attempt=$((attempt + 1))
 		sleep "$MYSQL_WAIT_INTERVAL"
 	done
+	log_event "info" "mysql_wait" "success" "mysql_ready"
+}
+
+function discover_container_cidr {
+	if ! container_ip_address=$(ifconfig eth0 2>>"$INIT_ERROR_LOG" | awk '/inet/{ print $2; exit }'); then
+		fail_step "cidr_discovery" "container_ip_discovery_failed"
+	fi
+	if [ -z "$container_ip_address" ]; then
+		fail_step "cidr_discovery" "container_ip_empty"
+	fi
+	if ! container_netmask=$(ifconfig eth0 2>>"$INIT_ERROR_LOG" | awk '/netmask/{ print $4; exit }'); then
+		fail_step "cidr_discovery" "container_netmask_discovery_failed"
+	fi
+	if [ -z "$container_netmask" ]; then
+		fail_step "cidr_discovery" "container_netmask_empty"
+	fi
+	if ! container_cidr=$(ipcalc "$container_ip_address" "$container_netmask" 2>>"$INIT_ERROR_LOG" | awk '/Network/{ print $2; exit }'); then
+		fail_step "cidr_discovery" "container_cidr_discovery_failed"
+	fi
+	if [ -z "$container_cidr" ]; then
+		fail_step "cidr_discovery" "container_cidr_empty"
+	fi
 }
 
 function prepare_freeradius_logs {
-	chown -R freerad:33 /var/log/freeradius
-	find /var/log/freeradius -type d -exec chmod 2750 {} +
-	find /var/log/freeradius -type f -exec chmod 0640 {} +
+	chown -R freerad:33 /var/log/freeradius 2>>"$INIT_ERROR_LOG" \
+		|| fail_step "freeradius_log_permissions" "log_owner_failed"
+	find /var/log/freeradius -type d -exec chmod 2750 {} + 2>>"$INIT_ERROR_LOG" \
+		|| fail_step "freeradius_log_permissions" "log_directory_mode_failed"
+	find /var/log/freeradius -type f -exec chmod 0640 {} + 2>>"$INIT_ERROR_LOG" \
+		|| fail_step "freeradius_log_permissions" "log_file_mode_failed"
 }
 
 function wait_for_radius_status {
@@ -305,11 +399,11 @@ if test -f "$INIT_LOCK"; then
 		echo "Init lock file exists but FreeRADIUS configuration is missing, reinitializing..."
 		rm -f "$INIT_LOCK"
 		init_freeradius
-		date > "$INIT_LOCK"
+		write_lock "$INIT_LOCK" "freeradius_init_lock"
 	fi
 else
 	init_freeradius
-	date > "$INIT_LOCK"
+	write_lock "$INIT_LOCK" "freeradius_init_lock"
 fi
 
 # Ensure Max-All-Session is enforced before FreeRADIUS starts, including after
@@ -321,15 +415,16 @@ fi
 DB_LOCK=/data/.db_init_done
 if freeradius_schema_ready; then
 	echo "Database schema already present, skipping initial setup of mysql database."
-	date > "$DB_LOCK"
+	write_lock "$DB_LOCK" "freeradius_db_lock"
 	ensure_daloradius_schema
 else
 	init_database
+	log_event "info" "freeradius_schema_check" "start" "checking_schema"
 	if ! freeradius_schema_ready; then
-		echo "FreeRADIUS database schema was not found after initialization."
-		exit 1
+		fail_step "freeradius_schema_check" "schema_post_check_failed"
 	fi
-	date > "$DB_LOCK"
+	log_event "info" "freeradius_schema_check" "success" "schema_present"
+	write_lock "$DB_LOCK" "freeradius_db_lock"
 fi
 
 # make logs readable to the shared www-data group without opening them world-wide

--- a/init-freeradius.sh
+++ b/init-freeradius.sh
@@ -315,10 +315,14 @@ function init_database {
 	client_secret_sql=$(sql_escape "$client_secret")
 	echo "Adding client for $container_cidr with configured shared secret."
 	log_event "info" "nas_client_insert" "start" "inserting_docker_client"
-	mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" \
-		-e "INSERT INTO nas (nasname,shortname,type,ports,secret,server,community,description) VALUES ('$container_cidr_sql','DOCKER NET','other',0,'$client_secret_sql',NULL,'','')" \
-		2>>"$INIT_ERROR_LOG" || fail_step "nas_client_insert" "client_insert_failed"
-	log_event "info" "nas_client_insert" "success" "docker_client_inserted"
+	if mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" 2>>"$INIT_ERROR_LOG" <<EOSQL
+INSERT INTO nas (nasname,shortname,type,ports,secret,server,community,description) VALUES ('$container_cidr_sql','DOCKER NET','other',0,'$client_secret_sql',NULL,'','');
+EOSQL
+	then
+		log_event "info" "nas_client_insert" "success" "docker_client_inserted"
+	else
+		fail_step "nas_client_insert" "client_insert_failed"
+	fi
 
 	echo "Database initialization for freeradius completed."
 }

--- a/init.sh
+++ b/init.sh
@@ -13,6 +13,7 @@ MYSQL_PASSWORD=${MYSQL_PASSWORD:-}
 MYSQL_WAIT_RETRIES=${MYSQL_WAIT_RETRIES:-30}
 MYSQL_WAIT_INTERVAL=${MYSQL_WAIT_INTERVAL:-2}
 INIT_ERROR_LOG=${INIT_ERROR_LOG:-/data/daloradius-init-errors.log}
+TZ=${TZ:-Europe/Vienna}
 PASSWORD_MIN_LENGTH=${PASSWORD_MIN_LENGTH:-}
 PASSWORD_MAX_LENGTH=${PASSWORD_MAX_LENGTH:-}
 DEFAULT_FREERADIUS_SERVER=${DEFAULT_FREERADIUS_SERVER:-radius}
@@ -125,6 +126,37 @@ function require_mysql_port {
     fi
 }
 
+function validate_optional_port {
+    local name="$1"
+    local value="${!name:-}"
+    if [ -n "$value" ]; then
+        require_mysql_port "$name"
+    fi
+}
+
+function require_timezone {
+    local name="$1"
+    local value="${!name:-}"
+    local zoneinfo_file
+    require_non_empty "$name"
+    reject_crlf "$name"
+    case "$value" in
+        /*|*..*|*//*|*/*/)
+            fail_step "validation" "invalid_timezone_${name}"
+            ;;
+    esac
+    if ! [[ "$value" =~ ^[A-Za-z0-9][A-Za-z0-9._+-]*(/[A-Za-z0-9][A-Za-z0-9._+-]*)*$ ]]; then
+        fail_step "validation" "invalid_timezone_${name}"
+    fi
+    if [ "$value" = "UTC" ]; then
+        return
+    fi
+    zoneinfo_file="/usr/share/zoneinfo/$value"
+    if [ ! -f "$zoneinfo_file" ] || [ "$(head -c 4 "$zoneinfo_file" 2>/dev/null)" != "TZif" ]; then
+        fail_step "validation" "invalid_timezone_${name}"
+    fi
+}
+
 function require_sql_identifier {
     local name="$1"
     local value="${!name:-}"
@@ -160,7 +192,27 @@ function require_host_token {
     fi
 }
 
+function validate_optional_host_token {
+    local name="$1"
+    local value="${!name:-}"
+    if [ -n "$value" ]; then
+        require_host_token "$name"
+    fi
+}
+
+function validate_optional_email {
+    local name="$1"
+    local value="${!name:-}"
+    if [ -n "$value" ]; then
+        reject_crlf "$name"
+        if ! [[ "$value" =~ ^[A-Za-z0-9._%+-]+@[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)+$ ]]; then
+            fail_step "validation" "invalid_email_${name}"
+        fi
+    fi
+}
+
 function validate_runtime_config {
+    require_timezone "TZ"
     require_host_token "MYSQL_HOST"
     require_mysql_port "MYSQL_PORT"
     require_sql_identifier "MYSQL_DATABASE"
@@ -176,9 +228,9 @@ function validate_runtime_config {
     validate_optional_no_crlf "DEFAULT_CLIENT_SECRET"
     validate_optional_no_crlf "PASSWORD_MIN_LENGTH"
     validate_optional_no_crlf "PASSWORD_MAX_LENGTH"
-    validate_optional_no_crlf "MAIL_SMTPADDR"
-    validate_optional_no_crlf "MAIL_PORT"
-    validate_optional_no_crlf "MAIL_FROM"
+    validate_optional_host_token "MAIL_SMTPADDR"
+    validate_optional_port "MAIL_PORT"
+    validate_optional_email "MAIL_FROM"
     validate_optional_no_crlf "MAIL_AUTH"
 }
 

--- a/init.sh
+++ b/init.sh
@@ -17,6 +17,7 @@ PASSWORD_MAX_LENGTH=${PASSWORD_MAX_LENGTH:-}
 DEFAULT_FREERADIUS_SERVER=${DEFAULT_FREERADIUS_SERVER:-radius}
 DEFAULT_FREERADIUS_PORT=${DEFAULT_FREERADIUS_PORT:-}
 DEFAULT_CLIENT_SECRET=${DEFAULT_CLIENT_SECRET:-}
+DALORADIUS_ADMIN_PASSWORD=${DALORADIUS_ADMIN_PASSWORD:-}
 MAIL_SMTPADDR=${MAIL_SMTPADDR:-}
 MAIL_PORT=${MAIL_PORT:-}
 MAIL_FROM=${MAIL_FROM:-}
@@ -46,6 +47,28 @@ function php_config_set {
     local value
     value=$(escape_sed_replacement "$(php_escape "$2")")
     sed -i "s|\\\$configValues\['$key'\] = .*;|\\\$configValues['$key'] = '$value';|" "$DALORADIUS_CONF_PATH"
+}
+
+function sql_escape {
+    printf '%s' "$1" | sed "s/'/''/g"
+}
+
+function require_admin_password {
+    if [ -z "$DALORADIUS_ADMIN_PASSWORD" ]; then
+        echo "DALORADIUS_ADMIN_PASSWORD must be set."
+        exit 1
+    fi
+}
+
+function set_admin_password {
+    require_admin_password
+
+    local admin_hash
+    admin_hash=$(php -r 'echo password_hash($argv[1], PASSWORD_DEFAULT);' "$DALORADIUS_ADMIN_PASSWORD")
+    admin_hash=$(sql_escape "$admin_hash")
+
+    mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" \
+        -e "UPDATE operators SET password='$admin_hash' WHERE username='administrator';"
 }
 
 function init_daloradius {
@@ -125,6 +148,8 @@ else
     fi
     date > "$DB_LOCK"
 fi
+
+set_admin_password
 
 # Start Apache2 in the foreground
 /usr/sbin/apachectl -DFOREGROUND -k start

--- a/init.sh
+++ b/init.sh
@@ -93,7 +93,9 @@ function init_daloradius {
     [ -n "$MAIL_PORT" ] && php_config_set "CONFIG_MAIL_SMTPPORT" "$MAIL_PORT"
     [ -n "$MAIL_FROM" ] && php_config_set "CONFIG_MAIL_SMTPFROM" "$MAIL_FROM"
     [ -n "$MAIL_AUTH" ] && php_config_set "CONFIG_MAIL_SMTPAUTH" "$MAIL_AUTH"
-    php_config_set "CONFIG_LOG_FILE" "/tmp/daloradius.log"
+    php_config_set "CONFIG_LOG_FILE" "/var/www/daloradius/var/log/daloradius.log"
+    chown www-data:www-data "$DALORADIUS_CONF_PATH"
+    chmod 0644 "$DALORADIUS_CONF_PATH"
 
     echo "daloRADIUS initialization completed."
 }

--- a/init.sh
+++ b/init.sh
@@ -9,7 +9,7 @@ MYSQL_HOST=${MYSQL_HOST:-localhost}
 MYSQL_PORT=${MYSQL_PORT:-3306}
 MYSQL_DATABASE=${MYSQL_DATABASE:-raddb}
 MYSQL_USER=${MYSQL_USER:-raduser}
-MYSQL_PASSWORD=${MYSQL_PASSWORD:-radpass}
+MYSQL_PASSWORD=${MYSQL_PASSWORD:-}
 MYSQL_WAIT_RETRIES=${MYSQL_WAIT_RETRIES:-30}
 MYSQL_WAIT_INTERVAL=${MYSQL_WAIT_INTERVAL:-2}
 PASSWORD_MIN_LENGTH=${PASSWORD_MIN_LENGTH:-}
@@ -22,6 +22,117 @@ MAIL_SMTPADDR=${MAIL_SMTPADDR:-}
 MAIL_PORT=${MAIL_PORT:-}
 MAIL_FROM=${MAIL_FROM:-}
 MAIL_AUTH=${MAIL_AUTH:-}
+
+function require_non_empty {
+    local name="$1"
+    local value="${!name:-}"
+    if [ -z "$value" ]; then
+        echo "$name must be set."
+        exit 1
+    fi
+}
+
+function reject_crlf {
+    local name="$1"
+    local value="${!name:-}"
+    case "$value" in
+        *$'\r'*|*$'\n'*)
+            echo "$name must not contain CR or LF characters."
+            exit 1
+            ;;
+    esac
+}
+
+function validate_optional_no_crlf {
+    local name="$1"
+    local value="${!name:-}"
+    if [ -n "$value" ]; then
+        reject_crlf "$name"
+    fi
+}
+
+function require_positive_integer {
+    local name="$1"
+    local value="${!name:-}"
+    if ! [[ "$value" =~ ^[1-9][0-9]*$ ]]; then
+        echo "$name must be a positive integer."
+        exit 1
+    fi
+}
+
+function require_mysql_port {
+    local name="$1"
+    local value="${!name:-}"
+    require_positive_integer "$name"
+    if [ "${#value}" -gt 5 ] || { [ "${#value}" -eq 5 ] && [[ "$value" > "65535" ]]; }; then
+        echo "$name must be between 1 and 65535."
+        exit 1
+    fi
+}
+
+function require_sql_identifier {
+    local name="$1"
+    local value="${!name:-}"
+    require_non_empty "$name"
+    if ! [[ "$value" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+        echo "$name must start with a letter or underscore and contain only letters, digits, and underscores."
+        exit 1
+    fi
+}
+
+function require_host_token {
+    local name="$1"
+    local value="${!name:-}"
+    local -a host_labels
+    local label
+    require_non_empty "$name"
+    reject_crlf "$name"
+
+    case "$value" in
+        .*|*.|*..*)
+            echo "$name must not contain leading, trailing, or consecutive dots."
+            exit 1
+            ;;
+    esac
+
+    IFS='.' read -r -a host_labels <<< "$value"
+    for label in "${host_labels[@]}"; do
+        if ! [[ "$label" =~ ^[A-Za-z0-9]([A-Za-z0-9_-]*[A-Za-z0-9])?$ ]]; then
+            echo "$name must use dot-separated labels that start and end with a letter or digit."
+            exit 1
+        fi
+    done
+
+    if [ "${#host_labels[@]}" -eq 0 ]; then
+        echo "$name must be a valid host token."
+        exit 1
+    fi
+}
+
+function validate_runtime_config {
+    require_host_token "MYSQL_HOST"
+    require_mysql_port "MYSQL_PORT"
+    require_sql_identifier "MYSQL_DATABASE"
+    require_sql_identifier "MYSQL_USER"
+    require_non_empty "MYSQL_PASSWORD"
+    reject_crlf "MYSQL_PASSWORD"
+    require_positive_integer "MYSQL_WAIT_RETRIES"
+    require_positive_integer "MYSQL_WAIT_INTERVAL"
+    require_non_empty "DALORADIUS_ADMIN_PASSWORD"
+    reject_crlf "DALORADIUS_ADMIN_PASSWORD"
+    reject_crlf "DEFAULT_FREERADIUS_SERVER"
+    validate_optional_no_crlf "DEFAULT_FREERADIUS_PORT"
+    validate_optional_no_crlf "DEFAULT_CLIENT_SECRET"
+    validate_optional_no_crlf "PASSWORD_MIN_LENGTH"
+    validate_optional_no_crlf "PASSWORD_MAX_LENGTH"
+    validate_optional_no_crlf "MAIL_SMTPADDR"
+    validate_optional_no_crlf "MAIL_PORT"
+    validate_optional_no_crlf "MAIL_FROM"
+    validate_optional_no_crlf "MAIL_AUTH"
+}
+
+validate_runtime_config
+
 MYSQL_DEFAULTS_FILE=$(mktemp)
 
 chmod 600 "$MYSQL_DEFAULTS_FILE"

--- a/init.sh
+++ b/init.sh
@@ -257,7 +257,7 @@ function init_daloradius {
     php_config_set "CONFIG_LOG_FILE" "/var/www/daloradius/var/log/daloradius.log"
     chown www-data:www-data "$DALORADIUS_CONF_PATH" 2>>"$INIT_ERROR_LOG" \
         || fail_step "daloradius_init" "config_owner_failed"
-    chmod 0644 "$DALORADIUS_CONF_PATH" 2>>"$INIT_ERROR_LOG" \
+    chmod 0600 "$DALORADIUS_CONF_PATH" 2>>"$INIT_ERROR_LOG" \
         || fail_step "daloradius_init" "config_mode_failed"
 
     log_event "info" "daloradius_init" "success" "daloradius_configured"

--- a/init.sh
+++ b/init.sh
@@ -12,6 +12,7 @@ MYSQL_USER=${MYSQL_USER:-raduser}
 MYSQL_PASSWORD=${MYSQL_PASSWORD:-}
 MYSQL_WAIT_RETRIES=${MYSQL_WAIT_RETRIES:-30}
 MYSQL_WAIT_INTERVAL=${MYSQL_WAIT_INTERVAL:-2}
+INIT_ERROR_LOG=${INIT_ERROR_LOG:-/data/daloradius-init-errors.log}
 PASSWORD_MIN_LENGTH=${PASSWORD_MIN_LENGTH:-}
 PASSWORD_MAX_LENGTH=${PASSWORD_MAX_LENGTH:-}
 DEFAULT_FREERADIUS_SERVER=${DEFAULT_FREERADIUS_SERVER:-radius}
@@ -23,12 +24,69 @@ MAIL_PORT=${MAIL_PORT:-}
 MAIL_FROM=${MAIL_FROM:-}
 MAIL_AUTH=${MAIL_AUTH:-}
 
+function log_event {
+    local level="$1"
+    local event="$2"
+    local outcome="$3"
+    local detail="$4"
+    printf 'level=%s component=daloradius-init event=%s outcome=%s detail=%s\n' "$level" "$event" "$outcome" "$detail"
+}
+
+function fail_step {
+    local event="$1"
+    local detail="$2"
+    log_event "error" "$event" "failure" "$detail"
+    exit 1
+}
+
+function setup_error_log {
+    if ! { : > "$INIT_ERROR_LOG"; } 2>/dev/null; then
+        fail_step "error_log_setup" "error_log_create_failed"
+    fi
+    if ! chmod 600 "$INIT_ERROR_LOG" 2>/dev/null; then
+        fail_step "error_log_setup" "error_log_chmod_failed"
+    fi
+}
+
+function setup_mysql_defaults_file {
+    local defaults_file
+    if ! [ -w "$INIT_ERROR_LOG" ]; then
+        fail_step "mysql_defaults_setup" "error_log_unwritable"
+    fi
+    if ! defaults_file="$(mktemp)" 2>>"$INIT_ERROR_LOG"; then
+        fail_step "mysql_defaults_setup" "defaults_file_create_failed"
+    fi
+    MYSQL_DEFAULTS_FILE="$defaults_file"
+    trap 'rm -f "$MYSQL_DEFAULTS_FILE"' EXIT
+    if ! chmod 600 "$MYSQL_DEFAULTS_FILE" 2>>"$INIT_ERROR_LOG"; then
+        fail_step "mysql_defaults_setup" "defaults_file_chmod_failed"
+    fi
+    if ! cat 2>>"$INIT_ERROR_LOG" > "$MYSQL_DEFAULTS_FILE" <<EOF
+[client]
+host=$MYSQL_HOST
+port=$MYSQL_PORT
+user=$MYSQL_USER
+password=$MYSQL_PASSWORD
+EOF
+    then
+        fail_step "mysql_defaults_setup" "defaults_file_write_failed"
+    fi
+}
+
+function write_lock {
+    local lock_path="$1"
+    local event="$2"
+    if ! [ -w "$INIT_ERROR_LOG" ]; then
+        fail_step "$event" "error_log_unwritable"
+    fi
+    date 2>>"$INIT_ERROR_LOG" > "$lock_path" || fail_step "$event" "lock_write_failed"
+}
+
 function require_non_empty {
     local name="$1"
     local value="${!name:-}"
     if [ -z "$value" ]; then
-        echo "$name must be set."
-        exit 1
+        fail_step "validation" "missing_required_${name}"
     fi
 }
 
@@ -37,8 +95,7 @@ function reject_crlf {
     local value="${!name:-}"
     case "$value" in
         *$'\r'*|*$'\n'*)
-            echo "$name must not contain CR or LF characters."
-            exit 1
+            fail_step "validation" "invalid_crlf_${name}"
             ;;
     esac
 }
@@ -55,8 +112,7 @@ function require_positive_integer {
     local name="$1"
     local value="${!name:-}"
     if ! [[ "$value" =~ ^[1-9][0-9]*$ ]]; then
-        echo "$name must be a positive integer."
-        exit 1
+        fail_step "validation" "invalid_positive_integer_${name}"
     fi
 }
 
@@ -65,8 +121,7 @@ function require_mysql_port {
     local value="${!name:-}"
     require_positive_integer "$name"
     if [ "${#value}" -gt 5 ] || { [ "${#value}" -eq 5 ] && [[ "$value" > "65535" ]]; }; then
-        echo "$name must be between 1 and 65535."
-        exit 1
+        fail_step "validation" "invalid_mysql_port_${name}"
     fi
 }
 
@@ -75,8 +130,7 @@ function require_sql_identifier {
     local value="${!name:-}"
     require_non_empty "$name"
     if ! [[ "$value" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
-        echo "$name must start with a letter or underscore and contain only letters, digits, and underscores."
-        exit 1
+        fail_step "validation" "invalid_sql_identifier_${name}"
     fi
 }
 
@@ -90,22 +144,19 @@ function require_host_token {
 
     case "$value" in
         .*|*.|*..*)
-            echo "$name must not contain leading, trailing, or consecutive dots."
-            exit 1
+            fail_step "validation" "invalid_host_dots_${name}"
             ;;
     esac
 
     IFS='.' read -r -a host_labels <<< "$value"
     for label in "${host_labels[@]}"; do
         if ! [[ "$label" =~ ^[A-Za-z0-9]([A-Za-z0-9_-]*[A-Za-z0-9])?$ ]]; then
-            echo "$name must use dot-separated labels that start and end with a letter or digit."
-            exit 1
+            fail_step "validation" "invalid_host_label_${name}"
         fi
     done
 
     if [ "${#host_labels[@]}" -eq 0 ]; then
-        echo "$name must be a valid host token."
-        exit 1
+        fail_step "validation" "invalid_host_empty_${name}"
     fi
 }
 
@@ -131,19 +182,9 @@ function validate_runtime_config {
     validate_optional_no_crlf "MAIL_AUTH"
 }
 
+setup_error_log
 validate_runtime_config
-
-MYSQL_DEFAULTS_FILE=$(mktemp)
-
-chmod 600 "$MYSQL_DEFAULTS_FILE"
-cat > "$MYSQL_DEFAULTS_FILE" <<EOF
-[client]
-host=$MYSQL_HOST
-port=$MYSQL_PORT
-user=$MYSQL_USER
-password=$MYSQL_PASSWORD
-EOF
-trap 'rm -f "$MYSQL_DEFAULTS_FILE"' EXIT
+setup_mysql_defaults_file
 
 function escape_sed_replacement {
     printf '%s' "$1" | sed -e 's/[\/&|\\]/\\&/g'
@@ -157,7 +198,8 @@ function php_config_set {
     local key="$1"
     local value
     value=$(escape_sed_replacement "$(php_escape "$2")")
-    sed -i "s|\\\$configValues\['$key'\] = .*;|\\\$configValues['$key'] = '$value';|" "$DALORADIUS_CONF_PATH"
+    sed -i "s|\\\$configValues\['$key'\] = .*;|\\\$configValues['$key'] = '$value';|" "$DALORADIUS_CONF_PATH" \
+        2>>"$INIT_ERROR_LOG" || fail_step "daloradius_init" "config_update_failed"
 }
 
 function sql_escape {
@@ -166,8 +208,7 @@ function sql_escape {
 
 function require_admin_password {
     if [ -z "$DALORADIUS_ADMIN_PASSWORD" ]; then
-        echo "DALORADIUS_ADMIN_PASSWORD must be set."
-        exit 1
+        fail_step "validation" "missing_required_DALORADIUS_ADMIN_PASSWORD"
     fi
 }
 
@@ -178,14 +219,19 @@ function set_admin_password {
     admin_hash=$(php -r 'echo password_hash($argv[1], PASSWORD_DEFAULT);' "$DALORADIUS_ADMIN_PASSWORD")
     admin_hash=$(sql_escape "$admin_hash")
 
+    log_event "info" "admin_password_update" "start" "updating_admin_password"
     mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" \
-        -e "UPDATE operators SET password='$admin_hash' WHERE username='administrator';"
+        -e "UPDATE operators SET password='$admin_hash' WHERE username='administrator';" \
+        2>>"$INIT_ERROR_LOG" || fail_step "admin_password_update" "admin_password_update_failed"
+    log_event "info" "admin_password_update" "success" "admin_password_updated"
 }
 
 function init_daloradius {
+    log_event "info" "daloradius_init" "start" "configuring_daloradius"
 
     if ! test -f "$DALORADIUS_CONF_PATH" || ! test -s "$DALORADIUS_CONF_PATH"; then
-        cp "$DALORADIUS_CONF_PATH.sample" "$DALORADIUS_CONF_PATH"
+        cp "$DALORADIUS_CONF_PATH.sample" "$DALORADIUS_CONF_PATH" 2>>"$INIT_ERROR_LOG" \
+            || fail_step "daloradius_init" "config_copy_failed"
     fi
     php_config_set "CONFIG_DB_HOST" "$MYSQL_HOST"
     php_config_set "CONFIG_DB_PORT" "$MYSQL_PORT"
@@ -205,9 +251,12 @@ function init_daloradius {
     [ -n "$MAIL_FROM" ] && php_config_set "CONFIG_MAIL_SMTPFROM" "$MAIL_FROM"
     [ -n "$MAIL_AUTH" ] && php_config_set "CONFIG_MAIL_SMTPAUTH" "$MAIL_AUTH"
     php_config_set "CONFIG_LOG_FILE" "/var/www/daloradius/var/log/daloradius.log"
-    chown www-data:www-data "$DALORADIUS_CONF_PATH"
-    chmod 0644 "$DALORADIUS_CONF_PATH"
+    chown www-data:www-data "$DALORADIUS_CONF_PATH" 2>>"$INIT_ERROR_LOG" \
+        || fail_step "daloradius_init" "config_owner_failed"
+    chmod 0644 "$DALORADIUS_CONF_PATH" 2>>"$INIT_ERROR_LOG" \
+        || fail_step "daloradius_init" "config_mode_failed"
 
+    log_event "info" "daloradius_init" "success" "daloradius_configured"
     echo "daloRADIUS initialization completed."
 }
 
@@ -215,8 +264,13 @@ function init_database {
     # The official MariaDB container creates MYSQL_DATABASE/MYSQL_USER during startup.
     # Import the daloRADIUS schema with the application user instead of trying to
     # create local users/databases from the web container.
-    mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" < "$DALORADIUS_PATH/contrib/db/mariadb-daloradius.sql"
-    echo "Database initialization for daloRADIUS completed."
+    log_event "info" "daloradius_schema_import" "start" "importing_schema"
+    if mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" < "$DALORADIUS_PATH/contrib/db/mariadb-daloradius.sql" 2>>"$INIT_ERROR_LOG"; then
+        log_event "info" "daloradius_schema_import" "success" "schema_imported"
+        echo "Database initialization for daloRADIUS completed."
+    else
+        fail_step "daloradius_schema_import" "schema_import_failed"
+    fi
 }
 
 function daloradius_schema_ready {
@@ -225,25 +279,23 @@ function daloradius_schema_ready {
 }
 
 function wait_for_mysql {
-    echo -n "Waiting for mysql ($MYSQL_HOST)..."
+    log_event "info" "mysql_wait" "start" "waiting_for_mysql"
     local attempt=1
-    while ! mysqladmin --defaults-extra-file="$MYSQL_DEFAULTS_FILE" ping --silent; do
+    while ! mysqladmin --defaults-extra-file="$MYSQL_DEFAULTS_FILE" ping --silent >/dev/null 2>>"$INIT_ERROR_LOG"; do
         if [ "$attempt" -ge "$MYSQL_WAIT_RETRIES" ]; then
-            echo "failed"
-            echo "MySQL did not become ready after $MYSQL_WAIT_RETRIES attempts."
-            exit 1
+            fail_step "mysql_wait" "mysql_wait_timeout"
         fi
         attempt=$((attempt + 1))
         sleep "$MYSQL_WAIT_INTERVAL"
     done
-    echo "ok"
+    log_event "info" "mysql_wait" "success" "mysql_ready"
 }
 
 echo "Starting daloRADIUS..."
 
 INIT_LOCK=/data/.init_done
 init_daloradius
-date > "$INIT_LOCK"
+write_lock "$INIT_LOCK" "daloradius_init_lock"
 
 # wait for MySQL-Server to be ready
 wait_for_mysql
@@ -251,14 +303,15 @@ wait_for_mysql
 DB_LOCK=/data/.db_init_done
 if daloradius_schema_ready; then
     echo "Database schema already present, skipping initial setup of mysql database."
-    date > "$DB_LOCK"
+    write_lock "$DB_LOCK" "daloradius_db_lock"
 else
     init_database
+    log_event "info" "daloradius_schema_check" "start" "checking_schema"
     if ! daloradius_schema_ready; then
-        echo "daloRADIUS database schema was not found after initialization."
-        exit 1
+        fail_step "daloradius_schema_check" "schema_post_check_failed"
     fi
-    date > "$DB_LOCK"
+    log_event "info" "daloradius_schema_check" "success" "schema_present"
+    write_lock "$DB_LOCK" "daloradius_db_lock"
 fi
 
 set_admin_password

--- a/init.sh
+++ b/init.sh
@@ -21,7 +21,32 @@ MAIL_SMTPADDR=${MAIL_SMTPADDR:-}
 MAIL_PORT=${MAIL_PORT:-}
 MAIL_FROM=${MAIL_FROM:-}
 MAIL_AUTH=${MAIL_AUTH:-}
+MYSQL_DEFAULTS_FILE=$(mktemp)
 
+chmod 600 "$MYSQL_DEFAULTS_FILE"
+cat > "$MYSQL_DEFAULTS_FILE" <<EOF
+[client]
+host=$MYSQL_HOST
+port=$MYSQL_PORT
+user=$MYSQL_USER
+password=$MYSQL_PASSWORD
+EOF
+trap 'rm -f "$MYSQL_DEFAULTS_FILE"' EXIT
+
+function escape_sed_replacement {
+    printf '%s' "$1" | sed -e 's/[\/&|\\]/\\&/g'
+}
+
+function php_escape {
+    printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e "s/'/\\\\'/g"
+}
+
+function php_config_set {
+    local key="$1"
+    local value
+    value=$(escape_sed_replacement "$(php_escape "$2")")
+    sed -i "s|\\\$configValues\['$key'\] = .*;|\\\$configValues['$key'] = '$value';|" "$DALORADIUS_CONF_PATH"
+}
 
 function init_daloradius {
 
@@ -29,26 +54,24 @@ function init_daloradius {
         cp "$DALORADIUS_CONF_PATH.sample" "$DALORADIUS_CONF_PATH"
         chown www-data:www-data "$DALORADIUS_CONF_PATH"
     fi
-    [ -n "$MYSQL_HOST" ] && sed -i "s/\$configValues\['CONFIG_DB_HOST'\] = .*;/\$configValues\['CONFIG_DB_HOST'\] = '$MYSQL_HOST';/" $DALORADIUS_CONF_PATH || MYSQL_HOST=localhost
-    [ -n "$MYSQL_PORT" ] && sed -i "s/\$configValues\['CONFIG_DB_PORT'\] = .*;/\$configValues\['CONFIG_DB_PORT'\] = '$MYSQL_PORT';/" $DALORADIUS_CONF_PATH
-    [ -n "$MYSQL_PASSWORD" ] && sed -i "s/\$configValues\['CONFIG_DB_PASS'\] = .*;/\$configValues\['CONFIG_DB_PASS'\] = '$MYSQL_PASSWORD';/" $DALORADIUS_CONF_PATH || MYSQL_PASSWORD=radpass
-    [ -n "$MYSQL_USER" ] && sed -i "s/\$configValues\['CONFIG_DB_USER'\] = .*;/\$configValues\['CONFIG_DB_USER'\] = '$MYSQL_USER';/" $DALORADIUS_CONF_PATH || MYSQL_USER=raduser
-    [ -n "$MYSQL_DATABASE" ] && sed -i "s/\$configValues\['CONFIG_DB_NAME'\] = .*;/\$configValues\['CONFIG_DB_NAME'\] = '$MYSQL_DATABASE';/" $DALORADIUS_CONF_PATH || MYSQL_DATABASE=raddb
-    sed -i "s/\$configValues\['FREERADIUS_VERSION'\] = .*;/\$configValues\['FREERADIUS_VERSION'\] = '3';/" $DALORADIUS_CONF_PATH
-    [ -n "$PASSWORD_MIN_LENGTH" ] && sed -i "s/\$configValues\['CONFIG_DB_PASSWORD_MIN_LENGTH'\] = .*;/\$configValues\['CONFIG_DB_PASSWORD_MIN_LENGTH'\] = '$PASSWORD_MIN_LENGTH';/" $DALORADIUS_CONF_PATH
-    [ -n "$PASSWORD_MAX_LENGTH" ] && sed -i "s/\$configValues\['CONFIG_DB_PASSWORD_MAX_LENGTH'\] = .*;/\$configValues\['CONFIG_DB_PASSWORD_MAX_LENGTH'\] = '$PASSWORD_MAX_LENGTH';/" $DALORADIUS_CONF_PATH
+    php_config_set "CONFIG_DB_HOST" "$MYSQL_HOST"
+    php_config_set "CONFIG_DB_PORT" "$MYSQL_PORT"
+    php_config_set "CONFIG_DB_PASS" "$MYSQL_PASSWORD"
+    php_config_set "CONFIG_DB_USER" "$MYSQL_USER"
+    php_config_set "CONFIG_DB_NAME" "$MYSQL_DATABASE"
+    php_config_set "FREERADIUS_VERSION" "3"
+    [ -n "$PASSWORD_MIN_LENGTH" ] && php_config_set "CONFIG_DB_PASSWORD_MIN_LENGTH" "$PASSWORD_MIN_LENGTH"
+    [ -n "$PASSWORD_MAX_LENGTH" ] && php_config_set "CONFIG_DB_PASSWORD_MAX_LENGTH" "$PASSWORD_MAX_LENGTH"
 
-    [ -n "$DEFAULT_FREERADIUS_SERVER" ] \
-        && sed -i "s/\$configValues\['CONFIG_MAINT_TEST_USER_RADIUSSERVER'\] = .*;/\$configValues\['CONFIG_MAINT_TEST_USER_RADIUSSERVER'\] = '$DEFAULT_FREERADIUS_SERVER';/" $DALORADIUS_CONF_PATH \
-        || sed -i "s/\$configValues\['CONFIG_MAINT_TEST_USER_RADIUSSERVER'\] = .*;/\$configValues\['CONFIG_MAINT_TEST_USER_RADIUSSERVER'\] = 'radius';/" $DALORADIUS_CONF_PATH
-    [ -n "$DEFAULT_FREERADIUS_PORT" ] && sed -i "s/\$configValues\['CONFIG_MAINT_TEST_USER_RADIUSPORT'\] = .*;/\$configValues\['CONFIG_MAINT_TEST_USER_RADIUSPORT'\] = '$DEFAULT_FREERADIUS_PORT';/" $DALORADIUS_CONF_PATH
-    [ -n "$DEFAULT_CLIENT_SECRET" ] && sed -i "s/\$configValues\['CONFIG_MAINT_TEST_USER_RADIUSSECRET'\] = .*;/\$configValues\['CONFIG_MAINT_TEST_USER_RADIUSSECRET'\] = '$DEFAULT_CLIENT_SECRET';/" $DALORADIUS_CONF_PATH
+    php_config_set "CONFIG_MAINT_TEST_USER_RADIUSSERVER" "$DEFAULT_FREERADIUS_SERVER"
+    [ -n "$DEFAULT_FREERADIUS_PORT" ] && php_config_set "CONFIG_MAINT_TEST_USER_RADIUSPORT" "$DEFAULT_FREERADIUS_PORT"
+    [ -n "$DEFAULT_CLIENT_SECRET" ] && php_config_set "CONFIG_MAINT_TEST_USER_RADIUSSECRET" "$DEFAULT_CLIENT_SECRET"
 
-    [ -n "$MAIL_SMTPADDR" ] && sed -i "s/\$configValues\['CONFIG_MAIL_SMTPADDR'\] = .*;/\$configValues\['CONFIG_MAIL_SMTPADDR'\] = '$MAIL_SMTPADDR';/" $DALORADIUS_CONF_PATH
-    [ -n "$MAIL_PORT" ] && sed -i "s/\$configValues\['CONFIG_MAIL_SMTPPORT'\] = .*;/\$configValues\['CONFIG_MAIL_SMTPPORT'\] = '$MAIL_PORT';/" $DALORADIUS_CONF_PATH
-    [ -n "$MAIL_FROM" ] && sed -i "s/\$configValues\['CONFIG_MAIL_SMTPFROM'\] = .*;/\$configValues\['CONFIG_MAIL_SMTPFROM'\] = '$MAIL_FROM';/" $DALORADIUS_CONF_PATH
-    [ -n "$MAIL_AUTH" ] && sed -i "s/\$configValues\['CONFIG_MAIL_SMTPAUTH'\] = .*;/\$configValues\['CONFIG_MAIL_SMTPAUTH'\] = '$MAIL_AUTH';/" $DALORADIUS_CONF_PATH
-    sed -i "s/\$configValues\['CONFIG_LOG_FILE'\] = .*;/\$configValues\['CONFIG_LOG_FILE'\] = '\/tmp\/daloradius.log';/" $DALORADIUS_CONF_PATH
+    [ -n "$MAIL_SMTPADDR" ] && php_config_set "CONFIG_MAIL_SMTPADDR" "$MAIL_SMTPADDR"
+    [ -n "$MAIL_PORT" ] && php_config_set "CONFIG_MAIL_SMTPPORT" "$MAIL_PORT"
+    [ -n "$MAIL_FROM" ] && php_config_set "CONFIG_MAIL_SMTPFROM" "$MAIL_FROM"
+    [ -n "$MAIL_AUTH" ] && php_config_set "CONFIG_MAIL_SMTPAUTH" "$MAIL_AUTH"
+    php_config_set "CONFIG_LOG_FILE" "/tmp/daloradius.log"
 
     echo "daloRADIUS initialization completed."
 }
@@ -57,19 +80,19 @@ function init_database {
     # The official MariaDB container creates MYSQL_DATABASE/MYSQL_USER during startup.
     # Import the daloRADIUS schema with the application user instead of trying to
     # create local users/databases from the web container.
-    mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" < "$DALORADIUS_PATH/contrib/db/mariadb-daloradius.sql"
+    mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" < "$DALORADIUS_PATH/contrib/db/mariadb-daloradius.sql"
     echo "Database initialization for daloRADIUS completed."
 }
 
 function daloradius_schema_ready {
-    mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" \
+    mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" \
         -e "SELECT 1 FROM operators LIMIT 1;" >/dev/null 2>&1
 }
 
 function wait_for_mysql {
     echo -n "Waiting for mysql ($MYSQL_HOST)..."
     local attempt=1
-    while ! mysqladmin ping -h"$MYSQL_HOST" -P"$MYSQL_PORT" -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" --silent; do
+    while ! mysqladmin --defaults-extra-file="$MYSQL_DEFAULTS_FILE" ping --silent; do
         if [ "$attempt" -ge "$MYSQL_WAIT_RETRIES" ]; then
             echo "failed"
             echo "MySQL did not become ready after $MYSQL_WAIT_RETRIES attempts."

--- a/init.sh
+++ b/init.sh
@@ -216,14 +216,18 @@ function set_admin_password {
     require_admin_password
 
     local admin_hash
-    admin_hash=$(php -r 'echo password_hash($argv[1], PASSWORD_DEFAULT);' "$DALORADIUS_ADMIN_PASSWORD")
+    admin_hash=$(printf '%s' "$DALORADIUS_ADMIN_PASSWORD" | php -r 'echo password_hash(stream_get_contents(STDIN), PASSWORD_DEFAULT);')
     admin_hash=$(sql_escape "$admin_hash")
 
     log_event "info" "admin_password_update" "start" "updating_admin_password"
-    mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" \
-        -e "UPDATE operators SET password='$admin_hash' WHERE username='administrator';" \
-        2>>"$INIT_ERROR_LOG" || fail_step "admin_password_update" "admin_password_update_failed"
-    log_event "info" "admin_password_update" "success" "admin_password_updated"
+    if mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" 2>>"$INIT_ERROR_LOG" <<EOSQL
+UPDATE operators SET password='$admin_hash' WHERE username='administrator';
+EOSQL
+    then
+        log_event "info" "admin_password_update" "success" "admin_password_updated"
+    else
+        fail_step "admin_password_update" "admin_password_update_failed"
+    fi
 }
 
 function init_daloradius {

--- a/init.sh
+++ b/init.sh
@@ -1,8 +1,26 @@
 #!/bin/bash
 # Executable process script for daloRADIUS docker image:
 # GitHub: git@github.com:lirantal/daloradius.git
+set -euo pipefail
+
 DALORADIUS_PATH=/var/www/daloradius
 DALORADIUS_CONF_PATH=/var/www/daloradius/app/common/includes/daloradius.conf.php
+MYSQL_HOST=${MYSQL_HOST:-localhost}
+MYSQL_PORT=${MYSQL_PORT:-3306}
+MYSQL_DATABASE=${MYSQL_DATABASE:-raddb}
+MYSQL_USER=${MYSQL_USER:-raduser}
+MYSQL_PASSWORD=${MYSQL_PASSWORD:-radpass}
+MYSQL_WAIT_RETRIES=${MYSQL_WAIT_RETRIES:-30}
+MYSQL_WAIT_INTERVAL=${MYSQL_WAIT_INTERVAL:-2}
+PASSWORD_MIN_LENGTH=${PASSWORD_MIN_LENGTH:-}
+PASSWORD_MAX_LENGTH=${PASSWORD_MAX_LENGTH:-}
+DEFAULT_FREERADIUS_SERVER=${DEFAULT_FREERADIUS_SERVER:-radius}
+DEFAULT_FREERADIUS_PORT=${DEFAULT_FREERADIUS_PORT:-}
+DEFAULT_CLIENT_SECRET=${DEFAULT_CLIENT_SECRET:-}
+MAIL_SMTPADDR=${MAIL_SMTPADDR:-}
+MAIL_PORT=${MAIL_PORT:-}
+MAIL_FROM=${MAIL_FROM:-}
+MAIL_AUTH=${MAIL_AUTH:-}
 
 
 function init_daloradius {
@@ -39,38 +57,50 @@ function init_database {
     # The official MariaDB container creates MYSQL_DATABASE/MYSQL_USER during startup.
     # Import the daloRADIUS schema with the application user instead of trying to
     # create local users/databases from the web container.
-    mysql -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" < $DALORADIUS_PATH/contrib/db/mariadb-daloradius.sql
+    mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" < "$DALORADIUS_PATH/contrib/db/mariadb-daloradius.sql"
     echo "Database initialization for daloRADIUS completed."
+}
+
+function daloradius_schema_ready {
+    mysql -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" \
+        -e "SELECT 1 FROM operators LIMIT 1;" >/dev/null 2>&1
+}
+
+function wait_for_mysql {
+    echo -n "Waiting for mysql ($MYSQL_HOST)..."
+    local attempt=1
+    while ! mysqladmin ping -h"$MYSQL_HOST" -P"$MYSQL_PORT" -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" --silent; do
+        if [ "$attempt" -ge "$MYSQL_WAIT_RETRIES" ]; then
+            echo "failed"
+            echo "MySQL did not become ready after $MYSQL_WAIT_RETRIES attempts."
+            exit 1
+        fi
+        attempt=$((attempt + 1))
+        sleep "$MYSQL_WAIT_INTERVAL"
+    done
+    echo "ok"
 }
 
 echo "Starting daloRADIUS..."
 
 INIT_LOCK=/data/.init_done
-if test -f "$INIT_LOCK"; then
-    #
-    if ! test -f "$DALORADIUS_CONF_PATH" || ! test -s "$DALORADIUS_CONF_PATH"; then
-        echo "Init lock file exists but config file does not exist or is 0 bytes, performing initial setup of daloRADIUS."
-        init_daloradius
-    fi
-    echo "Init lock file exists and config file exists, skipping initial setup of daloRADIUS."
-else
-    init_daloradius
-    date > $INIT_LOCK
-fi
+init_daloradius
+date > "$INIT_LOCK"
 
 # wait for MySQL-Server to be ready
-echo -n "Waiting for mysql ($MYSQL_HOST)..."
-while ! mysqladmin ping -h"$MYSQL_HOST" -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" --silent; do
-    sleep 20
-done
-echo "ok"
+wait_for_mysql
 
 DB_LOCK=/data/.db_init_done
-if test -f "$DB_LOCK"; then
-    echo "Database lock file exists, skipping initial setup of mysql database."
+if daloradius_schema_ready; then
+    echo "Database schema already present, skipping initial setup of mysql database."
+    date > "$DB_LOCK"
 else
     init_database
-    date > $DB_LOCK
+    if ! daloradius_schema_ready; then
+        echo "daloRADIUS database schema was not found after initialization."
+        exit 1
+    fi
+    date > "$DB_LOCK"
 fi
 
 # Start Apache2 in the foreground

--- a/init.sh
+++ b/init.sh
@@ -75,7 +75,6 @@ function init_daloradius {
 
     if ! test -f "$DALORADIUS_CONF_PATH" || ! test -s "$DALORADIUS_CONF_PATH"; then
         cp "$DALORADIUS_CONF_PATH.sample" "$DALORADIUS_CONF_PATH"
-        chown www-data:www-data "$DALORADIUS_CONF_PATH"
     fi
     php_config_set "CONFIG_DB_HOST" "$MYSQL_HOST"
     php_config_set "CONFIG_DB_PORT" "$MYSQL_PORT"
@@ -152,4 +151,4 @@ fi
 set_admin_password
 
 # Start Apache2 in the foreground
-/usr/sbin/apachectl -DFOREGROUND -k start
+exec /usr/sbin/apachectl -DFOREGROUND -k start

--- a/scripts/docker/hash-imported-passwords.php
+++ b/scripts/docker/hash-imported-passwords.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+function required_env(string $name): string
+{
+    $value = getenv($name);
+    if ($value === false || $value === '') {
+        fwrite(STDERR, "Missing required environment variable: {$name}\n");
+        exit(1);
+    }
+
+    return $value;
+}
+
+function stored_value_is_hash(string $storedValue): bool
+{
+    $info = password_get_info($storedValue);
+    return !empty($info['algo']);
+}
+
+$host = required_env('MYSQL_HOST');
+$port = required_env('MYSQL_PORT');
+$database = required_env('MYSQL_DATABASE');
+$user = required_env('MYSQL_USER');
+$databaseSecret = required_env('MYSQL_PASSWORD');
+$administratorSecret = required_env('DALORADIUS_ADMIN_PASSWORD');
+
+$dsn = sprintf('mysql:host=%s;port=%s;dbname=%s;charset=utf8mb4', $host, $port, $database);
+$pdo = new PDO($dsn, $user, $databaseSecret, [
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+]);
+
+$select = $pdo->query('SELECT `id`, `username`, `password` FROM `operators` ORDER BY `id`');
+$update = $pdo->prepare('UPDATE `operators` SET `password` = :hash WHERE `id` = :id');
+
+$converted = 0;
+$administratorUpdated = 0;
+
+foreach ($select as $row) {
+    $id = (int) $row['id'];
+    $username = (string) $row['username'];
+    $storedValue = (string) $row['password'];
+    $newSecret = null;
+
+    if ($username === 'administrator') {
+        if (!stored_value_is_hash($storedValue) || !password_verify($administratorSecret, $storedValue)) {
+            $newSecret = $administratorSecret;
+            $administratorUpdated++;
+        }
+    } elseif (!stored_value_is_hash($storedValue)) {
+        $newSecret = $storedValue;
+    }
+
+    if ($newSecret === null) {
+        continue;
+    }
+
+    $update->execute([
+        ':hash' => password_hash($newSecret, PASSWORD_DEFAULT),
+        ':id' => $id,
+    ]);
+    $converted++;
+}
+
+printf("operator_passwords_converted=%d\n", $converted);
+printf("administrator_password_updated=%d\n", $administratorUpdated);

--- a/scripts/docker/import-backup.ps1
+++ b/scripts/docker/import-backup.ps1
@@ -1,0 +1,168 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$DumpPath,
+
+    [string]$ProjectDirectory = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path,
+
+    [switch]$SkipBuild
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+if ($PSVersionTable.PSVersion.Major -ge 7) {
+    $PSNativeCommandUseErrorActionPreference = $true
+}
+
+$InitialDirectory = (Get-Location).ProviderPath
+$MariaDbCommand = @'
+set -eu
+defaults_file="$(mktemp)"
+cleanup() {
+    rm -f "$defaults_file"
+}
+trap cleanup EXIT
+{
+    printf "[client]\n"
+    printf "user=radius\n"
+    printf "password=%s\n" "$MYSQL_PASSWORD"
+} > "$defaults_file"
+chmod 600 "$defaults_file"
+mariadb --defaults-extra-file="$defaults_file" --batch --skip-column-names radius
+'@
+
+function Assert-LastExitCode {
+    param(
+        [Parameter(Mandatory = $true)][string]$Action
+    )
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Action failed with exit code $LASTEXITCODE."
+    }
+}
+
+function Resolve-InputPath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if ([System.IO.Path]::IsPathRooted($Path)) {
+        return (Resolve-Path -LiteralPath $Path).Path
+    }
+
+    return (Resolve-Path -LiteralPath (Join-Path $InitialDirectory $Path)).Path
+}
+
+function Invoke-Compose {
+    param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Arguments)
+
+    & docker compose @Arguments
+}
+
+function Wait-ComposeServiceHealthy {
+    param(
+        [Parameter(Mandatory = $true)][string]$ServiceName,
+        [int]$TimeoutSeconds = 180
+    )
+
+    $containerId = (Invoke-Compose ps -q $ServiceName).Trim()
+    if (-not $containerId) {
+        throw "No container found for Compose service '$ServiceName'."
+    }
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $status = ""
+    do {
+        $status = (& docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' $containerId).Trim()
+        Assert-LastExitCode "Inspecting Compose service '$ServiceName'"
+        if ($status -eq "healthy" -or $status -eq "running") {
+            return
+        }
+
+        Start-Sleep -Seconds 3
+    } while ((Get-Date) -lt $deadline)
+
+    throw "Service '$ServiceName' did not become healthy within $TimeoutSeconds seconds. Last status: $status"
+}
+
+function Invoke-MariaDbScalar {
+    param([Parameter(Mandatory = $true)][string]$Sql)
+
+    $result = $Sql | docker compose exec -T radius-mysql sh -lc $MariaDbCommand
+    Assert-LastExitCode "Executing MariaDB scalar query"
+
+    return ($result | Select-Object -First 1).Trim()
+}
+
+function Validate-ImportedSchema {
+    $passwordWidth = Invoke-MariaDbScalar "SELECT CHARACTER_MAXIMUM_LENGTH FROM information_schema.COLUMNS WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='operators' AND COLUMN_NAME='password';"
+    if ([int]$passwordWidth -lt 95) {
+        throw "Expected operators.password width >= 95, found $passwordWidth."
+    }
+
+    $passwordNullable = Invoke-MariaDbScalar "SELECT IS_NULLABLE FROM information_schema.COLUMNS WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='operators' AND COLUMN_NAME='password';"
+    if ($passwordNullable -ne "NO") {
+        throw "Expected operators.password to be NOT NULL, found IS_NULLABLE=$passwordNullable."
+    }
+
+    foreach ($table in @("operators", "operators_acl", "radcheck", "radreply", "radusergroup", "radacct", "nas")) {
+        $count = Invoke-MariaDbScalar "SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='$table';"
+        if ([int]$count -ne 1) {
+            throw "Expected imported table '$table' to exist."
+        }
+    }
+}
+
+function Invoke-PostImportPasswordConversion {
+    docker compose build radius-web
+    Assert-LastExitCode "Building radius-web for post-import password conversion"
+
+    docker compose run --rm --no-deps --entrypoint php radius-web /usr/local/bin/daloradius-hash-imported-passwords.php
+    Assert-LastExitCode "Converting imported operator passwords"
+}
+
+Push-Location $ProjectDirectory
+try {
+    $resolvedDump = Resolve-InputPath $DumpPath
+    if (-not (Test-Path -LiteralPath ".env")) {
+        throw "Missing .env in $ProjectDirectory. Copy .env.example to .env and set required variables first."
+    }
+
+    docker compose config --quiet
+    Assert-LastExitCode "Validating Docker Compose configuration"
+
+    gzip -t $resolvedDump
+    Assert-LastExitCode "Validating dump integrity"
+
+    docker compose stop radius radius-web
+    Assert-LastExitCode "Stopping application services"
+
+    docker compose up -d radius-mysql
+    Assert-LastExitCode "Starting radius-mysql"
+    Wait-ComposeServiceHealthy -ServiceName "radius-mysql"
+
+    gzip -cd $resolvedDump | docker compose exec -T radius-mysql sh -lc $MariaDbCommand
+    Assert-LastExitCode "Importing database dump"
+
+    Get-ChildItem -LiteralPath (Join-Path $ProjectDirectory "docker\post-import-migrations") -Filter "*.sql" | Sort-Object Name | ForEach-Object {
+        Write-Host "Applying post-import migration $($_.Name)"
+        Get-Content -Raw -LiteralPath $_.FullName | docker compose exec -T radius-mysql sh -lc $MariaDbCommand
+        Assert-LastExitCode "Applying post-import migration $($_.Name)"
+    }
+
+    Invoke-PostImportPasswordConversion
+
+    Validate-ImportedSchema
+
+    if ($SkipBuild) {
+        docker compose up -d
+        Assert-LastExitCode "Starting Docker Compose stack"
+    } else {
+        docker compose up -d --build
+        Assert-LastExitCode "Building and starting Docker Compose stack"
+    }
+
+    docker compose ps
+    Assert-LastExitCode "Listing Docker Compose services"
+}
+finally {
+    Pop-Location
+}

--- a/scripts/docker/import-backup.sh
+++ b/scripts/docker/import-backup.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+project_dir="$(cd -- "$script_dir/../.." && pwd)"
+skip_build=0
+dump_path=""
+
+usage() {
+    printf 'Usage: %s [--skip-build] <dump.sql.gz>\n' "$(basename "$0")" >&2
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --skip-build)
+            skip_build=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            if [ -n "$dump_path" ]; then
+                usage
+                exit 1
+            fi
+            dump_path="$1"
+            shift
+            ;;
+    esac
+done
+
+if [ -z "$dump_path" ]; then
+    usage
+    exit 1
+fi
+
+if [ "${dump_path#/}" != "$dump_path" ]; then
+    resolved_dump="$dump_path"
+else
+    dump_dir="$(dirname -- "$dump_path")"
+    dump_name="$(basename -- "$dump_path")"
+    resolved_dump="$(cd -- "$dump_dir" && pwd)/$dump_name"
+fi
+
+if [ ! -f "$resolved_dump" ]; then
+    printf 'Dump not found: %s\n' "$resolved_dump" >&2
+    exit 1
+fi
+
+mariadb_command='set -eu
+defaults_file="$(mktemp)"
+cleanup() {
+    rm -f "$defaults_file"
+}
+trap cleanup EXIT
+{
+    printf "[client]\n"
+    printf "user=radius\n"
+    printf "password=%s\n" "$MYSQL_PASSWORD"
+} > "$defaults_file"
+chmod 600 "$defaults_file"
+mariadb --defaults-extra-file="$defaults_file" --batch --skip-column-names radius'
+
+compose() {
+    docker compose "$@"
+}
+
+wait_compose_service_healthy() {
+    service_name="$1"
+    timeout_seconds="${2:-180}"
+    container_id="$(compose ps -q "$service_name")"
+
+    if [ -z "$container_id" ]; then
+        printf "No container found for Compose service '%s'.\n" "$service_name" >&2
+        exit 1
+    fi
+
+    deadline=$((SECONDS + timeout_seconds))
+    status=""
+    while [ "$SECONDS" -lt "$deadline" ]; do
+        status="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container_id")"
+        if [ "$status" = "healthy" ] || [ "$status" = "running" ]; then
+            return 0
+        fi
+        sleep 3
+    done
+
+    printf "Service '%s' did not become healthy within %s seconds. Last status: %s\n" "$service_name" "$timeout_seconds" "$status" >&2
+    exit 1
+}
+
+mariadb_scalar() {
+    sql="$1"
+    printf '%s\n' "$sql" | compose exec -T radius-mysql sh -lc "$mariadb_command" | head -n 1
+}
+
+validate_imported_schema() {
+    password_width="$(mariadb_scalar "SELECT CHARACTER_MAXIMUM_LENGTH FROM information_schema.COLUMNS WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='operators' AND COLUMN_NAME='password';")"
+    if [ "$password_width" -lt 95 ]; then
+        printf 'Expected operators.password width >= 95, found %s.\n' "$password_width" >&2
+        exit 1
+    fi
+
+    password_nullable="$(mariadb_scalar "SELECT IS_NULLABLE FROM information_schema.COLUMNS WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='operators' AND COLUMN_NAME='password';")"
+    if [ "$password_nullable" != "NO" ]; then
+        printf 'Expected operators.password to be NOT NULL, found IS_NULLABLE=%s.\n' "$password_nullable" >&2
+        exit 1
+    fi
+
+    for table in operators operators_acl radcheck radreply radusergroup radacct nas; do
+        count="$(mariadb_scalar "SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='$table';")"
+        if [ "$count" -ne 1 ]; then
+            printf "Expected imported table '%s' to exist.\n" "$table" >&2
+            exit 1
+        fi
+    done
+}
+
+run_post_import_password_conversion() {
+    docker compose build radius-web
+    docker compose run --rm --no-deps --entrypoint php radius-web /usr/local/bin/daloradius-hash-imported-passwords.php
+}
+
+cd "$project_dir"
+
+if [ ! -f .env ]; then
+    printf 'Missing .env in %s. Copy .env.example to .env and set required variables first.\n' "$project_dir" >&2
+    exit 1
+fi
+
+docker compose config --quiet
+gzip -t "$resolved_dump"
+
+docker compose stop radius radius-web
+docker compose up -d radius-mysql
+wait_compose_service_healthy "radius-mysql"
+
+gzip -cd "$resolved_dump" | docker compose exec -T radius-mysql sh -lc "$mariadb_command"
+
+while IFS= read -r -d '' migration; do
+    printf 'Applying post-import migration %s\n' "$(basename -- "$migration")"
+    docker compose exec -T radius-mysql sh -lc "$mariadb_command" < "$migration"
+done < <(find "$project_dir/docker/post-import-migrations" -maxdepth 1 -name '*.sql' -print0 | sort -z)
+
+run_post_import_password_conversion
+validate_imported_schema
+
+if [ "$skip_build" -eq 1 ]; then
+    docker compose up -d
+else
+    docker compose up -d --build
+fi
+
+docker compose ps

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -581,10 +581,11 @@ daloradius_load_sql_schema() {
 system_finalize() {
     INIT_USERNAME="administrator"
     INIT_PASSWORD=$(generate_random_string 12)
-    SQL="UPDATE operators SET password='${INIT_PASSWORD}' WHERE username='${INIT_USERNAME}'"
+    INIT_PASSWORD_HASH=$(php -r 'echo password_hash($argv[1], PASSWORD_DEFAULT);' "${INIT_PASSWORD}")
+    SQL="UPDATE operators SET password='${INIT_PASSWORD_HASH}' WHERE username='${INIT_USERNAME}'"
     if ! mariadb --defaults-extra-file="${MARIADB_CLIENT_FILENAME}" --execute="${SQL}" >/dev/null 2>&1; then
-        INIT_PASSWORD="radius"
-        print_yellow "[!] Failed to update ${INIT_USERNAME}'s default password"
+        print_red "[!] Failed to update ${INIT_USERNAME}'s default password"
+        exit 1
     fi
 
     echo -e "[+] ${GREEN}daloRADIUS${NC} has been installed."

--- a/tests/docker/docker-infra.test.js
+++ b/tests/docker/docker-infra.test.js
@@ -57,6 +57,14 @@ test("Docker build context excludes local state and copies only required trees",
   assert.match(dockerfile, /^COPY init\.sh \/var\/www\/daloradius\/init\.sh$/m);
 });
 
+test("Docker image recreates shared static asset symlinks", () => {
+  const dockerfile = read("Dockerfile");
+
+  assert.match(dockerfile, /rm -rf \/var\/www\/daloradius\/app\/operators\/static \/var\/www\/daloradius\/app\/users\/static/);
+  assert.match(dockerfile, /ln -s \.\.\/common\/static \/var\/www\/daloradius\/app\/operators\/static/);
+  assert.match(dockerfile, /ln -s \.\.\/common\/static \/var\/www\/daloradius\/app\/users\/static/);
+});
+
 test("Docker init scripts fail fast and use bounded database waits", () => {
   for (const scriptPath of ["init.sh", "init-freeradius.sh"]) {
     const script = read(scriptPath);

--- a/tests/docker/docker-infra.test.js
+++ b/tests/docker/docker-infra.test.js
@@ -235,7 +235,8 @@ test("Docker web logging defaults use the writable daloRADIUS var log path", () 
   assert.match(dockerfile, /chown -R www-data:www-data \/var\/www\/daloradius\/var/);
   assert.match(webInit, /php_config_set "CONFIG_LOG_FILE" "\/var\/www\/daloradius\/var\/log\/daloradius\.log"/);
   assert.match(webInit, /chown www-data:www-data "\$DALORADIUS_CONF_PATH"/);
-  assert.match(webInit, /chmod 0644 "\$DALORADIUS_CONF_PATH"/);
+  assert.match(webInit, /chmod 0600 "\$DALORADIUS_CONF_PATH"/);
+  assert.doesNotMatch(webInit, /chmod 0?6[0-7][4-7] "\$DALORADIUS_CONF_PATH"/);
   assert.doesNotMatch(webInit, /php_config_set "CONFIG_LOG_FILE" "\/tmp\/daloradius\.log"/);
 });
 
@@ -553,7 +554,7 @@ test("Docker init scripts guard critical file configuration steps", () => {
   assert.match(webInitBody, /fail_step "daloradius_init" "config_copy_failed"/);
   assert.match(webInitBody, /chown www-data:www-data "\$DALORADIUS_CONF_PATH" 2>>"\$INIT_ERROR_LOG"/);
   assert.match(webInitBody, /fail_step "daloradius_init" "config_owner_failed"/);
-  assert.match(webInitBody, /chmod 0644 "\$DALORADIUS_CONF_PATH" 2>>"\$INIT_ERROR_LOG"/);
+  assert.match(webInitBody, /chmod 0600 "\$DALORADIUS_CONF_PATH" 2>>"\$INIT_ERROR_LOG"/);
   assert.match(webInitBody, /fail_step "daloradius_init" "config_mode_failed"/);
   assert.match(webInitBody, /log_event "info" "daloradius_init" "success" "daloradius_configured"/);
 

--- a/tests/docker/docker-infra.test.js
+++ b/tests/docker/docker-infra.test.js
@@ -170,6 +170,16 @@ test("Docker init scripts escape environment-derived config values", () => {
   assert.doesNotMatch(radiusInit, /echo "Adding client .*secret \$SECRET"/);
 });
 
+test("FreeRADIUS Docker client insertion uses descriptive variable names", () => {
+  const radiusInit = read("init-freeradius.sh");
+
+  assert.doesNotMatch(radiusInit, /^\s*(IP|NM|CIDR|SECRET)=/m);
+  assert.match(radiusInit, /container_ip_address=/);
+  assert.match(radiusInit, /container_netmask=/);
+  assert.match(radiusInit, /container_cidr=/);
+  assert.match(radiusInit, /client_secret=/);
+});
+
 test("Operator passwords are hashed and Docker admin password is explicit", () => {
   const login = read("app/operators/dologin.php");
   const operatorNew = read("app/operators/config-operators-new.php");

--- a/tests/docker/docker-infra.test.js
+++ b/tests/docker/docker-infra.test.js
@@ -180,6 +180,30 @@ test("Compose avoids insecure local defaults", () => {
   assert.match(compose, /FREERADIUS_SQL_TLS=\$\{FREERADIUS_SQL_TLS:\?Set FREERADIUS_SQL_TLS to require or disabled\}/);
 });
 
+test("Compose exposes configurable timezone and mail environment", () => {
+  const compose = read("docker-compose.yml");
+  const mysqlService = compose.match(/radius-mysql:[\s\S]*?(?=\n  radius:)/);
+  const radiusService = compose.match(/radius:[\s\S]*?(?=\n  radius-web:)/);
+  const webService = compose.match(/radius-web:[\s\S]*/);
+
+  assert.notEqual(mysqlService, null, "radius-mysql service should be present");
+  assert.notEqual(radiusService, null, "radius service should be present");
+  assert.notEqual(webService, null, "radius-web service should be present");
+
+  assert.doesNotMatch(mysqlService[0], /^\s*-\s*TZ=/m);
+
+  for (const service of [radiusService[0], webService[0]]) {
+    assert.match(service, /TZ=\$\{TZ:-Europe\/Vienna\}/);
+  }
+
+  assert.match(webService[0], /MAIL_SMTPADDR=\$\{MAIL_SMTPADDR:-127\.0\.0\.1\}/);
+  assert.match(webService[0], /MAIL_PORT=\$\{MAIL_PORT:-25\}/);
+  assert.match(webService[0], /MAIL_FROM=\$\{MAIL_FROM:-root@daloradius\.xdsl\.by\}/);
+  assert.match(webService[0], /MAIL_AUTH=\$\{MAIL_AUTH:-\}/);
+  assert.doesNotMatch(webService[0], /MAIL_SMTPADDR=127\.0\.0\.1/);
+  assert.doesNotMatch(webService[0], /MAIL_PORT=25/);
+});
+
 test("Docker Compose env example is a safe copyable template", () => {
   const envExamplePath = path.join(root, ".env.example");
   const dockerignore = read(".dockerignore");
@@ -220,6 +244,11 @@ test("Docker Compose env example is a safe copyable template", () => {
     "DEFAULT_CLIENT_SECRET",
     "DALORADIUS_ADMIN_PASSWORD",
     "FREERADIUS_SQL_TLS",
+    "TZ",
+    "MAIL_SMTPADDR",
+    "MAIL_PORT",
+    "MAIL_FROM",
+    "MAIL_AUTH",
   ]) {
     assert.ok(Object.hasOwn(templateValues, variableName), `${variableName} should be represented in .env.example`);
   }
@@ -238,6 +267,11 @@ test("Docker Compose env example is a safe copyable template", () => {
   }
 
   assert.match(templateValues.FREERADIUS_SQL_TLS, /^(require|disabled)$/);
+  assert.equal(templateValues.TZ, "Europe/Vienna");
+  assert.equal(templateValues.MAIL_SMTPADDR, "127.0.0.1");
+  assert.equal(templateValues.MAIL_PORT, "25");
+  assert.equal(templateValues.MAIL_FROM, "root@daloradius.xdsl.by");
+  assert.equal(templateValues.MAIL_AUTH, "");
   assert.doesNotMatch(envExample, /^\s*[A-Z0-9_]+=CHANGE_ME_[A-Z0-9_]*$/m);
   assert.deepEqual(values, {}, ".env.example should not contain active variable assignments");
 
@@ -442,14 +476,34 @@ test("Docker init scripts validate runtime configuration before creating default
 
   const webInit = read("init.sh");
   const radiusInit = read("init-freeradius.sh");
+  const webTimezone = functionBody(webInit, "require_timezone");
+  const radiusTimezone = functionBody(radiusInit, "require_timezone");
+  const validateEmail = functionBody(webInit, "validate_optional_email");
 
   assert.doesNotMatch(webInit, /MYSQL_PASSWORD=\$\{MYSQL_PASSWORD:-radpass\}/);
   assert.doesNotMatch(radiusInit, /MYSQL_PASSWORD=\$\{MYSQL_PASSWORD:-radpass\}/);
   assert.match(webInit, /MYSQL_PASSWORD=\$\{MYSQL_PASSWORD:-\}/);
   assert.match(radiusInit, /MYSQL_PASSWORD=\$\{MYSQL_PASSWORD:-\}/);
+  assert.match(webInit, /TZ=\$\{TZ:-Europe\/Vienna\}/);
+  assert.match(radiusInit, /TZ=\$\{TZ:-Europe\/Vienna\}/);
+  assert.match(webInit, /function require_timezone/);
+  assert.match(radiusInit, /function require_timezone/);
+  assert.match(webTimezone, /\/usr\/share\/zoneinfo\/\$value/);
+  assert.match(radiusTimezone, /\/usr\/share\/zoneinfo\/\$value/);
+  assert.match(webTimezone, /\[ "\$value" = "UTC" \]/);
+  assert.match(radiusTimezone, /\[ "\$value" = "UTC" \]/);
+  assert.match(webTimezone, /TZif/);
+  assert.match(radiusTimezone, /TZif/);
+  assert.match(webInit, /require_timezone "TZ"/);
+  assert.match(radiusInit, /require_timezone "TZ"/);
   assert.match(webInit, /require_non_empty "DALORADIUS_ADMIN_PASSWORD"/);
   assert.match(webInit, /validate_optional_no_crlf "DEFAULT_CLIENT_SECRET"/);
-  assert.match(webInit, /validate_optional_no_crlf "MAIL_SMTPADDR"/);
+  assert.match(webInit, /validate_optional_host_token "MAIL_SMTPADDR"/);
+  assert.match(webInit, /validate_optional_port "MAIL_PORT"/);
+  assert.match(webInit, /validate_optional_email "MAIL_FROM"/);
+  assert.match(webInit, /validate_optional_no_crlf "MAIL_AUTH"/);
+  assert.match(validateEmail, /A-Za-z0-9-\]\*/);
+  assert.doesNotMatch(validateEmail, /A-Za-z0-9_-\]\*/);
   assert.match(webInit, /validate_optional_no_crlf "PASSWORD_MIN_LENGTH"/);
 
   assert.match(radiusInit, /require_non_empty "DEFAULT_CLIENT_SECRET"/);

--- a/tests/docker/docker-infra.test.js
+++ b/tests/docker/docker-infra.test.js
@@ -1,0 +1,17 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const root = path.resolve(__dirname, "..", "..");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+test("FreeRADIUS image uses one executable startup directive", () => {
+  const dockerfile = read("Dockerfile-freeradius");
+
+  assert.match(dockerfile, /^ENTRYPOINT \["\/app\/init-freeradius\.sh"\]$/m);
+  assert.doesNotMatch(dockerfile, /^CMD \["\/app\/init-freeradius\.sh"\]$/m);
+});

--- a/tests/docker/docker-infra.test.js
+++ b/tests/docker/docker-infra.test.js
@@ -64,7 +64,7 @@ test("Docker init scripts fail fast and use bounded database waits", () => {
     assert.match(script, /^set -euo pipefail$/m);
     assert.match(script, /MYSQL_WAIT_RETRIES=\$\{MYSQL_WAIT_RETRIES:-30\}/);
     assert.match(script, /function wait_for_mysql/);
-    assert.match(script, /while ! mysqladmin ping/);
+    assert.match(script, /while ! mysqladmin .* ping/);
     assert.match(script, /if \[ "\$attempt" -ge "\$MYSQL_WAIT_RETRIES" \]/);
   }
 });
@@ -80,4 +80,27 @@ test("Database initialization locks are backed by schema checks", () => {
   assert.match(radiusInit, /function freeradius_schema_ready/);
   assert.match(radiusInit, /if freeradius_schema_ready; then[\s\S]*Database schema already present/);
   assert.match(radiusInit, /init_database[\s\S]*if ! freeradius_schema_ready; then/);
+});
+
+test("Docker init scripts do not expose DB passwords in process arguments", () => {
+  for (const scriptPath of ["init.sh", "init-freeradius.sh"]) {
+    const script = read(scriptPath);
+
+    assert.doesNotMatch(script, /-p"\$MYSQL_PASSWORD"/);
+    assert.match(script, /MYSQL_DEFAULTS_FILE=\$\(mktemp\)/);
+    assert.match(script, /--defaults-extra-file="\$MYSQL_DEFAULTS_FILE"/);
+  }
+});
+
+test("Docker init scripts escape environment-derived config values", () => {
+  const webInit = read("init.sh");
+  const radiusInit = read("init-freeradius.sh");
+
+  assert.match(webInit, /function escape_sed_replacement/);
+  assert.match(webInit, /function php_escape/);
+  assert.match(webInit, /function php_config_set/);
+  assert.match(radiusInit, /function escape_sed_replacement/);
+  assert.match(radiusInit, /function sql_escape/);
+  assert.match(radiusInit, /function require_default_client_secret/);
+  assert.doesNotMatch(radiusInit, /echo "Adding client .*secret \$SECRET"/);
 });

--- a/tests/docker/docker-infra.test.js
+++ b/tests/docker/docker-infra.test.js
@@ -314,7 +314,7 @@ test("Docker build context excludes local state and copies only required trees",
   const dockerignore = read(".dockerignore");
   const dockerfile = read("Dockerfile");
 
-  for (const ignoredPath of [".git", ".planning", "data/", "internal_data/", "*.log", "*.sql", ".env"]) {
+  for (const ignoredPath of [".git", ".planning", "data/", "internal_data/", "*.log", "*.sql", "*.sql.gz", ".env"]) {
     assert.match(dockerignore, new RegExp(`^${ignoredPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`, "m"));
   }
 
@@ -796,6 +796,119 @@ test("Docker init database writes do not pass secrets through process arguments"
   assert.doesNotMatch(nasInsertMatch[0], /'\$client_secret_sql'/);
   assert.equal(Buffer.from(dangerousSecretHex, "hex").toString("utf8"), dangerousSecret);
   assert.doesNotMatch(dangerousSecretHex, /['\\;-]/);
+});
+
+test("Docker post-import migration assets are present and ordered", () => {
+  const migrationPath = path.join(root, "docker", "post-import-migrations", "001-operators-password-width.sql");
+  const runnerPath = path.join(root, "scripts", "docker", "import-backup.ps1");
+  const bashRunnerPath = path.join(root, "scripts", "docker", "import-backup.sh");
+  const passwordConverterPath = path.join(root, "scripts", "docker", "hash-imported-passwords.php");
+
+  assert.ok(fs.existsSync(migrationPath), "operator password width migration should exist");
+  assert.ok(fs.existsSync(runnerPath), "backup import runner should exist");
+  assert.ok(fs.existsSync(bashRunnerPath), "Linux backup import runner should exist");
+  assert.ok(fs.existsSync(passwordConverterPath), "post-import password converter should exist");
+
+  const migration = read("docker/post-import-migrations/001-operators-password-width.sql");
+  assert.match(migration, /ALTER TABLE `operators` MODIFY `password` VARCHAR\(95\) NOT NULL;/);
+  assert.doesNotMatch(migration, /DROP TABLE|TRUNCATE|DELETE FROM/i);
+});
+
+test("Docker backup import PowerShell runner imports, migrates, hashes passwords, and starts stack last", () => {
+  const runner = read("scripts/docker/import-backup.ps1");
+
+  assert.match(runner, /param\s*\(/);
+  assert.match(runner, /\[Parameter\(Mandatory = \$true\)\]\s*\[string\]\$DumpPath/);
+  assert.match(runner, /docker compose config --quiet/);
+  assert.match(runner, /gzip -t/);
+  assert.match(runner, /docker compose stop radius radius-web/);
+  assert.match(runner, /docker compose up -d radius-mysql/);
+  assert.match(runner, /Wait-ComposeServiceHealthy -ServiceName "radius-mysql"/);
+  assert.match(runner, /gzip -cd/);
+  assert.match(runner, /mariadb --defaults-extra-file="\$defaults_file" --batch --skip-column-names radius/);
+  assert.match(runner, /password=%s\\n" "\$MYSQL_PASSWORD"/);
+  assert.doesNotMatch(runner, /-p"\$MYSQL_PASSWORD"/);
+  assert.match(runner, /Get-ChildItem .*docker.*post-import-migrations/);
+  assert.match(runner, /Validate-ImportedSchema/);
+  assert.match(runner, /SELECT IS_NULLABLE FROM information_schema\.COLUMNS/);
+  assert.match(runner, /Expected operators\.password to be NOT NULL/);
+  assert.match(runner, /function Invoke-PostImportPasswordConversion/);
+  assert.match(runner, /docker compose build radius-web/);
+  assert.match(runner, /docker compose run --rm --no-deps --entrypoint php radius-web \/usr\/local\/bin\/daloradius-hash-imported-passwords\.php/);
+
+  assert.ok(
+    runner.indexOf("gzip -cd") < runner.indexOf("Get-ChildItem"),
+    "dump import should run before post-import migrations",
+  );
+  assert.ok(
+    runner.indexOf("Validate-ImportedSchema") < runner.indexOf("docker compose up -d --build"),
+    "schema validation should run before full stack start",
+  );
+  assert.ok(
+    runner.indexOf("\n    Invoke-PostImportPasswordConversion\n") < runner.indexOf("\n    Validate-ImportedSchema\n"),
+    "password conversion should run before schema validation",
+  );
+});
+
+test("Docker backup import Linux runner mirrors the post-import workflow", () => {
+  const runner = read("scripts/docker/import-backup.sh");
+
+  assert.match(runner, /^set -euo pipefail$/m);
+  assert.match(runner, /docker compose config --quiet/);
+  assert.match(runner, /gzip -t "\$resolved_dump"/);
+  assert.match(runner, /docker compose stop radius radius-web/);
+  assert.match(runner, /docker compose up -d radius-mysql/);
+  assert.match(runner, /wait_compose_service_healthy "radius-mysql"/);
+  assert.match(runner, /gzip -cd "\$resolved_dump"/);
+  assert.match(runner, /mariadb --defaults-extra-file="\$defaults_file" --batch --skip-column-names radius/);
+  assert.match(runner, /find "\$project_dir\/docker\/post-import-migrations" -maxdepth 1 -name '\*\.sql' -print0 \| sort -z/);
+  assert.match(runner, /docker compose build radius-web/);
+  assert.match(runner, /docker compose run --rm --no-deps --entrypoint php radius-web \/usr\/local\/bin\/daloradius-hash-imported-passwords\.php/);
+  assert.match(runner, /validate_imported_schema/);
+
+  assert.ok(
+    runner.indexOf('gzip -cd "$resolved_dump"') < runner.indexOf("post-import-migrations"),
+    "Linux runner should import dump before applying migrations",
+  );
+  assert.ok(
+    runner.indexOf("\nrun_post_import_password_conversion\n") < runner.indexOf("\nvalidate_imported_schema\n"),
+    "Linux runner should convert passwords before validation",
+  );
+});
+
+test("Docker docs describe legacy dump post-import migrations", () => {
+  const readme = read("README.docker-standalone.md");
+
+  assert.match(readme, /Post-import migrations/);
+  assert.match(readme, /scripts\/docker\/import-backup\.ps1/);
+  assert.match(readme, /backup_radius_14-05-2026\.sql\.gz/);
+  assert.match(readme, /operators\.password/);
+  assert.match(readme, /VARCHAR\(95\)/);
+  assert.match(readme, /temporary client defaults file/);
+  assert.doesNotMatch(readme, /-p"\$MYSQL_PASSWORD"/);
+  assert.match(readme, /scripts\/docker\/import-backup\.sh/);
+  assert.match(readme, /hashes imported operator passwords/);
+  assert.match(readme, /does not rewrite daloRADIUS user portal passwords or FreeRADIUS `radcheck` authentication attributes/);
+  assert.match(readme, /docker compose up -d radius-mysql/);
+  assert.match(readme, /docker compose up -d --build/);
+});
+
+test("Docker post-import password converter hashes imported operator passwords only", () => {
+  const converter = read("scripts/docker/hash-imported-passwords.php");
+  const dockerfile = read("Dockerfile");
+
+  assert.match(dockerfile, /COPY scripts\/docker\/hash-imported-passwords\.php \/usr\/local\/bin\/daloradius-hash-imported-passwords\.php/);
+  assert.match(converter, /password_hash\(/);
+  assert.match(converter, /password_get_info\(/);
+  assert.match(converter, /DALORADIUS_ADMIN_PASSWORD/);
+  assert.match(converter, /\$username === 'administrator'/);
+  assert.match(converter, /SELECT `id`, `username`, `password` FROM `operators`/);
+  assert.match(converter, /operator_passwords_converted/);
+  assert.match(converter, /administrator_password_updated/);
+  assert.doesNotMatch(converter, /userinfo/);
+  assert.doesNotMatch(converter, /portalloginpassword/);
+  assert.doesNotMatch(converter, /radcheck/);
+  assert.doesNotMatch(converter, /echo .*password/i);
 });
 
 test("Standalone image builds from local context on a supported PHP runtime", () => {

--- a/tests/docker/docker-infra.test.js
+++ b/tests/docker/docker-infra.test.js
@@ -124,7 +124,7 @@ test("Docker compliance cleanup findings remain covered by explicit invariants",
           "MYSQL_PASSWORD",
           "DALORADIUS_ADMIN_PASSWORD",
           "admin_hash",
-          "client_secret_sql",
+          "client_secret_hex",
         ]) {
           assert.doesNotMatch(loggingLines, shellVariableReference(secretVariable));
         }
@@ -647,6 +647,8 @@ test("Operator passwords are hashed and Docker admin password is explicit", () =
 test("Docker init database writes do not pass secrets through process arguments", () => {
   const webInit = read("init.sh");
   const radiusInit = read("init-freeradius.sh");
+  const dangerousSecret = "radius\\'); DROP TABLE nas; --";
+  const dangerousSecretHex = Buffer.from(dangerousSecret, "utf8").toString("hex");
   const adminPasswordUpdate = functionBody(webInit, "set_admin_password").match(
     /mysql\b[\s\S]*?fail_step "admin_password_update" "admin_password_update_failed"/,
   );
@@ -662,7 +664,12 @@ test("Docker init database writes do not pass secrets through process arguments"
   assert.doesNotMatch(radiusInit, /mysql\b[^\n]*-e\s+"INSERT INTO nas/);
   assert.doesNotMatch(nasInsertMatch[0], /mysql\b[\s\S]*?-e\s+"INSERT INTO nas/);
   assert.match(nasInsertMatch[0], /<<[-]?'?[A-Z_]*'?/);
-  assert.match(nasInsertMatch[0], /client_secret_sql/);
+  assert.match(nasInsertMatch[0], /client_secret_hex=\$\(sql_hex "\$client_secret"\)/);
+  assert.match(nasInsertMatch[0], /UNHEX\('\$client_secret_hex'\)/);
+  assert.doesNotMatch(nasInsertMatch[0], /client_secret_sql/);
+  assert.doesNotMatch(nasInsertMatch[0], /'\$client_secret_sql'/);
+  assert.equal(Buffer.from(dangerousSecretHex, "hex").toString("utf8"), dangerousSecret);
+  assert.doesNotMatch(dangerousSecretHex, /['\\;-]/);
 });
 
 test("Standalone image builds from local context on a supported PHP runtime", () => {

--- a/tests/docker/docker-infra.test.js
+++ b/tests/docker/docker-infra.test.js
@@ -69,6 +69,16 @@ test("Docker init scripts fail fast and use bounded database waits", () => {
   }
 });
 
+test("Dockerfiles normalize copied shell scripts before execution", () => {
+  const webDockerfile = read("Dockerfile");
+  const radiusDockerfile = read("Dockerfile-freeradius");
+  const standaloneDockerfile = read("Dockerfile-standalone");
+
+  assert.match(webDockerfile, /sed -i 's\/\\r\$\/\/' \/var\/www\/daloradius\/init\.sh/);
+  assert.match(radiusDockerfile, /sed -i 's\/\\r\$\/\/' \/app\/init-freeradius\.sh/);
+  assert.match(standaloneDockerfile, /sed -i 's\/\\r\$\/\/' \/usr\/local\/bin\/apache-config\.sh/);
+});
+
 test("Database initialization locks are backed by schema checks", () => {
   const webInit = read("init.sh");
   const radiusInit = read("init-freeradius.sh");

--- a/tests/docker/docker-infra.test.js
+++ b/tests/docker/docker-infra.test.js
@@ -135,7 +135,7 @@ test("Standalone image builds from local context on a supported PHP runtime", ()
   assert.doesNotMatch(dockerfile, /git clone/);
   assert.doesNotMatch(dockerfile, /FROM php:7-apache/);
   assert.doesNotMatch(dockerfile, /apt-get -y upgrade/);
-  assert.match(dockerfile, /^FROM php:8\.4-apache$/m);
+  assert.match(dockerfile, /^FROM php:8\.4-apache(@sha256:[a-f0-9]{64})?$/m);
   assert.match(dockerfile, /^COPY app\/ \/var\/www\/html\/daloradius$/m);
   assert.match(dockerfile, /^COPY contrib\/scripts\/apache-config\.sh \/usr\/local\/bin\/apache-config\.sh$/m);
   assert.match(readme, /docker build -t daloradius-standalone -f Dockerfile-standalone \./);
@@ -161,4 +161,19 @@ test("Containers use Docker-friendly process, log, and hardening defaults", () =
   assert.match(operatorsConf, /CustomLog \/proc\/self\/fd\/1 combined/);
   assert.match(compose, /security_opt:[\s\S]*no-new-privileges:true/);
   assert.match(compose, /cap_drop:[\s\S]*- NET_RAW/);
+});
+
+test("Runtime images are pinned and avoid unnecessary build/debug packages", () => {
+  const webDockerfile = read("Dockerfile");
+  const radiusDockerfile = read("Dockerfile-freeradius");
+  const standaloneDockerfile = read("Dockerfile-standalone");
+  const compose = read("docker-compose.yml");
+
+  assert.match(webDockerfile, /^FROM debian:13-slim@sha256:[a-f0-9]{64}$/m);
+  assert.match(radiusDockerfile, /^FROM freeradius\/freeradius-server:3\.2\.8@sha256:[a-f0-9]{64}$/m);
+  assert.match(standaloneDockerfile, /^FROM php:8\.4-apache@sha256:[a-f0-9]{64}$/m);
+  assert.match(compose, /image: mariadb:11\.8@sha256:[a-f0-9]{64}/);
+  assert.doesNotMatch(webDockerfile, /apt-utils|php-dev|default-libmysqlclient-dev|unzip|wget/);
+  assert.doesNotMatch(radiusDockerfile, /apt-utils|libmysqlclient-dev|unzip|wget/);
+  assert.match(radiusDockerfile, /-p 1812:1812\/udp -p 1813:1813\/udp/);
 });

--- a/tests/docker/docker-infra.test.js
+++ b/tests/docker/docker-infra.test.js
@@ -72,6 +72,44 @@ test("Docker image recreates shared static asset symlinks", () => {
   assert.match(dockerfile, /ln -s \.\.\/common\/static \/var\/www\/daloradius\/app\/users\/static/);
 });
 
+test("Docker web logging defaults use the writable daloRADIUS var log path", () => {
+  const dockerfile = read("Dockerfile");
+  const webInit = read("init.sh");
+
+  assert.match(dockerfile, /mkdir -p \/var\/www\/daloradius\/var\/log/);
+  assert.match(dockerfile, /touch \/var\/www\/daloradius\/var\/log\/daloradius\.log/);
+  assert.match(dockerfile, /chown -R www-data:www-data \/var\/www\/daloradius\/var/);
+  assert.match(webInit, /php_config_set "CONFIG_LOG_FILE" "\/var\/www\/daloradius\/var\/log\/daloradius\.log"/);
+  assert.match(webInit, /chown www-data:www-data "\$DALORADIUS_CONF_PATH"/);
+  assert.match(webInit, /chmod 0644 "\$DALORADIUS_CONF_PATH"/);
+  assert.doesNotMatch(webInit, /php_config_set "CONFIG_LOG_FILE" "\/tmp\/daloradius\.log"/);
+});
+
+test("FreeRADIUS log volume keeps log files readable by the web service", () => {
+  const radiusInit = read("init-freeradius.sh");
+  const compose = read("docker-compose.yml");
+
+  assert.match(compose, /radius:[\s\S]*?- radius_logs:\/var\/log\/freeradius/);
+  assert.match(compose, /radius-web:[\s\S]*?- radius_logs:\/var\/log\/freeradius/);
+  assert.match(radiusInit, /function prepare_freeradius_logs/);
+  assert.match(radiusInit, /function wait_for_radius_status/);
+  assert.match(radiusInit, /radclient -q -r 1 -t 3 127\.0\.0\.1:18121 status adminsecret >\/dev\/null 2>&1/);
+  assert.match(radiusInit, /chown -R freerad:33 \/var\/log\/freeradius/);
+  assert.match(radiusInit, /find \/var\/log\/freeradius -type d -exec chmod 2750/);
+  assert.match(radiusInit, /find \/var\/log\/freeradius -type f -exec chmod 0640/);
+  assert.match(radiusInit, /freeradius -f "\$@" &[\s\S]*RADIUS_PID=\$![\s\S]*wait_for_radius_status[\s\S]*prepare_freeradius_logs/);
+});
+
+test("Docker web image provides readable placeholders for unavailable host logs", () => {
+  const dockerfile = read("Dockerfile");
+
+  assert.match(dockerfile, /System logs are not available inside this container/);
+  assert.match(dockerfile, /> \/var\/log\/syslog/);
+  assert.match(dockerfile, /Boot logs are not available inside this container/);
+  assert.match(dockerfile, /> \/var\/log\/boot\.log/);
+  assert.match(dockerfile, /chmod 0644 \/var\/log\/syslog \/var\/log\/boot\.log/);
+});
+
 test("Docker init scripts fail fast and use bounded database waits", () => {
   for (const scriptPath of ["init.sh", "init-freeradius.sh"]) {
     const script = read(scriptPath);

--- a/tests/docker/docker-infra.test.js
+++ b/tests/docker/docker-infra.test.js
@@ -127,3 +127,17 @@ test("Operator passwords are hashed and Docker admin password is explicit", () =
   assert.match(webInit, /password_hash\(\$argv\[1\], PASSWORD_DEFAULT\)/);
   assert.match(installer, /INIT_PASSWORD_HASH=\$\(php -r 'echo password_hash\(\$argv\[1\], PASSWORD_DEFAULT\);'/);
 });
+
+test("Standalone image builds from local context on a supported PHP runtime", () => {
+  const dockerfile = read("Dockerfile-standalone");
+  const readme = read("README.docker-standalone.md");
+
+  assert.doesNotMatch(dockerfile, /git clone/);
+  assert.doesNotMatch(dockerfile, /FROM php:7-apache/);
+  assert.doesNotMatch(dockerfile, /apt-get -y upgrade/);
+  assert.match(dockerfile, /^FROM php:8\.4-apache$/m);
+  assert.match(dockerfile, /^COPY app\/ \/var\/www\/html\/daloradius$/m);
+  assert.match(dockerfile, /^COPY contrib\/scripts\/apache-config\.sh \/usr\/local\/bin\/apache-config\.sh$/m);
+  assert.match(readme, /docker build -t daloradius-standalone -f Dockerfile-standalone \./);
+  assert.doesNotMatch(readme, /dormancygrace\/daloradius/);
+});

--- a/tests/docker/docker-infra.test.js
+++ b/tests/docker/docker-infra.test.js
@@ -9,6 +9,16 @@ function read(relativePath) {
   return fs.readFileSync(path.join(root, relativePath), "utf8");
 }
 
+function functionBody(script, functionName) {
+  const functionStart = script.indexOf(`function ${functionName} {`);
+  assert.notEqual(functionStart, -1);
+
+  const nextFunctionStart = script.indexOf("\nfunction ", functionStart + 1);
+  assert.notEqual(nextFunctionStart, -1);
+
+  return script.slice(functionStart, nextFunctionStart);
+}
+
 test("FreeRADIUS image uses one executable startup directive", () => {
   const dockerfile = read("Dockerfile-freeradius");
 
@@ -160,14 +170,76 @@ test("Docker init scripts do not expose DB passwords in process arguments", () =
 test("Docker init scripts escape environment-derived config values", () => {
   const webInit = read("init.sh");
   const radiusInit = read("init-freeradius.sh");
+  const radiusSqlConfigSet = functionBody(radiusInit, "sql_config_set");
 
   assert.match(webInit, /function escape_sed_replacement/);
   assert.match(webInit, /function php_escape/);
   assert.match(webInit, /function php_config_set/);
   assert.match(radiusInit, /function escape_sed_replacement/);
+  assert.match(radiusInit, /function freeradius_quote_escape/);
   assert.match(radiusInit, /function sql_escape/);
   assert.match(radiusInit, /function require_default_client_secret/);
+  assert.match(radiusSqlConfigSet, /freeradius_quote_escape "\$2"/);
+  assert.match(radiusSqlConfigSet, /escape_sed_replacement "\$\(freeradius_quote_escape "\$2"\)"/);
+  assert.match(radiusInit, /escape_sed_replacement "\$\(freeradius_quote_escape "\$DEFAULT_CLIENT_SECRET"\)"/);
   assert.doesNotMatch(radiusInit, /echo "Adding client .*secret \$SECRET"/);
+});
+
+test("Docker init scripts validate runtime configuration before creating defaults files", () => {
+  for (const scriptPath of ["init.sh", "init-freeradius.sh"]) {
+    const script = read(scriptPath);
+    const validationCallIndex = script.indexOf("\nvalidate_runtime_config\n");
+    const defaultsFileIndex = script.indexOf("MYSQL_DEFAULTS_FILE=$(mktemp)");
+
+    assert.match(script, /function validate_runtime_config/);
+    assert.notEqual(validationCallIndex, -1);
+    assert.notEqual(defaultsFileIndex, -1);
+    assert.ok(validationCallIndex < defaultsFileIndex);
+
+    const hostValidator = functionBody(script, "require_host_token");
+    const hostCrlfCheckIndex = hostValidator.indexOf('reject_crlf "$name"');
+    const hostSplitIndex = hostValidator.indexOf("IFS='.' read -r -a host_labels");
+    const portValidator = functionBody(script, "require_mysql_port");
+
+    assert.match(script, /function require_non_empty/);
+    assert.match(script, /function reject_crlf/);
+    assert.match(script, /function require_positive_integer/);
+    assert.match(script, /function require_mysql_port/);
+    assert.match(script, /function require_sql_identifier/);
+    assert.match(script, /function require_host_token/);
+    assert.match(script, /65535/);
+    assert.doesNotMatch(portValidator, /\[ "\$value" -gt 65535 \]/);
+    assert.match(portValidator, /\[ "\$\{#value\}" -gt 5 \]/);
+    assert.match(portValidator, /\[ "\$\{#value\}" -eq 5 \]/);
+    assert.match(portValidator, /\[\[ "\$value" > "65535" \]\]/);
+    assert.match(script, /\[\[ "\$value" =~ \^\[A-Za-z_\]\[A-Za-z0-9_\]\*\$ \]\]/);
+    assert.doesNotMatch(script, /\[\[ "\$value" =~ \^\[A-Za-z0-9_\]\+\$ \]\]/);
+    assert.match(script, /\.\*\|\*\.\|\*\.\.\*\)/);
+    assert.match(script, /IFS='\.' read -r -a host_labels <<< "\$value"/);
+    assert.match(script, /for label in "\$\{host_labels\[@\]\}"; do/);
+    assert.match(script, /\[\[ "\$label" =~ \^\[A-Za-z0-9\]\(\[A-Za-z0-9_-\]\*\[A-Za-z0-9\]\)\?\$ \]\]/);
+    assert.doesNotMatch(script, /\[\[ "\$value" =~ \^\[A-Za-z0-9_.-\]\+\$ \]\]/);
+    assert.notEqual(hostCrlfCheckIndex, -1);
+    assert.notEqual(hostSplitIndex, -1);
+    assert.ok(hostCrlfCheckIndex < hostSplitIndex);
+  }
+
+  const webInit = read("init.sh");
+  const radiusInit = read("init-freeradius.sh");
+
+  assert.doesNotMatch(webInit, /MYSQL_PASSWORD=\$\{MYSQL_PASSWORD:-radpass\}/);
+  assert.doesNotMatch(radiusInit, /MYSQL_PASSWORD=\$\{MYSQL_PASSWORD:-radpass\}/);
+  assert.match(webInit, /MYSQL_PASSWORD=\$\{MYSQL_PASSWORD:-\}/);
+  assert.match(radiusInit, /MYSQL_PASSWORD=\$\{MYSQL_PASSWORD:-\}/);
+  assert.match(webInit, /require_non_empty "DALORADIUS_ADMIN_PASSWORD"/);
+  assert.match(webInit, /validate_optional_no_crlf "DEFAULT_CLIENT_SECRET"/);
+  assert.match(webInit, /validate_optional_no_crlf "MAIL_SMTPADDR"/);
+  assert.match(webInit, /validate_optional_no_crlf "PASSWORD_MIN_LENGTH"/);
+
+  assert.match(radiusInit, /require_non_empty "DEFAULT_CLIENT_SECRET"/);
+  assert.match(radiusInit, /reject_crlf "DEFAULT_CLIENT_SECRET"/);
+  assert.match(radiusInit, /FREERADIUS_SQL_TLS" != "require"/);
+  assert.match(radiusInit, /FREERADIUS_SQL_TLS" != "disabled"/);
 });
 
 test("FreeRADIUS Docker client insertion uses descriptive variable names", () => {

--- a/tests/docker/docker-infra.test.js
+++ b/tests/docker/docker-infra.test.js
@@ -425,7 +425,8 @@ test("Critical Docker init database operations do not dump raw command errors", 
   assert.match(webInit, /fail_step "daloradius_schema_import" "schema_import_failed"/);
   assert.match(webInit, /log_event "info" "daloradius_schema_import" "success" "schema_imported"/);
   assert.match(webInit, /log_event "info" "admin_password_update" "start" "updating_admin_password"/);
-  assert.match(webInit, /2>>"\$INIT_ERROR_LOG" \|\| fail_step "admin_password_update" "admin_password_update_failed"/);
+  assert.match(webInit, /mysql --defaults-extra-file="\$MYSQL_DEFAULTS_FILE" "\$MYSQL_DATABASE" 2>>"\$INIT_ERROR_LOG" <<EOSQL\nUPDATE operators SET password='\$admin_hash'/);
+  assert.match(webInit, /fail_step "admin_password_update" "admin_password_update_failed"/);
   assert.match(webInit, /log_event "info" "admin_password_update" "success" "admin_password_updated"/);
   assert.match(webInit, /log_event "info" "daloradius_schema_check" "start" "checking_schema"/);
   assert.match(webInit, /log_event "info" "daloradius_schema_check" "success" "schema_present"/);
@@ -618,8 +619,30 @@ test("Operator passwords are hashed and Docker admin password is explicit", () =
   assert.doesNotMatch(seedSql, /'administrator','radius'/);
   assert.match(webInit, /DALORADIUS_ADMIN_PASSWORD=\$\{DALORADIUS_ADMIN_PASSWORD:-\}/);
   assert.match(webInit, /function set_admin_password/);
-  assert.match(webInit, /password_hash\(\$argv\[1\], PASSWORD_DEFAULT\)/);
+  assert.doesNotMatch(webInit, /password_hash\(\$argv\[1\]/);
+  assert.doesNotMatch(webInit, /php\b[^\n|;&]*\$DALORADIUS_ADMIN_PASSWORD/);
   assert.match(installer, /INIT_PASSWORD_HASH=\$\(php -r 'echo password_hash\(\$argv\[1\], PASSWORD_DEFAULT\);'/);
+});
+
+test("Docker init database writes do not pass secrets through process arguments", () => {
+  const webInit = read("init.sh");
+  const radiusInit = read("init-freeradius.sh");
+  const adminPasswordUpdate = functionBody(webInit, "set_admin_password").match(
+    /mysql\b[\s\S]*?fail_step "admin_password_update" "admin_password_update_failed"/,
+  );
+  const nasInsertMatch = radiusInit.match(/mysql\b[\s\S]*?INSERT INTO nas[\s\S]*?fail_step "nas_client_insert" "client_insert_failed"/);
+
+  assert.notEqual(adminPasswordUpdate, null, "admin password update mysql command should be present");
+  assert.doesNotMatch(webInit, /mysql\b[\s\S]*?-e\s+"UPDATE operators SET password=/);
+  assert.match(adminPasswordUpdate[0], /<<[-]?'?[A-Z_]*'?/);
+  assert.doesNotMatch(adminPasswordUpdate[0].split(/<<[-]?'?[A-Z_]*'?/)[0], /\$admin_hash/);
+  assert.match(adminPasswordUpdate[0], /\$admin_hash/);
+
+  assert.notEqual(nasInsertMatch, null, "NAS insert mysql command should be present");
+  assert.doesNotMatch(radiusInit, /mysql\b[^\n]*-e\s+"INSERT INTO nas/);
+  assert.doesNotMatch(nasInsertMatch[0], /mysql\b[\s\S]*?-e\s+"INSERT INTO nas/);
+  assert.match(nasInsertMatch[0], /<<[-]?'?[A-Z_]*'?/);
+  assert.match(nasInsertMatch[0], /client_secret_sql/);
 });
 
 test("Standalone image builds from local context on a supported PHP runtime", () => {

--- a/tests/docker/docker-infra.test.js
+++ b/tests/docker/docker-infra.test.js
@@ -42,3 +42,17 @@ test("Compose runtime state does not live inside the build context", () => {
   assert.match(compose, /radius_freeradius_data:/);
   assert.match(compose, /radius_daloradius_data:/);
 });
+
+test("Docker build context excludes local state and copies only required trees", () => {
+  const dockerignore = read(".dockerignore");
+  const dockerfile = read("Dockerfile");
+
+  for (const ignoredPath of [".git", ".planning", "data/", "internal_data/", "*.log", "*.sql", ".env"]) {
+    assert.match(dockerignore, new RegExp(`^${ignoredPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`, "m"));
+  }
+
+  assert.doesNotMatch(dockerfile, /^ADD \. \/var\/www\/daloradius$/m);
+  assert.match(dockerfile, /^COPY app \/var\/www\/daloradius\/app$/m);
+  assert.match(dockerfile, /^COPY contrib \/var\/www\/daloradius\/contrib$/m);
+  assert.match(dockerfile, /^COPY init\.sh \/var\/www\/daloradius\/init\.sh$/m);
+});

--- a/tests/docker/docker-infra.test.js
+++ b/tests/docker/docker-infra.test.js
@@ -34,6 +34,13 @@ test("Compose limits exposed admin surface and waits for FreeRADIUS health", () 
   assert.match(compose, /radius-web:[\s\S]*?radius:[\s\S]*?condition: service_healthy/);
 });
 
+test("FreeRADIUS healthcheck queries the live status server", () => {
+  const compose = read("docker-compose.yml");
+
+  assert.doesNotMatch(compose, /freeradius -C/);
+  assert.match(compose, /echo 'FreeRADIUS-Statistics-Type = 1' \| radclient -q -r 1 -t 3 127\.0\.0\.1:18121 status adminsecret >\/dev\/null/);
+});
+
 test("Compose runtime state does not live inside the build context", () => {
   const compose = read("docker-compose.yml");
 

--- a/tests/docker/docker-infra.test.js
+++ b/tests/docker/docker-infra.test.js
@@ -1,4 +1,5 @@
 const assert = require("node:assert/strict");
+const childProcess = require("node:child_process");
 const fs = require("node:fs");
 const path = require("node:path");
 const test = require("node:test");
@@ -6,7 +7,7 @@ const test = require("node:test");
 const root = path.resolve(__dirname, "..", "..");
 
 function read(relativePath) {
-  return fs.readFileSync(path.join(root, relativePath), "utf8");
+  return fs.readFileSync(path.join(root, relativePath), "utf8").replace(/\r\n/g, "\n");
 }
 
 function functionBody(script, functionName) {
@@ -18,6 +19,147 @@ function functionBody(script, functionName) {
 
   return script.slice(functionStart, nextFunctionStart);
 }
+
+function trackedFiles(...paths) {
+  return childProcess
+    .execFileSync("git", ["ls-files", "--", ...paths], { cwd: root, encoding: "utf8" })
+    .split(/\r?\n/)
+    .filter(Boolean);
+}
+
+function loggingAndEchoLines(script) {
+  return script
+    .split("\n")
+    .filter((line) => line.includes("log_event") || line.includes("fail_step") || /^\s*echo\b/.test(line))
+    .join("\n");
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function shellVariableReference(variableName) {
+  const escapedName = escapeRegExp(variableName);
+  return new RegExp(`\\$(?:\\{${escapedName}\\}|${escapedName})(?![A-Za-z0-9_])`);
+}
+
+function assertLineOrder(contents, beforeMarker, afterMarker) {
+  const beforeIndex = contents.indexOf(beforeMarker);
+  const afterIndex = contents.indexOf(afterMarker);
+
+  assert.notEqual(beforeIndex, -1, `${beforeMarker.trim()} marker should be present`);
+  assert.notEqual(afterIndex, -1, `${afterMarker.trim()} marker should be present`);
+  assert.ok(beforeIndex < afterIndex, `${beforeMarker.trim()} should appear before ${afterMarker.trim()}`);
+}
+
+test("Secret variable reference matcher catches braced and unbraced shell variables", () => {
+  const matcher = shellVariableReference("DEFAULT_CLIENT_SECRET");
+
+  assert.match("echo $DEFAULT_CLIENT_SECRET", matcher);
+  assert.match("echo ${DEFAULT_CLIENT_SECRET}", matcher);
+  assert.doesNotMatch("fail_step \"validation\" \"missing_required_DEFAULT_CLIENT_SECRET\"", matcher);
+});
+
+test("Line order helper rejects missing markers before comparing order", () => {
+  assert.throws(
+    () => assertLineOrder("setup_mysql_defaults_file\n", "\nvalidate_runtime_config\n", "\nsetup_mysql_defaults_file\n"),
+    /validate_runtime_config/,
+  );
+});
+
+test("Docker compliance cleanup findings remain covered by explicit invariants", () => {
+  const compose = read("docker-compose.yml");
+  const dockerignore = read(".dockerignore");
+  const webInit = read("init.sh");
+  const radiusInit = read("init-freeradius.sh");
+  const composeMysqlServiceMatch = compose.match(/radius-mysql:[\s\S]*?(?=\n  radius:)/);
+  assert.notEqual(composeMysqlServiceMatch, null, "radius-mysql service should be present");
+  const composeMysqlService = composeMysqlServiceMatch[0];
+  const scriptBundle = `${webInit}\n${radiusInit}`;
+  const loggingLines = `${loggingAndEchoLines(webInit)}\n${loggingAndEchoLines(radiusInit)}`;
+  const discoverCidr = functionBody(radiusInit, "discover_container_cidr");
+  const prepareLogs = functionBody(radiusInit, "prepare_freeradius_logs");
+
+  const complianceFindings = [
+    [
+      "no tracked or build-context .env defaults",
+      () => {
+        assert.doesNotMatch(compose, /radiusdbpw|radiusrootdbpw|testing123/);
+        assert.match(dockerignore, /^\.env$/m);
+        assert.deepEqual(trackedFiles(".env"), []);
+      },
+    ],
+    [
+      "MariaDB 3306 is internal only",
+      () => {
+        assert.doesNotMatch(composeMysqlService, /^\s*ports:/m);
+      },
+    ],
+    [
+      "FreeRADIUS SQL TLS compose mode is explicit",
+      () => {
+        assert.match(compose, /FREERADIUS_SQL_TLS=\$\{FREERADIUS_SQL_TLS:\?Set FREERADIUS_SQL_TLS to require or disabled\}/);
+        assert.doesNotMatch(compose, /FREERADIUS_SQL_TLS=\$\{FREERADIUS_SQL_TLS:-disabled\}/);
+        assert.match(radiusInit, /FREERADIUS_SQL_TLS=\$\{FREERADIUS_SQL_TLS:-require\}/);
+      },
+    ],
+    [
+      "Docker init scripts do not disable MySQL SSL checks",
+      () => assert.doesNotMatch(scriptBundle, /--skip-ssl/),
+    ],
+    [
+      "FreeRADIUS logs use grouped permissions",
+      () => {
+        assert.doesNotMatch(radiusInit, /chmod -R a\+rX/);
+        assert.match(prepareLogs, /chown -R freerad:33 \/var\/log\/freeradius 2>>"\$INIT_ERROR_LOG"/);
+        assert.match(prepareLogs, /find \/var\/log\/freeradius -type d -exec chmod 2750 \{\} \+ 2>>"\$INIT_ERROR_LOG"/);
+        assert.match(prepareLogs, /find \/var\/log\/freeradius -type f -exec chmod 0640 \{\} \+ 2>>"\$INIT_ERROR_LOG"/);
+      },
+    ],
+    [
+      "structured logs and echo lines do not print secrets",
+      () => {
+        for (const secretVariable of [
+          "DEFAULT_CLIENT_SECRET",
+          "MYSQL_PASSWORD",
+          "DALORADIUS_ADMIN_PASSWORD",
+          "admin_hash",
+          "client_secret_sql",
+        ]) {
+          assert.doesNotMatch(loggingLines, shellVariableReference(secretVariable));
+        }
+      },
+    ],
+    [
+      "env-derived identifiers, hosts, and ports are validated before use",
+      () => {
+        for (const script of [webInit, radiusInit]) {
+          assertLineOrder(script, "\nvalidate_runtime_config\n", "\nsetup_mysql_defaults_file\n");
+          assert.match(script, /function require_sql_identifier/);
+          assert.match(script, /function require_host_token/);
+          assert.match(script, /function require_mysql_port/);
+        }
+      },
+    ],
+    [
+      "critical Docker init writes and permissions are guarded",
+      () => {
+        for (const script of [webInit, radiusInit]) {
+          assert.match(functionBody(script, "setup_mysql_defaults_file"), /fail_step "mysql_defaults_setup" "defaults_file_write_failed"/);
+          assert.match(functionBody(script, "write_lock"), /fail_step "\$event" "lock_write_failed"/);
+          assert.match(functionBody(script, "setup_error_log"), /fail_step "error_log_setup" "error_log_create_failed"/);
+        }
+
+        assert.match(discoverCidr, /fail_step "cidr_discovery" "container_cidr_discovery_failed"/);
+        assert.match(prepareLogs, /fail_step "freeradius_log_permissions" "log_file_mode_failed"/);
+      },
+    ],
+  ];
+
+  for (const [finding, assertInvariant] of complianceFindings) {
+    assert.doesNotThrow(assertInvariant, finding);
+  }
+});
 
 test("FreeRADIUS image uses one executable startup directive", () => {
   const dockerfile = read("Dockerfile-freeradius");
@@ -451,10 +593,10 @@ test("FreeRADIUS Docker client insertion uses descriptive variable names", () =>
   const radiusInit = read("init-freeradius.sh");
 
   assert.doesNotMatch(radiusInit, /^\s*(IP|NM|CIDR|SECRET)=/m);
-  assert.match(radiusInit, /container_ip_address=/);
-  assert.match(radiusInit, /container_netmask=/);
-  assert.match(radiusInit, /container_cidr=/);
-  assert.match(radiusInit, /client_secret=/);
+  assert.match(radiusInit, /^\s*(?:if ! )?container_ip_address=/m);
+  assert.match(radiusInit, /^\s*(?:if ! )?container_netmask=/m);
+  assert.match(radiusInit, /^\s*(?:if ! )?container_cidr=/m);
+  assert.match(radiusInit, /^\s*client_secret=/m);
 });
 
 test("Operator passwords are hashed and Docker admin password is explicit", () => {

--- a/tests/docker/docker-infra.test.js
+++ b/tests/docker/docker-infra.test.js
@@ -563,7 +563,26 @@ test("Docker init scripts guard critical file configuration steps", () => {
   assert.match(radiusInitBody, /log_event "info" "freeradius_init" "start" "configuring_freeradius"/);
   assert.match(radiusInitBody, /run_freeradius_sed/);
   assert.match(radiusInitBody, /run_freeradius_link/);
+  assert.match(radiusInitBody, /chown root:freerad "\$RADIUS_PATH\/mods-available\/sql" 2>>"\$INIT_ERROR_LOG"/);
+  assert.match(radiusInitBody, /fail_step "freeradius_init" "sql_config_owner_failed"/);
+  assert.match(radiusInitBody, /chmod 0640 "\$RADIUS_PATH\/mods-available\/sql" 2>>"\$INIT_ERROR_LOG"/);
+  assert.match(radiusInitBody, /fail_step "freeradius_init" "sql_config_mode_failed"/);
   assert.match(radiusInitBody, /log_event "info" "freeradius_init" "success" "freeradius_configured"/);
+  assertLineOrder(
+    radiusInitBody,
+    'sql_config_set "password" "$MYSQL_PASSWORD"',
+    'chown root:freerad "$RADIUS_PATH/mods-available/sql" 2>>"$INIT_ERROR_LOG"',
+  );
+  assertLineOrder(
+    radiusInitBody,
+    'run_freeradius_sed "s|testing123|$(escape_sed_replacement "$(freeradius_quote_escape "$DEFAULT_CLIENT_SECRET")")|" "$RADIUS_PATH/mods-available/sql"',
+    'chmod 0640 "$RADIUS_PATH/mods-available/sql" 2>>"$INIT_ERROR_LOG"',
+  );
+  assertLineOrder(
+    radiusInitBody,
+    'chmod 0640 "$RADIUS_PATH/mods-available/sql" 2>>"$INIT_ERROR_LOG"',
+    'log_event "info" "freeradius_init" "success" "freeradius_configured"',
+  );
   assert.match(radiusInit, /function run_freeradius_sed/);
   assert.match(radiusInit, /function run_freeradius_link/);
   assert.match(radiusInit, /sed -i "\$@" 2>>"\$INIT_ERROR_LOG" \|\| fail_step "freeradius_init" "config_update_failed"/);

--- a/tests/docker/docker-infra.test.js
+++ b/tests/docker/docker-infra.test.js
@@ -24,6 +24,8 @@ test("Compose avoids insecure local defaults", () => {
   assert.match(compose, /MYSQL_ROOT_PASSWORD=\$\{MYSQL_ROOT_PASSWORD:\?Set MYSQL_ROOT_PASSWORD\}/);
   assert.match(compose, /DEFAULT_CLIENT_SECRET=\$\{DEFAULT_CLIENT_SECRET:\?Set DEFAULT_CLIENT_SECRET\}/);
   assert.match(compose, /DALORADIUS_ADMIN_PASSWORD=\$\{DALORADIUS_ADMIN_PASSWORD:\?Set DALORADIUS_ADMIN_PASSWORD\}/);
+  assert.doesNotMatch(compose, /FREERADIUS_SQL_TLS=\$\{FREERADIUS_SQL_TLS:-disabled\}/);
+  assert.match(compose, /FREERADIUS_SQL_TLS=\$\{FREERADIUS_SQL_TLS:\?Set FREERADIUS_SQL_TLS to require or disabled\}/);
 });
 
 test("Compose limits exposed admin surface and waits for FreeRADIUS health", () => {

--- a/tests/docker/docker-infra.test.js
+++ b/tests/docker/docker-infra.test.js
@@ -104,3 +104,26 @@ test("Docker init scripts escape environment-derived config values", () => {
   assert.match(radiusInit, /function require_default_client_secret/);
   assert.doesNotMatch(radiusInit, /echo "Adding client .*secret \$SECRET"/);
 });
+
+test("Operator passwords are hashed and Docker admin password is explicit", () => {
+  const login = read("app/operators/dologin.php");
+  const operatorNew = read("app/operators/config-operators-new.php");
+  const operatorEdit = read("app/operators/config-operators-edit.php");
+  const helper = read("app/operators/library/operator_passwords.php");
+  const seedSql = read("contrib/db/mariadb-daloradius.sql");
+  const webInit = read("init.sh");
+  const installer = read("setup/install.sh");
+
+  assert.match(helper, /function operator_password_hash/);
+  assert.match(helper, /function operator_password_verify/);
+  assert.doesNotMatch(login, /where username='%s' and password='%s'/i);
+  assert.match(login, /operator_password_verify\(\$operator_pass, \$row\['password'\]\)/);
+  assert.match(operatorNew, /operator_password_hash\(\$operator_password\)/);
+  assert.match(operatorEdit, /operator_password_hash\(\$operator_password\)/);
+  assert.match(operatorEdit, /"value" => ""/);
+  assert.doesNotMatch(seedSql, /'administrator','radius'/);
+  assert.match(webInit, /DALORADIUS_ADMIN_PASSWORD=\$\{DALORADIUS_ADMIN_PASSWORD:-\}/);
+  assert.match(webInit, /function set_admin_password/);
+  assert.match(webInit, /password_hash\(\$argv\[1\], PASSWORD_DEFAULT\)/);
+  assert.match(installer, /INIT_PASSWORD_HASH=\$\(php -r 'echo password_hash\(\$argv\[1\], PASSWORD_DEFAULT\);'/);
+});

--- a/tests/docker/docker-infra.test.js
+++ b/tests/docker/docker-infra.test.js
@@ -162,7 +162,8 @@ test("Docker init scripts do not expose DB passwords in process arguments", () =
     const script = read(scriptPath);
 
     assert.doesNotMatch(script, /-p"\$MYSQL_PASSWORD"/);
-    assert.match(script, /MYSQL_DEFAULTS_FILE=\$\(mktemp\)/);
+    assert.match(script, /function setup_mysql_defaults_file/);
+    assert.match(script, /MYSQL_DEFAULTS_FILE="\$defaults_file"/);
     assert.match(script, /--defaults-extra-file="\$MYSQL_DEFAULTS_FILE"/);
   }
 });
@@ -189,7 +190,7 @@ test("Docker init scripts validate runtime configuration before creating default
   for (const scriptPath of ["init.sh", "init-freeradius.sh"]) {
     const script = read(scriptPath);
     const validationCallIndex = script.indexOf("\nvalidate_runtime_config\n");
-    const defaultsFileIndex = script.indexOf("MYSQL_DEFAULTS_FILE=$(mktemp)");
+    const defaultsFileIndex = script.indexOf("\nsetup_mysql_defaults_file\n");
 
     assert.match(script, /function validate_runtime_config/);
     assert.notEqual(validationCallIndex, -1);
@@ -240,6 +241,210 @@ test("Docker init scripts validate runtime configuration before creating default
   assert.match(radiusInit, /reject_crlf "DEFAULT_CLIENT_SECRET"/);
   assert.match(radiusInit, /FREERADIUS_SQL_TLS" != "require"/);
   assert.match(radiusInit, /FREERADIUS_SQL_TLS" != "disabled"/);
+});
+
+test("Docker init scripts use structured redacted init logging", () => {
+  for (const scriptPath of ["init.sh", "init-freeradius.sh"]) {
+    const script = read(scriptPath);
+    const logEvent = functionBody(script, "log_event");
+    const failStep = functionBody(script, "fail_step");
+    const validationHelpers = [
+      "require_non_empty",
+      "reject_crlf",
+      "require_positive_integer",
+      "require_mysql_port",
+      "require_sql_identifier",
+      "require_host_token",
+    ].map((helperName) => functionBody(script, helperName)).join("\n");
+
+    assert.match(script, /function log_event/);
+    assert.match(script, /function fail_step/);
+    assert.match(logEvent, /level=%s component=/);
+    assert.match(logEvent, /event=%s outcome=%s detail=%s/);
+    assert.match(logEvent, /component=[a-z-]+-init/);
+    assert.match(failStep, /log_event "error"/);
+    assert.match(failStep, /exit 1/);
+    assert.match(validationHelpers, /fail_step "validation"/);
+    assert.doesNotMatch(validationHelpers, /echo "\$name must/);
+    assert.doesNotMatch(validationHelpers, /echo "FREERADIUS_SQL_TLS must/);
+  }
+});
+
+test("Critical Docker init database operations do not dump raw command errors", () => {
+  const webInit = read("init.sh");
+  const radiusInit = read("init-freeradius.sh");
+
+  assert.match(webInit, /INIT_ERROR_LOG=\$\{INIT_ERROR_LOG:-\/data\/daloradius-init-errors\.log\}/);
+  assert.match(webInit, /log_event "info" "mysql_wait" "start" "waiting_for_mysql"/);
+  assert.match(webInit, /mysqladmin --defaults-extra-file="\$MYSQL_DEFAULTS_FILE" ping --silent >\/dev\/null 2>>"\$INIT_ERROR_LOG"/);
+  assert.match(webInit, /fail_step "mysql_wait" "mysql_wait_timeout"/);
+  assert.match(webInit, /log_event "info" "daloradius_schema_import" "start" "importing_schema"/);
+  assert.match(webInit, /mysql --defaults-extra-file="\$MYSQL_DEFAULTS_FILE" "\$MYSQL_DATABASE" < "\$DALORADIUS_PATH\/contrib\/db\/mariadb-daloradius\.sql" 2>>"\$INIT_ERROR_LOG"/);
+  assert.match(webInit, /fail_step "daloradius_schema_import" "schema_import_failed"/);
+  assert.match(webInit, /log_event "info" "daloradius_schema_import" "success" "schema_imported"/);
+  assert.match(webInit, /log_event "info" "admin_password_update" "start" "updating_admin_password"/);
+  assert.match(webInit, /2>>"\$INIT_ERROR_LOG" \|\| fail_step "admin_password_update" "admin_password_update_failed"/);
+  assert.match(webInit, /log_event "info" "admin_password_update" "success" "admin_password_updated"/);
+  assert.match(webInit, /log_event "info" "daloradius_schema_check" "start" "checking_schema"/);
+  assert.match(webInit, /log_event "info" "daloradius_schema_check" "success" "schema_present"/);
+  assert.match(webInit, /fail_step "daloradius_schema_check" "schema_post_check_failed"/);
+
+  assert.match(radiusInit, /INIT_ERROR_LOG=\$\{INIT_ERROR_LOG:-\/data\/freeradius-init-errors\.log\}/);
+  assert.match(radiusInit, /log_event "info" "mysql_wait" "start" "waiting_for_mysql"/);
+  assert.match(radiusInit, /mysqladmin --defaults-extra-file="\$MYSQL_DEFAULTS_FILE" ping --silent >\/dev\/null 2>>"\$INIT_ERROR_LOG"/);
+  assert.match(radiusInit, /fail_step "mysql_wait" "mysql_wait_timeout"/);
+  assert.match(radiusInit, /log_event "info" "freeradius_schema_import" "start" "importing_schema"/);
+  assert.match(radiusInit, /mysql --defaults-extra-file="\$MYSQL_DEFAULTS_FILE" "\$MYSQL_DATABASE" < "\$RADIUS_PATH\/mods-config\/sql\/main\/mysql\/schema\.sql" 2>>"\$INIT_ERROR_LOG"/);
+  assert.match(radiusInit, /fail_step "freeradius_schema_import" "schema_import_failed"/);
+  assert.match(radiusInit, /log_event "info" "freeradius_schema_import" "success" "schema_imported"/);
+  assert.match(radiusInit, /log_event "info" "ippool_schema_import" "start" "importing_schema"/);
+  assert.match(radiusInit, /mysql --defaults-extra-file="\$MYSQL_DEFAULTS_FILE" "\$MYSQL_DATABASE" < "\$RADIUS_PATH\/mods-config\/sql\/ippool\/mysql\/schema\.sql" 2>>"\$INIT_ERROR_LOG"/);
+  assert.match(radiusInit, /fail_step "ippool_schema_import" "schema_import_failed"/);
+  assert.match(radiusInit, /log_event "info" "ippool_schema_import" "success" "schema_imported"/);
+  assert.match(radiusInit, /log_event "info" "radhuntgroup_schema_ensure" "start" "ensuring_schema"/);
+  assert.match(radiusInit, /fail_step "radhuntgroup_schema_ensure" "schema_ensure_failed"/);
+  assert.match(radiusInit, /log_event "info" "radhuntgroup_schema_ensure" "success" "schema_ensured"/);
+  assert.match(radiusInit, /log_event "info" "nas_client_insert" "start" "inserting_docker_client"/);
+  assert.match(radiusInit, /fail_step "nas_client_insert" "client_insert_failed"/);
+  assert.match(radiusInit, /log_event "info" "nas_client_insert" "success" "docker_client_inserted"/);
+  assert.match(radiusInit, /fail_step "noresetcounter_config" "noresetcounter_insert_failed"/);
+  assert.match(radiusInit, /log_event "info" "freeradius_schema_check" "start" "checking_schema"/);
+  assert.match(radiusInit, /log_event "info" "freeradius_schema_check" "success" "schema_present"/);
+  assert.match(radiusInit, /fail_step "freeradius_schema_check" "schema_post_check_failed"/);
+});
+
+test("Docker init scripts initialize private error logs before redirection use", () => {
+  for (const scriptPath of ["init.sh", "init-freeradius.sh"]) {
+    const script = read(scriptPath);
+    const setupErrorLog = functionBody(script, "setup_error_log");
+    const setupCallIndex = script.indexOf("\nsetup_error_log\n");
+    const validationCallIndex = script.indexOf("\nvalidate_runtime_config\n");
+    const mysqlDefaultsCallIndex = script.indexOf("\nsetup_mysql_defaults_file\n");
+
+    assert.match(script, /function setup_error_log/);
+    assert.match(setupErrorLog, /: > "\$INIT_ERROR_LOG"; \} 2>\/dev\/null/);
+    assert.match(setupErrorLog, /chmod 600 "\$INIT_ERROR_LOG" 2>\/dev\/null/);
+    assert.match(setupErrorLog, /fail_step "error_log_setup" "error_log_create_failed"/);
+    assert.match(setupErrorLog, /fail_step "error_log_setup" "error_log_chmod_failed"/);
+    assert.doesNotMatch(setupErrorLog, /2>>"\$INIT_ERROR_LOG"/);
+    assert.notEqual(setupCallIndex, -1);
+    assert.notEqual(validationCallIndex, -1);
+    assert.notEqual(mysqlDefaultsCallIndex, -1);
+    assert.ok(setupCallIndex < validationCallIndex);
+    assert.ok(setupCallIndex < mysqlDefaultsCallIndex);
+    assert.doesNotMatch(script, /INIT_ERROR_LOG=\$\{INIT_ERROR_LOG:-\/tmp\//);
+  }
+});
+
+test("Docker init scripts guard MySQL defaults files and lock writes", () => {
+  for (const scriptPath of ["init.sh", "init-freeradius.sh"]) {
+    const script = read(scriptPath);
+    const mysqlDefaults = functionBody(script, "setup_mysql_defaults_file");
+    const writeLock = functionBody(script, "write_lock");
+    const setupErrorLogIndex = script.indexOf("\nsetup_error_log\n");
+    const validateRuntimeIndex = script.indexOf("\nvalidate_runtime_config\n");
+    const setupMysqlIndex = script.indexOf("\nsetup_mysql_defaults_file\n");
+
+    assert.match(mysqlDefaults, /defaults_file="\$\(mktemp\)"/);
+    assert.match(mysqlDefaults, /MYSQL_DEFAULTS_FILE="\$defaults_file"/);
+    assert.match(mysqlDefaults, /chmod 600 "\$MYSQL_DEFAULTS_FILE" 2>>"\$INIT_ERROR_LOG"/);
+    assert.match(mysqlDefaults, /cat 2>>"\$INIT_ERROR_LOG" > "\$MYSQL_DEFAULTS_FILE"/);
+    assert.match(mysqlDefaults, /password=\$MYSQL_PASSWORD/);
+    assert.match(mysqlDefaults, /trap 'rm -f "\$MYSQL_DEFAULTS_FILE"' EXIT/);
+    assert.match(mysqlDefaults, /fail_step "mysql_defaults_setup" "defaults_file_create_failed"/);
+    assert.match(mysqlDefaults, /fail_step "mysql_defaults_setup" "defaults_file_chmod_failed"/);
+    assert.match(mysqlDefaults, /fail_step "mysql_defaults_setup" "defaults_file_write_failed"/);
+    assert.doesNotMatch(mysqlDefaults, /log_event [^\n]*MYSQL_PASSWORD/);
+    assert.match(writeLock, /date 2>>"\$INIT_ERROR_LOG" > "\$lock_path"/);
+    assert.match(writeLock, /fail_step "\$event" "lock_write_failed"/);
+    assert.notEqual(setupErrorLogIndex, -1);
+    assert.notEqual(validateRuntimeIndex, -1);
+    assert.notEqual(setupMysqlIndex, -1);
+    assert.ok(setupErrorLogIndex < validateRuntimeIndex);
+    assert.ok(validateRuntimeIndex < setupMysqlIndex);
+    assert.doesNotMatch(script, /\nMYSQL_DEFAULTS_FILE=\$\(mktemp\)\n/);
+    assert.doesNotMatch(script, /\nchmod 600 "\$MYSQL_DEFAULTS_FILE"\n/);
+    assert.doesNotMatch(script, /\ncat > "\$MYSQL_DEFAULTS_FILE" <<EOF\n/);
+    assert.doesNotMatch(script, /date > "\$(?:INIT|DB)_LOCK"/);
+  }
+});
+
+test("FreeRADIUS init guards CIDR discovery and log permission setup", () => {
+  const radiusInit = read("init-freeradius.sh");
+  const initDatabase = functionBody(radiusInit, "init_database");
+  const discoverCidr = functionBody(radiusInit, "discover_container_cidr");
+  const prepareLogs = functionBody(radiusInit, "prepare_freeradius_logs");
+
+  assert.match(radiusInit, /function discover_container_cidr/);
+  assert.match(initDatabase, /discover_container_cidr/);
+  assert.match(discoverCidr, /container_cidr=/);
+  assert.doesNotMatch(initDatabase, /ifconfig eth0/);
+  assert.doesNotMatch(initDatabase, /ipcalc \$container_ip_address \$container_netmask/);
+  assert.match(discoverCidr, /ifconfig eth0 2>>"\$INIT_ERROR_LOG"/);
+  assert.match(discoverCidr, /fail_step "cidr_discovery" "container_ip_discovery_failed"/);
+  assert.match(discoverCidr, /fail_step "cidr_discovery" "container_netmask_discovery_failed"/);
+  assert.match(discoverCidr, /ipcalc "\$container_ip_address" "\$container_netmask" 2>>"\$INIT_ERROR_LOG"/);
+  assert.match(discoverCidr, /fail_step "cidr_discovery" "container_cidr_discovery_failed"/);
+  assert.match(discoverCidr, /fail_step "cidr_discovery" "container_cidr_empty"/);
+  assert.match(prepareLogs, /chown -R freerad:33 \/var\/log\/freeradius 2>>"\$INIT_ERROR_LOG"/);
+  assert.match(prepareLogs, /fail_step "freeradius_log_permissions" "log_owner_failed"/);
+  assert.match(prepareLogs, /find \/var\/log\/freeradius -type d -exec chmod 2750 \{\} \+ 2>>"\$INIT_ERROR_LOG"/);
+  assert.match(prepareLogs, /fail_step "freeradius_log_permissions" "log_directory_mode_failed"/);
+  assert.match(prepareLogs, /find \/var\/log\/freeradius -type f -exec chmod 0640 \{\} \+ 2>>"\$INIT_ERROR_LOG"/);
+  assert.match(prepareLogs, /fail_step "freeradius_log_permissions" "log_file_mode_failed"/);
+});
+
+test("Docker init scripts guard critical file configuration steps", () => {
+  const webInit = read("init.sh");
+  const radiusInit = read("init-freeradius.sh");
+  const webConfigSet = functionBody(webInit, "php_config_set");
+  const webInitBody = functionBody(webInit, "init_daloradius");
+  const radiusConfigSet = functionBody(radiusInit, "sql_config_set");
+  const radiusInitBody = functionBody(radiusInit, "init_freeradius");
+  const noresetcounterBody = functionBody(radiusInit, "enable_noresetcounter");
+
+  assert.match(webConfigSet, /sed -i[\s\S]*2>>"\$INIT_ERROR_LOG"/);
+  assert.match(webConfigSet, /fail_step "daloradius_init" "config_update_failed"/);
+  assert.match(webInitBody, /log_event "info" "daloradius_init" "start" "configuring_daloradius"/);
+  assert.match(webInitBody, /cp "\$DALORADIUS_CONF_PATH\.sample" "\$DALORADIUS_CONF_PATH" 2>>"\$INIT_ERROR_LOG"/);
+  assert.match(webInitBody, /fail_step "daloradius_init" "config_copy_failed"/);
+  assert.match(webInitBody, /chown www-data:www-data "\$DALORADIUS_CONF_PATH" 2>>"\$INIT_ERROR_LOG"/);
+  assert.match(webInitBody, /fail_step "daloradius_init" "config_owner_failed"/);
+  assert.match(webInitBody, /chmod 0644 "\$DALORADIUS_CONF_PATH" 2>>"\$INIT_ERROR_LOG"/);
+  assert.match(webInitBody, /fail_step "daloradius_init" "config_mode_failed"/);
+  assert.match(webInitBody, /log_event "info" "daloradius_init" "success" "daloradius_configured"/);
+
+  assert.match(radiusConfigSet, /sed -i[\s\S]*2>>"\$INIT_ERROR_LOG"/);
+  assert.match(radiusConfigSet, /fail_step "freeradius_init" "sql_config_update_failed"/);
+  assert.match(radiusInitBody, /log_event "info" "freeradius_init" "start" "configuring_freeradius"/);
+  assert.match(radiusInitBody, /run_freeradius_sed/);
+  assert.match(radiusInitBody, /run_freeradius_link/);
+  assert.match(radiusInitBody, /log_event "info" "freeradius_init" "success" "freeradius_configured"/);
+  assert.match(radiusInit, /function run_freeradius_sed/);
+  assert.match(radiusInit, /function run_freeradius_link/);
+  assert.match(radiusInit, /sed -i "\$@" 2>>"\$INIT_ERROR_LOG" \|\| fail_step "freeradius_init" "config_update_failed"/);
+  assert.match(radiusInit, /ln -sf "\$@" 2>>"\$INIT_ERROR_LOG" \|\| fail_step "freeradius_init" "config_link_failed"/);
+  assert.match(noresetcounterBody, /2>>"\$INIT_ERROR_LOG" > \/tmp\/freeradius-default/);
+  assert.match(noresetcounterBody, /mv \/tmp\/freeradius-default "\$RADIUS_PATH\/sites-available\/default" 2>>"\$INIT_ERROR_LOG"/);
+  assert.match(noresetcounterBody, /fail_step "noresetcounter_config" "noresetcounter_apply_failed"/);
+});
+
+test("Docker init structured logs do not interpolate secret values", () => {
+  for (const scriptPath of ["init.sh", "init-freeradius.sh"]) {
+    const script = read(scriptPath);
+    const loggingCalls = script
+      .split("\n")
+      .filter((line) => line.includes("log_event") || line.includes("fail_step"))
+      .join("\n");
+
+    assert.doesNotMatch(loggingCalls, /\$MYSQL_PASSWORD/);
+    assert.doesNotMatch(loggingCalls, /\$MYSQL_ROOT_PASSWORD/);
+    assert.doesNotMatch(loggingCalls, /\$DEFAULT_CLIENT_SECRET/);
+    assert.doesNotMatch(loggingCalls, /\$DALORADIUS_ADMIN_PASSWORD/);
+    assert.doesNotMatch(loggingCalls, /\$admin_hash/);
+    assert.doesNotMatch(loggingCalls, /password=.*\$/i);
+    assert.doesNotMatch(loggingCalls, /secret=.*\$/i);
+  }
 });
 
 test("FreeRADIUS Docker client insertion uses descriptive variable names", () => {

--- a/tests/docker/docker-infra.test.js
+++ b/tests/docker/docker-infra.test.js
@@ -180,6 +180,78 @@ test("Compose avoids insecure local defaults", () => {
   assert.match(compose, /FREERADIUS_SQL_TLS=\$\{FREERADIUS_SQL_TLS:\?Set FREERADIUS_SQL_TLS to require or disabled\}/);
 });
 
+test("Docker Compose env example is a safe copyable template", () => {
+  const envExamplePath = path.join(root, ".env.example");
+  const dockerignore = read(".dockerignore");
+  const gitignore = read(".gitignore");
+  const insecureDefaults = [
+    "radiusdbpw",
+    "radiusrootdbpw",
+    "testing123",
+    "radpass",
+    "local-db-",
+    "local-root-",
+    "local-radius-",
+    "local-admin-",
+  ];
+
+  assert.ok(fs.existsSync(envExamplePath), ".env.example should exist");
+
+  const envExample = read(".env.example");
+  const templateValues = {};
+
+  for (const line of envExample.split("\n")) {
+    const match = line.match(/^\s*#?\s*([A-Z0-9_]+)=(.*)$/);
+    if (match) {
+      templateValues[match[1]] = match[2];
+    }
+  }
+
+  const values = Object.fromEntries(
+    envExample
+      .split("\n")
+      .filter((line) => line.trim() && !line.trimStart().startsWith("#"))
+      .map((line) => line.split("=", 2)),
+  );
+
+  for (const variableName of [
+    "MYSQL_PASSWORD",
+    "MYSQL_ROOT_PASSWORD",
+    "DEFAULT_CLIENT_SECRET",
+    "DALORADIUS_ADMIN_PASSWORD",
+    "FREERADIUS_SQL_TLS",
+  ]) {
+    assert.ok(Object.hasOwn(templateValues, variableName), `${variableName} should be represented in .env.example`);
+  }
+
+  for (const secretVariable of [
+    "MYSQL_PASSWORD",
+    "MYSQL_ROOT_PASSWORD",
+    "DEFAULT_CLIENT_SECRET",
+    "DALORADIUS_ADMIN_PASSWORD",
+  ]) {
+    assert.match(
+      templateValues[secretVariable],
+      /^CHANGE_ME_[A-Z0-9_]+$/,
+      `${secretVariable} should use a CHANGE_ME placeholder`,
+    );
+  }
+
+  assert.match(templateValues.FREERADIUS_SQL_TLS, /^(require|disabled)$/);
+  assert.doesNotMatch(envExample, /^\s*[A-Z0-9_]+=CHANGE_ME_[A-Z0-9_]*$/m);
+  assert.deepEqual(values, {}, ".env.example should not contain active variable assignments");
+
+  for (const insecureDefault of insecureDefaults) {
+    assert.doesNotMatch(envExample, new RegExp(escapeRegExp(insecureDefault)));
+  }
+
+  assert.match(dockerignore, /^\.env$/m);
+  assert.match(dockerignore, /^\.env\.\*$/m);
+  assert.match(gitignore, /^\.env$/m);
+  assert.match(gitignore, /^\.env\.\*$/m);
+  assert.match(gitignore, /^!\.env\.example$/m);
+});
+
 test("Compose limits exposed admin surface and waits for FreeRADIUS health", () => {
   const compose = read("docker-compose.yml");
 

--- a/tests/docker/docker-infra.test.js
+++ b/tests/docker/docker-infra.test.js
@@ -15,3 +15,30 @@ test("FreeRADIUS image uses one executable startup directive", () => {
   assert.match(dockerfile, /^ENTRYPOINT \["\/app\/init-freeradius\.sh"\]$/m);
   assert.doesNotMatch(dockerfile, /^CMD \["\/app\/init-freeradius\.sh"\]$/m);
 });
+
+test("Compose avoids insecure local defaults", () => {
+  const compose = read("docker-compose.yml");
+
+  assert.doesNotMatch(compose, /radiusdbpw|radiusrootdbpw|testing123/);
+  assert.match(compose, /MYSQL_PASSWORD=\$\{MYSQL_PASSWORD:\?Set MYSQL_PASSWORD\}/);
+  assert.match(compose, /MYSQL_ROOT_PASSWORD=\$\{MYSQL_ROOT_PASSWORD:\?Set MYSQL_ROOT_PASSWORD\}/);
+  assert.match(compose, /DEFAULT_CLIENT_SECRET=\$\{DEFAULT_CLIENT_SECRET:\?Set DEFAULT_CLIENT_SECRET\}/);
+  assert.match(compose, /DALORADIUS_ADMIN_PASSWORD=\$\{DALORADIUS_ADMIN_PASSWORD:\?Set DALORADIUS_ADMIN_PASSWORD\}/);
+});
+
+test("Compose limits exposed admin surface and waits for FreeRADIUS health", () => {
+  const compose = read("docker-compose.yml");
+
+  assert.match(compose, /'\$\{DALORADIUS_OPERATORS_BIND:-127\.0\.0\.1:8000\}:8000'/);
+  assert.match(compose, /radius:[\s\S]*?healthcheck:/);
+  assert.match(compose, /radius-web:[\s\S]*?radius:[\s\S]*?condition: service_healthy/);
+});
+
+test("Compose runtime state does not live inside the build context", () => {
+  const compose = read("docker-compose.yml");
+
+  assert.doesNotMatch(compose, /\.\.?\s*\/data|\.\/data|"\.\/data|'\.\/data/);
+  assert.match(compose, /radius_mysql:/);
+  assert.match(compose, /radius_freeradius_data:/);
+  assert.match(compose, /radius_daloradius_data:/);
+});

--- a/tests/docker/docker-infra.test.js
+++ b/tests/docker/docker-infra.test.js
@@ -141,3 +141,24 @@ test("Standalone image builds from local context on a supported PHP runtime", ()
   assert.match(readme, /docker build -t daloradius-standalone -f Dockerfile-standalone \./);
   assert.doesNotMatch(readme, /dormancygrace\/daloradius/);
 });
+
+test("Containers use Docker-friendly process, log, and hardening defaults", () => {
+  const webInit = read("init.sh");
+  const radiusInit = read("init-freeradius.sh");
+  const usersConf = read("contrib/docker/users.conf");
+  const operatorsConf = read("contrib/docker/operators.conf");
+  const compose = read("docker-compose.yml");
+
+  assert.match(webInit, /exec \/usr\/sbin\/apachectl -DFOREGROUND -k start/);
+  assert.match(radiusInit, /RADIUS_STATUS=\$\?/);
+  assert.match(radiusInit, /exit "\$RADIUS_STATUS"/);
+  assert.doesNotMatch(radiusInit, /chmod -R a\+rX/);
+  assert.match(radiusInit, /FREERADIUS_SQL_TLS=\$\{FREERADIUS_SQL_TLS:-require\}/);
+  assert.match(radiusInit, /if \[ "\$FREERADIUS_SQL_TLS" = "disabled" \]/);
+  assert.match(usersConf, /ErrorLog \/proc\/self\/fd\/2/);
+  assert.match(usersConf, /CustomLog \/proc\/self\/fd\/1 combined/);
+  assert.match(operatorsConf, /ErrorLog \/proc\/self\/fd\/2/);
+  assert.match(operatorsConf, /CustomLog \/proc\/self\/fd\/1 combined/);
+  assert.match(compose, /security_opt:[\s\S]*no-new-privileges:true/);
+  assert.match(compose, /cap_drop:[\s\S]*- NET_RAW/);
+});

--- a/tests/docker/docker-infra.test.js
+++ b/tests/docker/docker-infra.test.js
@@ -56,3 +56,28 @@ test("Docker build context excludes local state and copies only required trees",
   assert.match(dockerfile, /^COPY contrib \/var\/www\/daloradius\/contrib$/m);
   assert.match(dockerfile, /^COPY init\.sh \/var\/www\/daloradius\/init\.sh$/m);
 });
+
+test("Docker init scripts fail fast and use bounded database waits", () => {
+  for (const scriptPath of ["init.sh", "init-freeradius.sh"]) {
+    const script = read(scriptPath);
+
+    assert.match(script, /^set -euo pipefail$/m);
+    assert.match(script, /MYSQL_WAIT_RETRIES=\$\{MYSQL_WAIT_RETRIES:-30\}/);
+    assert.match(script, /function wait_for_mysql/);
+    assert.match(script, /while ! mysqladmin ping/);
+    assert.match(script, /if \[ "\$attempt" -ge "\$MYSQL_WAIT_RETRIES" \]/);
+  }
+});
+
+test("Database initialization locks are backed by schema checks", () => {
+  const webInit = read("init.sh");
+  const radiusInit = read("init-freeradius.sh");
+
+  assert.match(webInit, /function daloradius_schema_ready/);
+  assert.match(webInit, /if daloradius_schema_ready; then[\s\S]*Database schema already present/);
+  assert.match(webInit, /init_database[\s\S]*if ! daloradius_schema_ready; then/);
+
+  assert.match(radiusInit, /function freeradius_schema_ready/);
+  assert.match(radiusInit, /if freeradius_schema_ready; then[\s\S]*Database schema already present/);
+  assert.match(radiusInit, /init_database[\s\S]*if ! freeradius_schema_ready; then/);
+});


### PR DESCRIPTION
Harden Docker deployment, add explicit environment configuration, and support legacy database imports

## Summary

With the strong assistance of Codex, I resumed the `PR #643`. This PR hardens the Docker deployment path for daloRADIUS and FreeRADIUS, removes insecure runtime defaults, adds a copyable environment template, improves container initialization safety, and adds a robust import workflow for existing MariaDB dumps.

The import workflow supports legacy non-Docker databases whose schema may not match the current Docker runtime, including legacy `operators.password` columns that are too narrow for PHP `password_hash()` values. Imported daloRADIUS operator passwords are converted before the full application stack starts.


## Technical Changes

### Docker Compose and Runtime Configuration

- Added a root `.env.example` template with required and optional Docker variables.
- Required explicit secrets for:
  - `MYSQL_PASSWORD`
  - `MYSQL_ROOT_PASSWORD`
  - `DEFAULT_CLIENT_SECRET`
  - `DALORADIUS_ADMIN_PASSWORD`
  - `FREERADIUS_SQL_TLS`
- Added configurable optional runtime values:
  - `DALORADIUS_OPERATORS_BIND`
  - `TZ`
  - `MAIL_SMTPADDR`
  - `MAIL_PORT`
  - `MAIL_FROM`
  - `MAIL_AUTH`
- Updated `docker-compose.yml` to fail fast when required environment variables are missing.
- Limited the operators UI default bind address to `127.0.0.1:8000`.
- Kept the users UI exposed on port `80`.
- Added Docker volumes for persistent database, FreeRADIUS data, daloRADIUS data, and shared FreeRADIUS logs.
- Added health checks and dependency ordering so `radius` and `radius-web` wait for the database and FreeRADIUS where appropriate.

### Secret Handling and Init Script Hardening

- Reworked database client usage in Docker init scripts to avoid passing database passwords as process arguments.
- Added temporary MariaDB client defaults files with restricted permissions for sensitive database operations.
- Added explicit runtime environment validation in `init.sh` and `init-freeradius.sh`.
- Added bounded database wait loops instead of open-ended startup behavior.
- Added structured, redacted init logging for startup operations.
- Hardened init error paths to avoid leaking raw command output containing sensitive values.
- Restricted generated daloRADIUS and FreeRADIUS configuration file permissions.
- Escaped environment-derived configuration values before writing config files.

### FreeRADIUS Docker Improvements

- Removed duplicate or conflicting startup behavior.
- Copied the FreeRADIUS init script explicitly into the image.
- Normalized copied runtime shell scripts for CRLF compatibility.
- Clarified FreeRADIUS client variable naming.
- Required an explicit `FREERADIUS_SQL_TLS` mode instead of silently defaulting.
- Avoided unnecessary SQL churn in the FreeRADIUS health check.
- Preserved readable FreeRADIUS logs for the web container through the shared log volume.
- Encoded the NAS shared secret safely when inserting Docker defaults.

### daloRADIUS Web Container Improvements
- Added readable placeholder files for host syslog and boot logs inside the container.
- Updated Docker log handling documentation to direct operators to `docker compose logs`.
- Normalized runtime scripts during image build.
- Reduced Docker build context exposure by adding `.dockerignore` and excluding local state, dumps, logs, runtime data, and `.env`.

### Operator Password Hashing

- Added `app/operators/library/operator_passwords.php`.
- Updated operator login to support PHP password hashes while preserving compatibility with legacy stored values.
- Rehashed operator passwords when needed during successful login.
- Updated operator create/edit flows to store hashed passwords.
- Updated the default daloRADIUS SQL seed so the default operator password is stored as a hash.
- Ensured `DALORADIUS_ADMIN_PASSWORD` is explicit and can be applied safely in Docker initialization.

### Legacy Database Import Workflow

- Added `docker/post-import-migrations/001-operators-password-width.sql`.
  - Widens `operators.password` to `VARCHAR(95) NOT NULL`.
  - Handles legacy dumps where `operators.password` was defined as `VARCHAR(32)`.
- Added `scripts/docker/hash-imported-passwords.php`.
  - Converts imported non-hash operator passwords with `password_hash()`.
  - Resets an existing `administrator` operator to `DALORADIUS_ADMIN_PASSWORD`.
  - Only updates the `operators` table.
  - Does not rewrite user portal passwords or FreeRADIUS authentication attributes such as `radcheck`.
- Added Windows import runner:
  - `scripts/docker/import-backup.ps1`
- Added Linux import runner:
  - `scripts/docker/import-backup.sh`
- Both runners:
  - validate `.env` through `docker compose config --quiet`;
  - validate compressed dumps with `gzip -t`;
  - start only `radius-mysql`;
  - import the dump;
  - apply ordered SQL migrations from `docker/post-import-migrations`;
  - build `radius-web`;
  - convert imported operator passwords before full stack startup;
  - validate required imported tables and `operators.password`;
  - start the full Compose stack last.

### Documentation

- Updated `README.docker-standalone.md` with:
  - required `.env` workflow;
  - normal Docker startup;
  - local bind behavior;
  - log access guidance;
  - legacy database import workflow;
  - operator password conversion behavior;
  - Windows and Linux import commands.
- Added Docker documentation references from `README.md`.
- Prepared a local operational runbook at `doc/setup/docker-operations.md`.
  - It documents normal startup, clean imports, replacement of an existing Docker database volume, post-import checks, and troubleshooting.

### Tests

- Added `tests/docker/docker-infra.test.js`.
- The test suite covers:
  - Compose secret requirements;
  - `.env.example` safety;
  - Docker build context exclusions;
  - runtime image hardening;
  - static asset symlinks;
  - log placeholder behavior;
  - init script validation and bounded waits;
  - secret handling through temporary defaults files;
  - structured redacted logging;
  - operator password hashing behavior;
  - post-import migration assets;
  - Windows and Linux import runner workflow ordering;
  - documentation coverage for legacy imports.

## Operational Notes

### Normal Fresh Docker Startup

Use this path when no existing database needs to be imported:

On Linux:

```bash
cp .env.example .env
docker compose config --quiet
docker compose up -d --build
docker compose ps
```

On  PowerShell:

```powershell
Copy-Item .env.example .env
docker compose config --quiet
docker compose up -d --build
docker compose ps
```

### Updating `DALORADIUS_ADMIN_PASSWORD` After Initialization

The `radius-web` init script applies `DALORADIUS_ADMIN_PASSWORD` to the `administrator` operator every time the container starts:

```sql
UPDATE operators SET password = <hash of DALORADIUS_ADMIN_PASSWORD> WHERE username = 'administrator';
```

If `DALORADIUS_ADMIN_PASSWORD` is changed in `.env` after the first initialization, recreate `radius-web` so Compose creates the container with the new environment:

On Linux:

```bash
docker compose up -d --force-recreate radius-web
```

On PowerShell:

```powershell
docker compose up -d --force-recreate radius-web
```

`docker compose restart radius-web` is not sufficient for this use case because it restarts the existing container with the environment that was set when the container was created.

### Clean Import From Existing Dump

Use this path to replace the Docker database volume and import an existing dump:

On Linux: 

```bash
docker compose down -v --remove-orphans
bash scripts/docker/import-backup.sh ./backup_radius.sql.gz
```

On PowerShell:

```powershell
docker compose down -v --remove-orphans
.\scripts\docker\import-backup.ps1 -DumpPath .\backup_radius.sql.gz
```

The `down -v` step is required for a guaranteed clean replacement of an existing Docker database. Running the import script without removing the existing volume imports into the current database and may leave residual state not covered by the dump.

## Verification

Fresh verification run on this branch:

```bash
node tests/docker/docker-infra.test.js
docker compose config --quiet
docker compose ps
```

Results:

- `tests/docker/docker-infra.test.js`: 39 tests passed, 0 failed.
- `docker compose config --quiet`: passed.
- Compose stack was running locally with:
  - `radius`: healthy;
  - `radius-mysql`: healthy;
  - `radius-web`: running on `127.0.0.1:8000` and port `80`.

Previous full import verification for `backup_radius.sql.gz` confirmed:

- `operator_passwords_converted=8`
- `administrator_password_updated=1`
- `operator_rows=8`
- `non_hash_operator_passwords=0`
- all imported operator password hashes used bcrypt;
- `administrator` verified against `DALORADIUS_ADMIN_PASSWORD`;
- `operators.password` was `VARCHAR(95) NOT NULL`;
- operators UI login succeeded with the configured administrator password.

## Security Considerations

- Secrets are no longer provided through insecure Compose defaults.
- Database passwords are not passed through process arguments for critical Docker init and import operations.
- Generated config files have restricted permissions.
- Init logs are structured and avoid interpolating secret values.
- `.env`, dumps, local runtime data, logs, and SQL dump files are excluded from Docker build context.
- Imported user portal passwords and FreeRADIUS authentication attributes are intentionally not rewritten.

## Compatibility Notes

- The import flow expects gzip-compressed SQL dumps such as `*.sql.gz`.
- `gzip` must be available on the host for the import runners.
- Legacy operator passwords that are not PHP password hashes are converted during the post-import phase.
- The `administrator` operator is reset to `DALORADIUS_ADMIN_PASSWORD` only if that operator exists in the imported database.
- Changing `DALORADIUS_ADMIN_PASSWORD` after initialization updates the database when `radius-web` is recreated with the new environment value.
- For clean replacement of an existing Docker database, remove Compose volumes before import.

## Files Changed

Tracked branch changes relative to `origin/master` base `4e83e20f`:

- `.dockerignore`
- `.env.example`
- `.gitignore`
- `Dockerfile`
- `Dockerfile-freeradius`
- `Dockerfile-standalone`
- `README.docker-standalone.md`
- `README.md`
- `app/operators/config-operators-edit.php`
- `app/operators/config-operators-new.php`
- `app/operators/dologin.php`
- `app/operators/library/operator_passwords.php`
- `contrib/db/mariadb-daloradius.sql`
- `contrib/docker/operators.conf`
- `contrib/docker/users.conf`
- `docker-compose.yml`
- `docker/post-import-migrations/001-operators-password-width.sql`
- `init-freeradius.sh`
- `init.sh`
- `scripts/docker/hash-imported-passwords.php`
- `scripts/docker/import-backup.ps1`
- `scripts/docker/import-backup.sh`
- `setup/install.sh`
- `tests/docker/docker-infra.test.js`
