### PR TITLE
feat: discover custom accounting fields

### DIFF
--- a/app/operators/acct-custom-query.php
+++ b/app/operators/acct-custom-query.php
@@ -36,6 +36,15 @@
     $logAction = "";
     $logDebugSQL = "";
 
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
+
+    list($acct_custom_query_options_all, $acct_custom_query_options_default) = get_accounting_custom_query_options(
+        $dbSocket,
+        $configValues['CONFIG_DB_TBL_RADACCT'],
+        $acct_custom_query_options_all,
+        $acct_custom_query_options_default
+    );
+
     // set session's page variable
     $_SESSION['PREV_LIST_PAGE'] = $_SERVER['REQUEST_URI'];
 
@@ -97,8 +106,6 @@
     print_title_and_help($title, $help);
 
     include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'pages_common.php' ]);
-    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
-
     // preparing the custom query
 
     $sql_WHERE = [];
@@ -130,10 +137,10 @@
             $where_value = "%" . $where_value . "%";
         }
 
-        $sql_WHERE[] = sprintf("%s %s '%s'", $where_field, $op, $where_value);
+        $sql_WHERE[] = sprintf("%s %s '%s'", quote_sql_identifier($where_field), $op, $where_value);
 
         $partial_query_string_pieces[] = sprintf("where_field=%s", $where_field);
-        $partial_query_string_pieces[] = sprintf("operator=%s", $where_operator);
+        $partial_query_string_pieces[] = sprintf("where_operator=%s", $where_operator);
         $partial_query_string_pieces[] = sprintf("where_value=%s", $where_value_enc);
     }
 
@@ -159,7 +166,7 @@
         // here we decide if page numbers should be shown
         $drawNumberLinks = strtolower($configValues['CONFIG_IFACE_TABLES_LISTING_NUM']) == "yes" && $maxPage > 1;
 
-        $sql .= sprintf(" ORDER BY %s %s LIMIT %s, %s", $orderBy, $orderType, $offset, $rowsPerPage);
+        $sql .= sprintf(" ORDER BY %s %s LIMIT %s, %s", quote_sql_identifier($orderBy), $orderType, $offset, $rowsPerPage);
 
         $res = $dbSocket->query($sql);
         $logDebugSQL .= "$sql;\n";

--- a/app/operators/include/management/functions.php
+++ b/app/operators/include/management/functions.php
@@ -29,6 +29,49 @@ if (strpos($_SERVER['PHP_SELF'], '/include/management/functions.php') !== false)
 }
 
 
+
+function quote_sql_identifier($identifier) {
+    if (!is_string($identifier) || !preg_match('/^[A-Za-z0-9_]+$/', $identifier)) {
+        return '';
+    }
+
+    return sprintf('`%s`', $identifier);
+}
+
+function get_table_column_names($dbSocket, $table_name, $fallback_columns=array()) {
+    $quoted_table_name = quote_sql_identifier($table_name);
+    if (empty($quoted_table_name)) {
+        return $fallback_columns;
+    }
+
+    $sql = sprintf('SHOW COLUMNS FROM %s', $quoted_table_name);
+    $columns = $dbSocket->getCol($sql);
+
+    if (!is_array($columns) || count($columns) == 0) {
+        return $fallback_columns;
+    }
+
+    $valid_columns = array();
+    foreach ($columns as $column) {
+        if (is_string($column) && preg_match('/^[A-Za-z0-9_]+$/', $column)) {
+            $valid_columns[] = $column;
+        }
+    }
+
+    return (count($valid_columns) > 0) ? $valid_columns : $fallback_columns;
+}
+
+function get_accounting_custom_query_options($dbSocket, $radacct_table, $fallback_all, $fallback_default) {
+    $all = get_table_column_names($dbSocket, $radacct_table, $fallback_all);
+    $default = array_values(array_intersect($fallback_default, $all));
+
+    if (count($default) == 0) {
+        $default = array_slice($all, 0, min(10, count($all)));
+    }
+
+    return array($all, $default);
+}
+
 // add invoice items contained in the $_POST array.
 // a single items is an associatime array starting with the string 'item'
 // and containing exactly 4 elements: plan, amount, tax and notes


### PR DESCRIPTION
# Summary

- Discover `Accounting → Custom Query` fields from the configured `radacct` table instead of relying only on the static accounting-field list.
- Continue using the discovered column list as a strict whitelist for `sqlfields[]`, `where_field`, and `orderBy`.
- Preserve the existing default accounting fields when those columns exist.
- Quote validated SQL identifiers in custom accounting filters and ordering.
- Preserve `where_operator` correctly in generated query links.

# Related issue
Closes: #596

# Test plan

- Ran PHP syntax checks on the changed files.
- Temporarily added a custom `radacct.alcatel_vsa` column.
- Inserted a temporary accounting row with a custom VSA value.
- Verified `Accounting → Custom Query` can select, filter, display, and order by the custom column.
- Verified the default custom query page still loads.
- Checked the web output/logs for PHP fatal errors, warnings, and database errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Discovers available fields for `Accounting → Custom Query` from the configured `radacct` table, so custom columns can be selected without code changes. Uses a strict whitelist with safe identifier quoting and keeps existing defaults when available.

- **New Features**
  - Discover columns from `radacct`; fall back to previous lists if needed.
  - Keep default fields when those columns exist; otherwise pick the first 10.
  - Enforce a whitelist for `sqlfields[]`, `where_field`, and `orderBy`.

- **Bug Fixes**
  - Quote validated SQL identifiers in WHERE and ORDER BY.
  - Preserve `where_operator` in generated query links.

<sup>Written for commit 8a4003b9fd1881d1ed9fa714cb408e6b39fe5796. Summary will update on new commits. <a href="https://cubic.dev/pr/lirantal/daloradius/pull/694?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

