### PR TITLE
fix(users): update profile for logged-in user

### DIFF
--- a/app/users/pref-userinfo-edit.php
+++ b/app/users/pref-userinfo-edit.php
@@ -78,7 +78,7 @@
                                $dbSocket->escapeSimple($mobilephone), $dbSocket->escapeSimple($address),
                                $dbSocket->escapeSimple($city), $dbSocket->escapeSimple($state),
                                $dbSocket->escapeSimple($country), $dbSocket->escapeSimple($zip),
-                               $dbSocket->escapeSimple($username));
+                               $dbSocket->escapeSimple($login_user));
 
                 $res = $dbSocket->query($sql);
                 $logDebugSQL .= "$sql;\n";


### PR DESCRIPTION
# Summary

Fixes the users portal profile update flow so that changes are applied to the currently logged-in user.

The profile edit page was using an undefined `$username` variable in the `UPDATE ... WHERE username=...` clause. As a result, the page could report that the user information was updated, while no actual `userinfo` row was changed.

This updates the query to use `$login_user`, which is already populated from the authenticated session and used elsewhere on the page.

# Validation

Tested manually in the Docker development environment:

- Created a users portal account with `changeuserinfo=1`
- Logged into the users portal
- Submitted changes through `pref-userinfo-edit.php`
- Confirmed that before the fix, the page reported success but the database row stayed unchanged
- Confirmed that after the fix, the corresponding `userinfo` row is updated correctly
- Ran PHP syntax check:

```text
No syntax errors detected in /var/www/daloradius/app/users/pref-userinfo-edit.php
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes profile updates in the users portal so edits apply to the currently logged-in user. Uses `$login_user` in the UPDATE WHERE clause instead of an undefined `$username`, preventing false success messages and updating the correct `userinfo` row.

<sup>Written for commit ed32e9a8a096beab5b24a8c84ef0b8d0bb0155dd. Summary will update on new commits. <a href="https://cubic.dev/pr/lirantal/daloradius/pull/697?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

