### PR TITLE
fix: lock disabled users group priority

### DIFF
--- a/app/operators/bill-pos-edit.php
+++ b/app/operators/bill-pos-edit.php
@@ -63,10 +63,11 @@
 
             // if profiles are associated with this plan, loop through each and add a usergroup entry for each
             foreach($cols as $profile_name) {
-                $sql = sprintf("INSERT INTO %s (username, groupname, priority) VALUES ('%s','%s','0')",
+                $priority = normalize_user_group_priority($profile_name, 0);
+                $sql = sprintf("INSERT INTO %s (username, groupname, priority) VALUES ('%s','%s',%d)",
                                $configValues['CONFIG_DB_TBL_RADUSERGROUP'],
                                $dbSocket->escapeSimple($username),
-                               $dbSocket->escapeSimple($profile_name));
+                               $dbSocket->escapeSimple($profile_name), $priority);
                 $res = $dbSocket->query($sql);
             }
         }
@@ -96,6 +97,7 @@
                 }
 
                 $priority = (!empty($groups_priority[$i])) ? $groups_priority[$i] : "0";
+                $priority = normalize_user_group_priority($group, $priority);
 
                 $sql = sprintf($insert_group_format,
                                $configValues['CONFIG_DB_TBL_RADUSERGROUP'],
@@ -117,10 +119,11 @@
                     continue;
                 }
 
+                $priority = normalize_user_group_priority($newgroup, 0);
                 $sql = sprintf($insert_group_format,
                                $configValues['CONFIG_DB_TBL_RADUSERGROUP'],
                                $dbSocket->escapeSimple($username),
-                               $dbSocket->escapeSimple($group), 0);
+                               $dbSocket->escapeSimple($newgroup), $priority);
                 $res = $dbSocket->query($sql);
                 $logDebugSQL .= "$sql;\n";
             }

--- a/app/operators/include/management/functions.php
+++ b/app/operators/include/management/functions.php
@@ -171,6 +171,26 @@ function group_exists($dbSocket, $groupname) {
 
 }
 
