### PR TITLE
security: fix reflected XSS in pagination and column sorting links

### DIFF
--- a/app/operators/include/management/pages_common.php
+++ b/app/operators/include/management/pages_common.php
@@ -401,8 +401,8 @@ function printTableHead($cols, $orderBy="", $orderType="asc", $partial_query_str
 
             $partial_query_string_safe = str_replace('%', '%%', $partial_query_string);
             $href_format = '?orderBy=%s&orderType=%s' . $partial_query_string_safe; 
-            $href_asc = sprintf($href_format, $param, 'asc');
-            $href_desc = sprintf($href_format, $param, 'desc');
+            $href_asc = htmlspecialchars(sprintf($href_format, $param, 'asc'), ENT_QUOTES, 'UTF-8', false);
+            $href_desc = htmlspecialchars(sprintf($href_format, $param, 'desc'), ENT_QUOTES, 'UTF-8', false);
 
             //~ $img_format = '<img src="%s" alt="%s">';
             //~ $img_asc = sprintf($img_format, 'static/images/icons/arrow_up.png', '^');

--- a/app/operators/include/management/pages_numbering.php
+++ b/app/operators/include/management/pages_numbering.php
@@ -78,8 +78,8 @@ function setupLinks_str($pageNum, $maxPage, $orderBy, $orderType, $request1="", 
     if ($pageNum > 1) {
         $page = $pageNum - 1;
 
-        $href_prev   = sprintf($href_format, $page, $orderBy, $orderType, $request1, $request2, $request3);
-        $href_first  = sprintf($href_format, 1, $orderBy, $orderType, $request1, $request2, $request3);
+        $href_prev   = htmlspecialchars(sprintf($href_format, $page, $orderBy, $orderType, $request1, $request2, $request3), ENT_QUOTES, 'UTF-8', false);
+        $href_first  = htmlspecialchars(sprintf($href_format, 1, $orderBy, $orderType, $request1, $request2, $request3), ENT_QUOTES, 'UTF-8', false);
         
         $prev = sprintf($link_format, $href_prev, $labels['prev']);
         $first = sprintf($link_format, $href_first, $labels['first']);
@@ -92,8 +92,8 @@ function setupLinks_str($pageNum, $maxPage, $orderBy, $orderType, $request1="", 
     if ($pageNum < $maxPage) {
         $page = $pageNum + 1;
         
-        $href_next = sprintf($href_format, $page, $orderBy, $orderType, $request1, $request2, $request3);
-        $href_last = sprintf($href_format, $maxPage, $orderBy, $orderType, $request1, $request2, $request3);
+        $href_next = htmlspecialchars(sprintf($href_format, $page, $orderBy, $orderType, $request1, $request2, $request3), ENT_QUOTES, 'UTF-8', false);
+        $href_last = htmlspecialchars(sprintf($href_format, $maxPage, $orderBy, $orderType, $request1, $request2, $request3), ENT_QUOTES, 'UTF-8', false);
         
         $next = sprintf($link_format, $href_next, $labels['next']);
         $last = sprintf($link_format, $href_last, $labels['last']);
@@ -141,11 +141,11 @@ function get_link_href($partial_query_string, $pageNum="", $orderBy="", $orderTy
 
 // this is an utility function used for printing a "go to <page num.>" link in the function setupNumbering_str()
 function print_link($aPageNum, $pageNum, $orderBy, $orderType, $request1="", $request2="", $request3="") {
-    $link_format = '<li class="page-item"><a class="page-link" href="?page=%s&orderBy=%s&orderType=%s%s%s%s">%s</a></li>';
     $selected_link_format = '<li class="page-item active" aria-current="page"><span class="page-link">%s</span></li>';
-    
     if ($aPageNum != $pageNum) {
-        return sprintf($link_format, $aPageNum, $orderBy, $orderType, $request1, $request2, $request3, $aPageNum);
+        $href = htmlspecialchars(sprintf("?page=%s&orderBy=%s&orderType=%s%s%s%s", $aPageNum, $orderBy, $orderType, $request1, $request2, $request3), ENT_QUOTES, 'UTF-8', false);
+        $link_format = '<li class="page-item"><a class="page-link" href="%s">%s</a></li>';
+        return sprintf($link_format, $href, $aPageNum);
     }
     
     return sprintf($selected_link_format, $aPageNum);


### PR DESCRIPTION
### Description
This pull request addresses a potential Reflected Cross-Site Scripting (XSS) vulnerability in the operator management pages. 
Dynamic URL query parameters (such as sorting options and pagination states) were previously injected directly into the `href` attribute of HTML anchor (`<a>`) tags without sanitization. An attacker could exploit this to perform an HTML attribute breakout and execute arbitrary JavaScript code.
### Changes
- **`app/operators/include/management/pages_common.php`**: Sanitize column header sorting links (`$href_asc`, `$href_desc`) generated inside `printTableHead()`.
- **`app/operators/include/management/pages_numbering.php`**: Sanitize pagination navigation links (First, Prev, Next, Last) inside `setupLinks_str()` and individual page links inside `print_link()`.
### Implementation Details
- Applied `htmlspecialchars()` with `ENT_QUOTES` to ensure both single and double quotes are safely escaped (preventing attribute breakout).
- Specified `'UTF-8'` encoding explicitly.
- Set the `$double_encode` parameter to `false` to prevent double-encoding of existing valid query separators (like `&amp;`), ensuring links remain fully functional while being secure.
### How to Verify
1. Navigate to any operator listing page that includes table pagination or column headers.
2. Click sorting arrows and page numbers to confirm that pagination and sorting continue to work flawlessly.
3. Confirm that special characters in custom query arguments are safely escaped in the rendered HTML source code, mitigating XSS attempts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a reflected XSS in operator management by escaping dynamic query params in pagination and column sorting links. Prevents attribute breakout while keeping links working.

- **Bug Fixes**
  - Escape generated hrefs in `printTableHead()`, `setupLinks_str()`, and `print_link()`.
  - Use `htmlspecialchars(..., ENT_QUOTES, 'UTF-8', false)` to encode quotes and avoid double-encoding.

<sup>Written for commit a9557c2fb1ad7dfd65166807574e79588cb39b38. Summary will update on new commits. <a href="https://cubic.dev/pr/lirantal/daloradius/pull/695?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

