### PR TITLE
fix(users): remove PHP 8 invoice helper warnings

### DIFF
--- a/app/users/include/common/notificationsUserInvoice.php
+++ b/app/users/include/common/notificationsUserInvoice.php
@@ -53,17 +53,22 @@
 		require(dirname(__FILE__)."/../../../common/includes/db_open.php");
 		require_once(dirname(__FILE__)."/../../lang/main.php");
 		
-		global $configValues;
+		global $configValues, $logDebugSQL;
+
+		if (!isset($logDebugSQL))
+			$logDebugSQL = "";
 		
 
 		$sql = "SELECT id, contactperson, city, state, username FROM ".$configValues['CONFIG_DB_TBL_DALOUSERBILLINFO'].
 		" WHERE username = '".$dbSocket->escapeSimple($username)."'";
 		$res = $dbSocket->query($sql);
 		$row = $res->fetchRow(DB_FETCHMODE_ASSOC);
-		$user_id = $row['id'];
+		$user_id = ($row && array_key_exists('id', $row)) ? $row['id'] : null;
 		
-		if (!$user_id)
+		if (!$user_id) {
+			require(dirname(__FILE__)."/../../../common/includes/db_close.php");
 			return false;
+		}
 		
 		if ($invoice_id == NULL || empty($invoice_id))
 			exit;

--- a/app/users/include/common/notificationsUserInvoice.php
+++ b/app/users/include/common/notificationsUserInvoice.php
@@ -48,7 +48,7 @@
 	}
 	
 	
-	function getInvoiceDetails($invoice_id = NULL, $username) {
+	function getInvoiceDetails($invoice_id, $username) {
 		
 		require(dirname(__FILE__)."/../../../common/includes/db_open.php");
 		require_once(dirname(__FILE__)."/../../lang/main.php");

--- a/app/users/include/management/pages_common.php
+++ b/app/users/include/management/pages_common.php
@@ -111,7 +111,7 @@ function time2str($time) {
 
 // return next billing date (Y-m-d format) based on
 // the billing recurring period and billing schedule type
-function getNextBillingDate($planRecurringBillingSchedule = "Fixed", $planRecurringPeriod, $billDates = null) {
+function getNextBillingDate($planRecurringBillingSchedule, $planRecurringPeriod, $billDates = null) {
 
     // initialize next bill date string (Y-m-d style)
 
@@ -212,7 +212,7 @@ function getNextBillingDate($planRecurringBillingSchedule = "Fixed", $planRecurr
 
 // return prev/start billing date (Y-m-d format) based on
 // the billing recurring period and billing schedule type
-function getPrevBillingDate($planRecurringBillingSchedule = "Fixed", $planRecurringPeriod, $billDates = null) {
+function getPrevBillingDate($planRecurringBillingSchedule, $planRecurringPeriod, $billDates = null) {
 
     // initialize next bill date string (Y-m-d style)
 


### PR DESCRIPTION
# Summary

Fixes PHP 8 deprecation warnings caused by optional parameters being declared before required parameters in users-portal billing/invoice helper functions.

Also cleans up two existing `E_ALL` warnings in `getInvoiceDetails()` by initializing the SQL debug log variable and safely handling the case where no billing user row is found.

# Changes

- Update `getInvoiceDetails()` so `$username` is a required parameter.
- Update `getNextBillingDate()` and `getPrevBillingDate()` so required billing schedule/period parameters come before the optional `$billDates` parameter.
- Initialize `$logDebugSQL` before appending SQL debug output.
- Avoid accessing `$row['id']` when no matching `userbillinfo` row exists.
- Close the DB connection before returning `false` for a missing billing user.

# Validation

Tested in the Docker development environment with PHP `8.4`:

- Confirmed the original PHP 8 signature deprecation warnings are no longer emitted.
- Ran PHP lint on the modified files.
- Smoke-tested `getNextBillingDate()` and `getPrevBillingDate()` across fixed and anniversary schedules.
- Created a temporary invoice fixture and verified `getInvoiceDetails()` returns the expected invoice/customer/item data.
- Verified `getInvoiceDetails()` returns `false` for a missing/wrong username without emitting PHP warnings.
- Checked recent web container logs for related PHP warnings/deprecations/fatal errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes PHP 8 parameter signature deprecations in users billing helpers and stops invoice warnings when no billing user is found. Tightens function signatures and adds safeguards to avoid E_ALL notices.

- **Bug Fixes**
  - Require `$invoice_id` in `getInvoiceDetails()` and initialize `$logDebugSQL`.
  - Safely handle missing billing user rows; avoid `$row['id']` access and close DB before returning `false`.
  - Make `getNextBillingDate()`/`getPrevBillingDate()` require schedule and period before optional `$billDates`.

- **Migration**
  - Update callers to pass `$planRecurringBillingSchedule` and `$planRecurringPeriod` explicitly; `$billDates` stays optional.
  - Pass a non-null `$invoice_id` to `getInvoiceDetails()`.

<sup>Written for commit f16f7988298ae0727b3e1cffe5c0caacc17584b4. Summary will update on new commits. <a href="https://cubic.dev/pr/lirantal/daloradius/pull/699?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

