### PR TITLE
docs: add Debian 13 install support

### DIFF
--- a/doc/install/INSTALL.debian.md
+++ b/doc/install/INSTALL.debian.md
@@ -1,10 +1,10 @@
-This guide will walk you through the process of deploying a **basic open-source AAA infrastructure** on a dedicated instance of [Debian](https://www.debian.org/download). The configurations that have been tested are provided separately for Debian 11 and Debian 12, as outlined in the table below:
-Package\OS|Debian 11|Debian 12|
---|--|--|
-[MariaDB](https://mariadb.org/download/)|10.5|10.11
-[FreeRADIUS](https://freeradius.org/releases/)|3.0.x|3.2.x
-[Apache 2](https://httpd.apache.org/download.cgi)|2.4.x|2.4.x
-[PHP](https://www.php.net/downloads.php)|7.4.x|8.2.x
+This guide will walk you through the process of deploying a **basic open-source AAA infrastructure** on a dedicated instance of [Debian](https://www.debian.org/download). The configurations that have been tested are provided separately for Debian 11, Debian 12, and Debian 13, as outlined in the table below:
+Package\OS|Debian 11|Debian 12|Debian 13|
+--|--|--|--|
+[MariaDB](https://mariadb.org/download/)|10.5|10.11|11.8
+[FreeRADIUS](https://freeradius.org/releases/)|3.0.x|3.2.x|3.2.x
+[Apache 2](https://httpd.apache.org/download.cgi)|2.4.x|2.4.x|2.4.x
+[PHP](https://www.php.net/downloads.php)|7.4.x|8.2.x|8.4.x
 
 # Prerequisites
 Before proceeding with the installation, please ensure the following:


### PR DESCRIPTION
Summary

Add Debian 13 support to the Debian installation guide.

The installation was successfully completed on a Debian 13 system, so this PR updates the package/OS matrix to include the tested Debian 13 package versions.

Changes

• Add Debian 13 to the Debian package/OS matrix.
• Document tested package versions for Debian 13:
• MariaDB 11.8
• FreeRADIUS 3.2.x
• Apache 2.4.x
• PHP 8.4.x

Testing

• Successfully completed the installation on a Debian 13 system.
• Documentation-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Debian 13 support to the Debian install guide. Updates the package/OS matrix with tested versions: `MariaDB` 11.8, `FreeRADIUS` 3.2.x, `Apache` 2.4.x, `PHP` 8.4.x.

<sup>Written for commit bd866be6d4cc8e9cbd3e692a31f67c02b2ed83ee. Summary will update on new commits. <a href="https://cubic.dev/pr/lirantal/daloradius/pull/690?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

