### PR TITLE
fix(php): replace removed split calls in status reports

### DIFF
--- a/app/operators/rep-stat-raid.php
+++ b/app/operators/rep-stat-raid.php
@@ -81,7 +81,7 @@
                     $table = array( 'title' => $mddevice, 'rows' => array() );
 
                     foreach($output as $line) {
-                        list($var, $val) = split(":", $line);
+                        list($var, $val) = array_pad(explode(":", $line, 2), 2, "");
                         $var = htmlspecialchars($var, ENT_QUOTES, 'UTF-8');
                         $val = htmlspecialchars($val, ENT_QUOTES, 'UTF-8');
 

--- a/app/operators/rep-stat-ups.php
+++ b/app/operators/rep-stat-ups.php
@@ -42,19 +42,17 @@
 
     print_title_and_help($title, $help);
 
-    exec("which apcaccess || command -v apcaccess", $output, $retStatus);
+    exec("apcaccess 2>/dev/null", $output, $retStatus);
 
     $failureMsg = "";
 
-    $sep = ":";
     if ($retStatus !== 0) {
-        $sep = "\n";
         $failureMsg = '<strong>Error</strong> accessing UPS device information';
     } else {
 
         $table = array( 'title' => 'General Information', 'rows' => array() );
         foreach ($output as $line) {
-            list($var, $val) = split($sep, $line);
+            list($var, $val) = array_pad(explode(":", $line, 2), 2, "");
             $var = htmlspecialchars($var, ENT_QUOTES, 'UTF-8');
             $val = htmlspecialchars($val, ENT_QUOTES, 'UTF-8');
 


### PR DESCRIPTION
# Summary

- Replace removed `split()` calls in the RAID and UPS status report pages.
- Parse report output with `explode(..., 2)` plus `array_pad()` to preserve key/value table rows.
- Update the UPS status page to execute `apcaccess` directly instead of only resolving the binary path.

# Rationale

`split()` was removed in PHP 7 and is unavailable in current PHP versions, including PHP `8.4`. If these report pages execute the old calls, they can fail with a fatal error.

The UPS status page also previously executed:

```sh
which apcaccess || command -v apcaccess
```

That only returns the path to the `apcaccess` binary, rather than the UPS status output that the page expects to parse.

# Validation

- Confirmed the target runtime does not provide `split()`:

```text
PHP 8.4.21
split=no
```

- Confirmed no `split()` calls remain in the updated report pages.
- Ran PHP lint successfully:

```text
No syntax errors detected in app/operators/rep-stat-raid.php
No syntax errors detected in app/operators/rep-stat-ups.php
```

- Smoke-tested both report pages through the operators UI:

```text
rep-stat-raid.php http=200 title=<title>RAID Status :: daloRADIUS errors=
rep-stat-ups.php  http=200 title=<title>UPS Status :: daloRADIUS errors=
```

- Verified UPS command behavior:
  - missing `apcaccess` exits non-zero and follows the existing error path;
  - installed `apcaccess` without a running `apcupsd` daemon exits non-zero and follows the existing error path;
  - representative `apcaccess` output is parsed into key/value rows correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced removed `split()` calls with `explode(..., 2)` + `array_pad` in RAID and UPS status pages to restore PHP 8.4 compatibility and keep key/value rows intact. Updated the UPS page to run `apcaccess` directly, fixing empty output and ensuring errors are handled correctly.

<sup>Written for commit 968c66da2fe7c1ed42601219adc48ac867de927f. Summary will update on new commits. <a href="https://cubic.dev/pr/lirantal/daloradius/pull/702?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