+if (!defined('DALO_DISABLED_USERS_GROUP')) {
+    define('DALO_DISABLED_USERS_GROUP', 'daloRADIUS-Disabled-Users');
+}
+if (!defined('DALO_DISABLED_USERS_GROUP_PRIORITY')) {
+    define('DALO_DISABLED_USERS_GROUP_PRIORITY', -1);
+}
+
+function is_disabled_users_group($groupname) {
+    return trim($groupname) === DALO_DISABLED_USERS_GROUP;
+}
+
+function normalize_user_group_priority($groupname, $priority=0) {
+    if (is_disabled_users_group($groupname)) {
+        return DALO_DISABLED_USERS_GROUP_PRIORITY;
+    }
+
+    $priority = intval($priority);
+    return ($priority < 0) ? 0 : $priority;
+}
+
 function update_user_group_mapping_priority($dbSocket, $username, $groupname, $new_priority) {
     global $configValues, $logDebugSQL;
 
@@ -188,7 +208,7 @@ function update_user_group_mapping_priority($dbSocket, $username, $groupname, $n
 
 
     if ($numrows > 0) {
-        $priority = (intval($new_priority) < 0) ? 0 : intval($new_priority);
+        $priority = normalize_user_group_priority($groupname, $new_priority);
 
         if ($numrows == 1) {
             $sql = sprintf("UPDATE %s SET priority=%d WHERE username='%s' AND groupname='%s'",
@@ -231,7 +251,7 @@ function insert_single_user_group_mapping($dbSocket, $username, $groupname, $pri
         return false;
     }
 
-    $priority = (intval($priority) < 0) ? 0 : intval($priority);
+    $priority = normalize_user_group_priority($groupname, $priority);
 
     $sql = sprintf("INSERT INTO %s (username, groupname, priority) VALUES ('%s', '%s', %d)",
                    $configValues['CONFIG_DB_TBL_RADUSERGROUP'], $dbSocket->escapeSimple($username),
@@ -360,11 +380,12 @@ function insert_multiple_user_group_mappings($dbSocket, $username, $groupnames) 
             continue;
         }
 
-        // insert user-group mapping with default priority 0
-        $sql = sprintf("INSERT INTO %s (username, groupname, priority) VALUES ('%s', '%s', 0)",
+        // insert user-group mapping with default priority 0, except reserved disabled users group
+        $priority = normalize_user_group_priority($groupname, 0);
+        $sql = sprintf("INSERT INTO %s (username, groupname, priority) VALUES ('%s', '%s', %d)",
                        $configValues['CONFIG_DB_TBL_RADUSERGROUP'],
                        $dbSocket->escapeSimple($username),
-                       $dbSocket->escapeSimple($groupname));
+                       $dbSocket->escapeSimple($groupname), $priority);
         $res = $dbSocket->query($sql);
         $logDebugSQL .= "$sql;\n";
 

--- a/app/operators/include/management/groups.php
+++ b/app/operators/include/management/groups.php
@@ -109,7 +109,12 @@ foreach ($_groups as $g => $p) {
     
     echo '<div>';
     printf('<label for="group-%d-priority">%s</label>', $counter, $prorityLabel);
-    printf('<input class="form-control" type="number" min="0" value="%d" name="groups[%d][1]" id="group-%d-priority">', $p, $counter, $counter);
+    $is_disabled_users_group = is_disabled_users_group($g);
+    $p = normalize_user_group_priority($g, $p);
+    printf('<input class="form-control%s" type="number" min="%d" value="%d" name="groups[%d][1]" id="group-%d-priority"%s>',
+           ($is_disabled_users_group ? ' bg-body-secondary text-muted' : ''),
+           ($is_disabled_users_group ? DALO_DISABLED_USERS_GROUP_PRIORITY : 0), $p, $counter, $counter,
+           ($is_disabled_users_group ? ' readonly title="Reserved disabled-users group; priority is locked to -1 so it is evaluated before normal groups."' : ''));
     echo '</div>';
     
     
@@ -130,14 +135,15 @@ echo '</div><!-- .container -->';
 
 echo "<script>" . "\n";
 
-echo "var selected_groups = [";
-if (count($_groups) > 0) {
-    echo "'" . implode("', '", array_keys($_groups)) . "'";
-}
-echo "]" . "\n";
-
+$selected_groups_js = json_encode(array_keys($_groups));
+$disabled_users_group_js = json_encode(DALO_DISABLED_USERS_GROUP);
+$disabled_users_group_priority_js = json_encode((string)DALO_DISABLED_USERS_GROUP_PRIORITY);
 
 echo <<<EOF
+var selected_groups = {$selected_groups_js};
+var disabledUsersGroupName = {$disabled_users_group_js};
+var disabledUsersGroupPriority = {$disabled_users_group_priority_js};
+
 function add_group() {
     var sel = document.getElementById('groups'),
         selected_group = sel.options[sel.selectedIndex].text;
@@ -161,9 +167,17 @@ function add_group() {
             +  `<input class="form-control" type="text" value="\${selected_group}" name="groups[\${num}][0]" id="group-\${num}-name">`
             +  '</div>';
     
+    var disabledUsersGroup = selected_group === disabledUsersGroupName;
+    var priorityValue = disabledUsersGroup ? disabledUsersGroupPriority : '0';
+    var priorityMin = disabledUsersGroup ? disabledUsersGroupPriority : '0';
+    var priorityLock = disabledUsersGroup
+        ? ' readonly title="Reserved disabled-users group; priority is locked to -1 so it is evaluated before normal groups."'
+        : '';
+    var priorityClass = disabledUsersGroup ? ' bg-body-secondary text-muted' : '';
+
     content += '<div>'
             +  `<label for="group-\${num}-priority">{$prorityLabel}</label>`
-            +  `<input class="form-control" type="number" min="0" value="0" name="groups[\${num}][1]" id="group-\${num}-priority">`
+            +  `<input class="form-control\${priorityClass}" type="number" min="\${priorityMin}" value="\${priorityValue}" name="groups[\${num}][1]" id="group-\${num}-priority"\${priorityLock}>`
             +  '</div>';
     
     var id = "group-" + num;

--- a/app/operators/mng-edit.php
+++ b/app/operators/mng-edit.php
@@ -77,10 +77,11 @@
 
         if (is_array($newProfiles) && count($newProfiles) > 0) {
             foreach ($newProfiles as $profile_name) {
-                $sql = sprintf("INSERT INTO %s (username, groupname, priority) VALUES ('%s', '%s', 0)",
+                $priority = normalize_user_group_priority($profile_name, 0);
+                $sql = sprintf("INSERT INTO %s (username, groupname, priority) VALUES ('%s', '%s', %d)",
                                $configValues['CONFIG_DB_TBL_RADUSERGROUP'],
                                $dbSocket->escapeSimple($username),
-                               $dbSocket->escapeSimple($profile_name));
+                               $dbSocket->escapeSimple($profile_name), $priority);
                 $res = $dbSocket->query($sql);
                 $logDebugSQL .= "$sql;\n";
             }

--- a/app/operators/mng-rad-usergroup-edit.php
+++ b/app/operators/mng-rad-usergroup-edit.php
@@ -26,6 +26,7 @@
 
     include('library/check_operator_perm.php');
     include_once('../common/includes/config_read.php');
+    include_once("include/management/functions.php");
 
     // init logging variables
     $log = "visited page: ";
@@ -43,8 +44,9 @@
         $current_groupname = (array_key_exists('current_group', $_POST) && !empty(str_replace("%", "", trim($_POST['current_group']))))
                       ? str_replace("%", "", trim($_POST['current_group'])) : "";
 
-        $priority = (array_key_exists('priority', $_POST) && isset($_POST['priority']) &&
-                     intval(trim($_POST['priority'])) >= 0) ? intval(trim($_POST['priority'])) : 0;
+        $priority = (array_key_exists('priority', $_POST) && isset($_POST['priority']))
+                  ? normalize_user_group_priority($groupname, $_POST['priority'])
+                  : normalize_user_group_priority($groupname, 0);
     } else {
         // declaring variables
         $username = (array_key_exists('username', $_REQUEST) && !empty(str_replace("%", "", trim($_REQUEST['username']))))
@@ -96,14 +98,15 @@
 
                 $new_mapping_inplace = intval($res->fetchrow()[0]) > 0;
 
-                if ($new_mapping_inplace) {
+                if ($new_mapping_inplace && $groupname !== $current_groupname) {
                     // error
                     $failureMsg = "The chosen user mapping ($username_enc - $groupname_enc) is already in place.";
                     $logAction .= "Failed updating user-group mapping [$username - $groupname already in place]: ";
                 } else {
-                    $sql = sprintf("UPDATE %s SET groupname='%s', priority=%s WHERE username='%s' AND groupname='%s'",
+                    $priority = normalize_user_group_priority($groupname, $priority);
+                    $sql = sprintf("UPDATE %s SET groupname='%s', priority=%d WHERE username='%s' AND groupname='%s'",
                                    $configValues['CONFIG_DB_TBL_RADUSERGROUP'], $dbSocket->escapeSimple($groupname),
-                                   $dbSocket->escapeSimple($priority), $dbSocket->escapeSimple($username),
+                                   $priority, $dbSocket->escapeSimple($username),
                                    $dbSocket->escapeSimple($current_groupname));
                     $res = $dbSocket->query($sql);
                     $logDebugSQL .= "$sql;\n";
@@ -213,17 +216,24 @@
                                         "type" => "select",
                                         "options" => $options,
                                         "selected_value" => $this_groupname,
-                                        "tooltipText" => t('Tooltip','groupTooltip')
+                                        "tooltipText" => t('Tooltip','groupTooltip'),
+                                        "onchange" => "setDisabledUsersGroupPriority()"
                                      );
 
-        $input_descriptors0[] = array(
+        $priority_descriptor = array(
                                         "id" => "priority",
                                         "name" => "priority",
                                         "caption" => t('all','Priority'),
                                         "type" => "number",
-                                        "min" => "0",
-                                        "value" => $this_priority,
+                                        "min" => "-1",
+                                        "value" => normalize_user_group_priority($this_groupname, $this_priority),
                                      );
+
+        if (is_disabled_users_group($this_groupname)) {
+            $priority_descriptor["title"] = "Reserved disabled-users group; priority is locked to -1 so it is evaluated before normal groups.";
+        }
+
+        $input_descriptors0[] = $priority_descriptor;
 
         $input_descriptors0[] = array(
                                         "type" => "hidden",
@@ -250,6 +260,44 @@
         close_fieldset();
 
         close_form();
+
+
+        $disabled_users_group_js = json_encode(DALO_DISABLED_USERS_GROUP);
+        $disabled_users_group_priority_js = json_encode((string)DALO_DISABLED_USERS_GROUP_PRIORITY);
+
+        echo <<<EOF
+<script>
+var disabledUsersGroupName = {$disabled_users_group_js};
+var disabledUsersGroupPriority = {$disabled_users_group_priority_js};
+
+function setDisabledUsersGroupPriority() {
+    var group = document.getElementById('group');
+    var priority = document.getElementById('priority');
+
+    if (!group || !priority) {
+        return;
+    }
+
+    if (group.value === disabledUsersGroupName) {
+        priority.value = disabledUsersGroupPriority;
+        priority.min = disabledUsersGroupPriority;
+        priority.readOnly = true;
+        priority.classList.add('bg-body-secondary', 'text-muted');
+        priority.title = 'Reserved disabled-users group; priority is locked to -1 so it is evaluated before normal groups.';
+    } else {
+        priority.min = '0';
+        priority.readOnly = false;
+        priority.classList.remove('bg-body-secondary', 'text-muted');
+        if (parseInt(priority.value, 10) < 0) {
+            priority.value = '0';
+        }
+        priority.title = '';
+    }
+}
+
+document.addEventListener('DOMContentLoaded', setDisabledUsersGroupPriority);
+</script>
+EOF;
 
     }
 

--- a/app/operators/mng-rad-usergroup-new.php
+++ b/app/operators/mng-rad-usergroup-new.php
@@ -46,8 +46,9 @@
                ? trim(str_replace("%", "", $_POST['group'])) : "";
     $groupname_enc = (!empty($groupname)) ? htmlspecialchars($groupname, ENT_QUOTES, 'UTF-8') : "";
     
-    $priority = (array_key_exists('priority', $_POST) && isset($_POST['priority']) &&
-                 intval(trim($_POST['priority'])) >= 0) ? intval(trim($_POST['priority'])) : 0;
+    $priority = (array_key_exists('priority', $_POST) && isset($_POST['priority']))
+              ? normalize_user_group_priority($groupname, $_POST['priority'])
+              : normalize_user_group_priority($groupname, 0);
     
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     
@@ -130,17 +131,24 @@
                                     "type" => "select",
                                     "options" => $options,
                                     "selected_value" => ((isset($failureMsg)) ? $groupname : ""),
-                                    "tooltipText" => t('Tooltip','groupTooltip')
+                                    "tooltipText" => t('Tooltip','groupTooltip'),
+                                    "onchange" => "setDisabledUsersGroupPriority()"
                                  );
                                  
-    $input_descriptors0[] = array(
+    $priority_descriptor = array(
                                     "id" => "priority",
                                     "name" => "priority",
                                     "caption" => t('all','Priority'),
                                     "type" => "number",
-                                    "min" => "0",
+                                    "min" => "-1",
                                     "value" => ((isset($failureMsg)) ? $priority : "0"),
                                  );
+
+    if (isset($failureMsg) && is_disabled_users_group($groupname)) {
+        $priority_descriptor["title"] = "Reserved disabled-users group; priority is locked to -1 so it is evaluated before normal groups.";
+    }
+
+    $input_descriptors0[] = $priority_descriptor;
 
     $input_descriptors1 = array();
 
@@ -173,7 +181,45 @@
     }
     
     close_form();
-    
+
+
+    $disabled_users_group_js = json_encode(DALO_DISABLED_USERS_GROUP);
+    $disabled_users_group_priority_js = json_encode((string)DALO_DISABLED_USERS_GROUP_PRIORITY);
+
+    echo <<<EOF
+<script>
+var disabledUsersGroupName = {$disabled_users_group_js};
+var disabledUsersGroupPriority = {$disabled_users_group_priority_js};
+
+function setDisabledUsersGroupPriority() {
+    var group = document.getElementById('group');
+    var priority = document.getElementById('priority');
+
+    if (!group || !priority) {
+        return;
+    }
+
+    if (group.value === disabledUsersGroupName) {
+        priority.value = disabledUsersGroupPriority;
+        priority.min = disabledUsersGroupPriority;
+        priority.readOnly = true;
+        priority.classList.add('bg-body-secondary', 'text-muted');
+        priority.title = 'Reserved disabled-users group; priority is locked to -1 so it is evaluated before normal groups.';
+    } else {
+        priority.min = '0';
+        priority.readOnly = false;
+        priority.classList.remove('bg-body-secondary', 'text-muted');
+        if (parseInt(priority.value, 10) < 0) {
+            priority.value = '0';
+        }
+        priority.title = '';
+    }
+}
+
+document.addEventListener('DOMContentLoaded', setDisabledUsersGroupPriority);
+</script>
+EOF;
+
     print_back_to_previous_page();
 
     include('include/config/logging.php');

--- a/doc/setup/disabled-users-group.md
+++ b/doc/setup/disabled-users-group.md
@@ -1,0 +1,21 @@
+# Disabled users group priority
+
+The reserved `daloRADIUS-Disabled-Users` group disables a user by applying
+`Auth-Type := Reject` from `radgroupcheck`.
+
+FreeRADIUS evaluates a user's groups by `radusergroup.priority` in ascending
+order. When a user belongs to multiple groups, the disabled-users group must be
+evaluated before the normal service/profile groups. Otherwise another group can
+be processed first and the disabled-users reject rule may not be reached.
+
+For this reason, daloRADIUS now locks `daloRADIUS-Disabled-Users` user mappings
+to priority `-1`. Normal user-group mappings continue to use priority `0` or
+higher.
+
+## Existing installations
+
+This change does not modify existing `radusergroup` rows automatically. If users
+were manually associated with `daloRADIUS-Disabled-Users` before this change,
+verify that those mappings have top priority when the user belongs to multiple
+groups. In practice, the disabled-users mapping should have a lower priority
+number than the user's other groups, such as `-1`.


### PR DESCRIPTION
# Summary

This PR makes `daloRADIUS-Disabled-Users` behave as a reserved user group whose priority is always forced to `-1`.

The disabled-users group works by applying `Auth-Type := Reject` through `radgroupcheck`, but FreeRADIUS evaluates user groups by ascending `radusergroup.priority`. If the disabled group is assigned with the same or lower precedence than a normal group, another group may be evaluated first and the reject rule may not be reached.

To prevent users from appearing disabled in daloRADIUS while still being accepted by FreeRADIUS, this change ensures that daloRADIUS-managed assignments of `daloRADIUS-Disabled-Users` are always evaluated before normal groups.

# Changes

- Adds centralized helpers for the reserved disabled-users group:
  - `DALO_DISABLED_USERS_GROUP`
  - `DALO_DISABLED_USERS_GROUP_PRIORITY`
  - `is_disabled_users_group()`
  - `normalize_user_group_priority()`
- Forces `daloRADIUS-Disabled-Users` mappings to priority `-1`.
- Preserves normal group behavior by clamping negative priorities to `0`.
- Applies the normalization across user-group creation/edit paths and related billing/profile assignment paths.
- Locks the disabled-users priority field in the UI.
- Greys the locked priority field to make it visually non-editable.
- Adds inline tooltip text explaining why the priority is locked.
- Adds documentation explaining the priority requirement and existing-installation behavior.

# Notes for existing installations

This PR does not automatically migrate existing `radusergroup` rows.

If an existing installation already has users manually associated with `daloRADIUS-Disabled-Users`, those rows should be checked when the user belongs to multiple groups. The disabled-users mapping should have the highest precedence / lowest priority number, for example `-1`.

# Validation

Validated in the Docker development environment:

- PHP syntax checks passed for all changed PHP files.
- `git diff --check` passed.
- Creating a disabled-users mapping with submitted priority `99` saves priority `-1`.
- Editing a normal mapping into `daloRADIUS-Disabled-Users` saves priority `-1`.
- Editing a normal group with a negative priority clamps it back to `0`.
- Users assigned to `daloRADIUS-Disabled-Users` with priority `-1` receive `Access-Reject` from FreeRADIUS.
- The embedded user edit UI renders the disabled-users priority field as grey, readonly, and fixed to `-1`.

Fixes #595

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks the reserved `daloRADIUS-Disabled-Users` group to priority `-1` so FreeRADIUS evaluates the reject before any other groups. Normal groups clamp to `0+`, and the UI now auto-locks and greys the disabled group’s priority; docs added.

- **Bug Fixes**
  - Added helpers: `DALO_DISABLED_USERS_GROUP`, `DALO_DISABLED_USERS_GROUP_PRIORITY`, `is_disabled_users_group()`, `normalize_user_group_priority()`.
  - Normalize priorities across all insert/update paths (user-group create/edit, bulk adds, and plan/profile assignments); negative priorities on normal groups save as `0`.
  - UI: priority locks to `-1` for the disabled group in group pickers and mapping forms, with grey styling, tooltip, and JS min set (`-1` for disabled, `0` otherwise).
  - Added documentation on the priority rule.

- **Migration**
  - No automatic data changes. For existing users in multiple groups, ensure the `daloRADIUS-Disabled-Users` mapping uses priority `-1`.

<sup>Written for commit 0deeee692ead8114ab24112ae74f0ee3a4f26a3f. Summary will update on new commits. <a href="https://cubic.dev/pr/lirantal/daloradius/pull/689?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

