### PR TITLE
fix(users): validate invoice notification id

### DIFF
--- a/app/users/include/common/notificationsUserInvoice.php
+++ b/app/users/include/common/notificationsUserInvoice.php
@@ -24,7 +24,8 @@
 	require_once(dirname(__FILE__)."/../../notifications/processNotificationUserInvoice.php");
 	require_once(dirname(__FILE__)."/../../../common/includes/config_read.php");
 	
-	isset($_GET['invoice_id']) ? $invoice_id = $_GET['invoice_id'] : $invoice_id = "";
+	$invoice_id = (array_key_exists('invoice_id', $_GET) && intval(trim($_GET['invoice_id'])) > 0)
+	            ? intval(trim($_GET['invoice_id'])) : "";
 	isset($_GET['destination']) ? $destination = $_GET['destination'] : $destination = "download";
 	
 	$login = $_SESSION['login_user'];
@@ -133,10 +134,11 @@
 			";
 
 		// get all invoice items
-		$sql = 'SELECT a.id, a.plan_id, a.amount, a.tax_amount, a.notes, b.planName '.
-				' FROM '.$configValues['CONFIG_DB_TBL_DALOBILLINGINVOICEITEMS'].' a '.
-				' LEFT JOIN '.$configValues['CONFIG_DB_TBL_DALOBILLINGPLANS'].' b ON a.plan_id = b.id '.
-				' WHERE a.invoice_id = '.$invoice_id.' ORDER BY a.id ASC';
+		$sql = sprintf("SELECT a.id, a.plan_id, a.amount, a.tax_amount, a.notes, b.planName
+		                  FROM %s a LEFT JOIN %s b ON a.plan_id = b.id
+		                 WHERE a.invoice_id = %d ORDER BY a.id ASC",
+		               $configValues['CONFIG_DB_TBL_DALOBILLINGINVOICEITEMS'],
+		               $configValues['CONFIG_DB_TBL_DALOBILLINGPLANS'], $invoice_id);
 		$res = $dbSocket->query($sql);
 		$logDebugSQL .= $sql . "\n";
 		


### PR DESCRIPTION
# Summary

Validates the users portal invoice notification `invoice_id` before using it in SQL queries.

The invoice PDF endpoint accepted the raw `invoice_id` query parameter and later concatenated it into the invoice-items query. In some MySQL coercion cases, a value such as `1 OR 1=1` could still pass the earlier invoice ownership check while affecting the later items query.

This change normalizes `invoice_id` to a positive integer before use and builds the invoice-items query with a numeric `%d` placeholder.

# Validation

Tested manually in the Docker development environment:

- Created two users portal accounts with separate invoices and invoice items
- Logged in as the owner of one invoice
- Confirmed that before the fix, a crafted `invoice_id` value could cause the invoice-items query to include rows from another invoice
- Rebuilt the web container with the fix
- Confirmed that:
  - a valid invoice download still works
  - a crafted `invoice_id` is normalized to the numeric invoice id
  - only the expected invoice items are selected
  - another user’s invoice id does not expose that invoice’s details
- Ran PHP syntax check:

```text
No syntax errors detected in /var/www/daloradius/app/users/include/common/notificationsUserInvoice.php
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates and normalizes the users portal `invoice_id` before use to prevent SQL manipulation and cross-invoice data leakage. Updates the invoice-items query to use a numeric placeholder.

- **Bug Fixes**
  - Normalize `invoice_id` to a positive integer; ignore invalid input.
  - Build the invoice-items SQL with a `%d` placeholder via `sprintf`, removing raw concatenation.
  - Blocks crafted values like `1 OR 1=1` from affecting the items query and ensures only the owner’s items are returned.

<sup>Written for commit 90fc0e0becffca60247d8f6bfb34312261b66ac2. Summary will update on new commits. <a href="https://cubic.dev/pr/lirantal/daloradius/pull/698?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

