### PR TITLE
feat(ui): improve responsive layouts

### DIFF
--- a/app/common/includes/layout.php
+++ b/app/common/includes/layout.php
@@ -36,6 +36,7 @@ function fix_placeholder_text($text) {
 const DEFAULT_COMMON_PROLOGUE_CSS = array(
     "static/css/bootstrap.min.css",
     "static/css/icons/bootstrap-icons.min.css",
+    "static/css/daloradius-responsive.css",
 );
 
 const DEFAULT_COMMON_PROLOGUE_JS = array(
@@ -105,7 +106,7 @@ EOF;
 </head>
 
 <body>
-    <div class="row">
+    <div class="app-page">
 
 EOF;
     // printing nav bar
@@ -120,9 +121,16 @@ EOF;
     // opening main wrapper container
     echo <<<EOF
 
-        <div class="container">
-            <div class="row m-0 p-0">
-                <div id="sidebar" class="min-vh-100 col-sm-2 p-sm-2 col-lg-2 p-lg-3 bg-light text-dark border-end">
+        <div class="container-fluid app-shell">
+            <div class="row g-0">
+                <aside id="sidebarOffcanvas" class="offcanvas-lg offcanvas-start app-sidebar col-lg-2 bg-light text-dark border-end"
+                       tabindex="-1" aria-labelledby="sidebarOffcanvasLabel">
+                    <div class="offcanvas-header d-lg-none">
+                        <h2 class="offcanvas-title fs-5" id="sidebarOffcanvasLabel">Menu</h2>
+                        <button type="button" class="btn-close" data-bs-dismiss="offcanvas" data-bs-target="#sidebarOffcanvas"
+                                aria-label="Close"></button>
+                    </div>
+                    <div class="offcanvas-body d-block p-2 p-lg-3">
 EOF;
 
     // printing sidebar
@@ -131,9 +139,10 @@ EOF;
     // closing sidebar col
     // opening main content col
     echo <<<EOF
-                </div><!-- .min-vh-100 col-sm-2 p-sm-2 col-lg-2 p-lg-3 bg-light text-dark border-end -->
+                    </div><!-- .offcanvas-body -->
+                </aside><!-- #sidebarOffcanvas -->
 
-                <div class="col-sm-10 p-sm-2 col-lg-10 p-lg-3 bg-white text-dark">
+                <main class="app-content col-12 col-lg-10 p-2 p-lg-3 bg-white text-dark">
 
 EOF;
 }
@@ -147,18 +156,18 @@ function print_footer_and_html_epilogue($inline_extra_js="", $extra_js=array(), 
     // closing main content col and
     // main wrapper container
     echo <<<EOF
-                </div><!-- .col-sm-10 p-sm-2 col-lg-10 p-lg-3 bg-white text-dark -->
+                </main><!-- .app-content -->
             </div><!-- .row -->
-        </div><!-- .container -->
+        </div><!-- .container-fluid -->
 
 EOF;
 
     // printing footer
     echo <<<EOF
-        <div class="p-4 text-center text-bg-light border-top border-bottom">
+        <div class="app-footer p-3 p-lg-4 text-center text-bg-light border-top border-bottom">
             <div class="d-flex align-items-center">
                 <div class="flex-shrink-0 text-bg-white">
-                    <img src="static/images/daloradius_small.png">
+                    <img src="static/images/daloradius_small.png" alt="daloRADIUS">
                 </div>
                 <div class="flex-grow-1 ms-3">
 EOF;
@@ -449,9 +458,9 @@ function print_checkbox($descriptor) {
 // - center => contains the page numbering controls
 // - end => contains additional controls (CSV export)
 function print_table_prologue($descriptors) {
-    echo '<div class="row p-0 my-3">';
+    echo '<div class="row g-2 p-0 my-3 align-items-center table-controls">';
 
-    echo '<div class="col-4 d-flex justify-content-start align-items-center">';
+    echo '<div class="col-12 col-lg-4 d-flex justify-content-start align-items-center flex-wrap gap-1">';
     if (isset($descriptors['start']) && is_array($descriptors['start'])) {
         
         $start = $descriptors['start'];
@@ -467,7 +476,7 @@ function print_table_prologue($descriptors) {
     }
     echo '</div>';
 
-    echo '<div class="col-4 d-flex justify-content-center align-items-center">';
+    echo '<div class="col-12 col-lg-4 d-flex justify-content-center align-items-center flex-wrap gap-1">';
     if (isset($descriptors['center']) && is_array($descriptors['center'])) {
         $center = $descriptors['center'];
 
@@ -477,7 +486,7 @@ function print_table_prologue($descriptors) {
     }
     echo '</div>';
 
-    echo '<div class="col-4 d-flex justify-content-end align-items-center">';
+    echo '<div class="col-12 col-lg-4 d-flex justify-content-start justify-content-lg-end align-items-center flex-wrap gap-1">';
     if (isset($descriptors['end']) && is_array($descriptors['end'])) {
         print_additional_controls($descriptors['end']);
     }
@@ -490,8 +499,9 @@ function print_table_prologue($descriptors) {
 function print_simple_table($table) {
     if (isset($table['title']) && isset($table['rows']) && count($table['rows']) > 0) {
         echo '<div class="container mb-4">';
-        echo '<div class="col-8 offset-2">';
+        echo '<div class="col-12 col-lg-8 offset-lg-2">';
         printf('<h5>%s</h5>', $table['title']);
+        echo '<div class="table-responsive">';
         echo '<table class="table table-striped">';
 
         foreach ($table['rows'] as $row) {
@@ -504,6 +514,7 @@ function print_simple_table($table) {
         }
 
         echo '</table>';
+        echo '</div>';
 
         echo '</div></div>';
 
@@ -531,6 +542,7 @@ function print_table_top($descriptor=array()) {
 
     echo <<<EOF
 
+<div class="table-responsive mb-3">
 <table class="{$class}">
     <thead>
         <tr>
@@ -586,6 +598,7 @@ function print_table_bottom($descriptor=array()) {
     }
 
     echo '</table>' . "\n";
+    echo '</div>' . "\n";
 
     if (isset($descriptor['form'])) {
         $csrf = array(

--- a/app/common/static/css/daloradius-responsive.css
+++ b/app/common/static/css/daloradius-responsive.css
@@ -67,6 +67,10 @@ svg {
     margin-bottom: 0;
 }
 
+.table-responsive:has(.dropdown-menu.show) {
+    padding-bottom: 10rem;
+}
+
 .table th,
 .table td {
     vertical-align: middle;
@@ -108,6 +112,25 @@ svg {
 
 .nav-tabs .nav-link {
     white-space: nowrap;
+}
+
+.accordion-body {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+.accordion-body .table {
+    min-width: 100%;
+}
+
+.accordion-body .table th,
+.accordion-body .table td {
+    white-space: normal;
+    overflow-wrap: anywhere;
+}
+
+.accordion-body .table th {
+    min-width: 8rem;
 }
 
 .app-footer .d-flex {

--- a/app/common/static/css/daloradius-responsive.css
+++ b/app/common/static/css/daloradius-responsive.css
@@ -114,22 +114,24 @@ svg {
     white-space: nowrap;
 }
 
-.accordion-body {
+.accordion-table-wrapper {
+    width: 100%;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
 }
 
-.accordion-body .table {
+.accordion-table-wrapper .table {
     min-width: 100%;
+    margin-bottom: 1rem;
 }
 
-.accordion-body .table th,
-.accordion-body .table td {
+.accordion-table-wrapper .table th,
+.accordion-table-wrapper .table td {
     white-space: normal;
     overflow-wrap: anywhere;
 }
 
-.accordion-body .table th {
+.accordion-table-wrapper .table th {
     min-width: 8rem;
 }
 

--- a/app/common/static/css/daloradius-responsive.css
+++ b/app/common/static/css/daloradius-responsive.css
@@ -49,22 +49,48 @@ svg {
     min-width: 0;
 }
 
+.app-content,
+.alert,
+.toast,
+.modal-body,
+.dropdown-menu {
+    overflow-wrap: anywhere;
+}
+
 .table-responsive {
     width: 100%;
 }
 
 .table-responsive > .table {
+    width: max-content;
+    min-width: 100%;
     margin-bottom: 0;
 }
 
 .table th,
 .table td {
     vertical-align: middle;
+    white-space: nowrap;
+}
+
+.table tfoot td {
+    white-space: normal;
 }
 
 .table-controls .btn-group,
 .table-controls .btn {
     flex-shrink: 0;
+}
+
+.table-controls .pagination {
+    flex-wrap: wrap;
+    gap: 0.125rem;
+    margin: 0;
+}
+
+.table-controls .page-link {
+    min-width: 2.25rem;
+    text-align: center;
 }
 
 .form-control,
@@ -86,6 +112,11 @@ svg {
 
 .app-footer .d-flex {
     justify-content: center;
+}
+
+.app-footer-text {
+    margin: 0;
+    text-align: center;
 }
 
 @media (min-width: 992px) {
@@ -129,6 +160,13 @@ svg {
 
     .table-controls > [class*="col-"] {
         justify-content: flex-start !important;
+    }
+
+    .table-controls .btn,
+    .table-controls .btn-group,
+    .table-controls .pagination,
+    .table-controls nav {
+        max-width: 100%;
     }
 
     .app-footer .d-flex {

--- a/app/common/static/css/daloradius-responsive.css
+++ b/app/common/static/css/daloradius-responsive.css
@@ -1,0 +1,166 @@
+html,
+body {
+    min-width: 0;
+    overflow-x: hidden;
+}
+
+img,
+svg {
+    max-width: 100%;
+    height: auto;
+}
+
+.app-page {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.app-header,
+.app-subnav {
+    min-width: 0;
+}
+
+.app-brand img {
+    width: 135px;
+    height: auto;
+}
+
+.app-primary-nav,
+.app-subnav .nav {
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin;
+}
+
+.app-primary-nav .nav-link,
+.app-subnav .nav-link {
+    white-space: nowrap;
+}
+
+.app-shell {
+    flex: 1 0 auto;
+}
+
+.app-sidebar {
+    min-width: 0;
+}
+
+.app-content {
+    min-width: 0;
+}
+
+.table-responsive {
+    width: 100%;
+}
+
+.table-responsive > .table {
+    margin-bottom: 0;
+}
+
+.table th,
+.table td {
+    vertical-align: middle;
+}
+
+.table-controls .btn-group,
+.table-controls .btn {
+    flex-shrink: 0;
+}
+
+.form-control,
+.form-select,
+.btn {
+    max-width: 100%;
+}
+
+.nav-tabs {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+}
+
+.nav-tabs .nav-link {
+    white-space: nowrap;
+}
+
+.app-footer .d-flex {
+    justify-content: center;
+}
+
+@media (min-width: 992px) {
+    .w-lg-auto {
+        width: auto !important;
+    }
+
+    .app-sidebar {
+        position: sticky;
+        top: 0;
+        min-height: 100vh;
+        max-height: 100vh;
+        overflow-y: auto;
+    }
+}
+
+@media (max-width: 991.98px) {
+    .app-header .dropdown .dropdown-menu {
+        max-width: calc(100vw - 1rem);
+    }
+
+    .app-search {
+        margin-top: 0.25rem;
+    }
+
+    .app-content {
+        padding-top: 1rem !important;
+    }
+
+    .offcanvas-lg.app-sidebar {
+        width: min(88vw, 22rem);
+    }
+
+    .offcanvas-lg .offcanvas-body {
+        overflow-y: auto;
+    }
+
+    .table-controls {
+        text-align: start;
+    }
+
+    .table-controls > [class*="col-"] {
+        justify-content: flex-start !important;
+    }
+
+    .app-footer .d-flex {
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+
+    .app-footer .ms-3 {
+        margin-left: 0 !important;
+    }
+}
+
+@media (max-width: 575.98px) {
+    .app-brand img {
+        width: 118px;
+    }
+
+    .app-primary-nav,
+    .app-subnav .nav {
+        margin-left: -0.5rem;
+        margin-right: -0.5rem;
+        padding-left: 0.5rem;
+        padding-right: 0.5rem;
+    }
+
+    .app-primary-nav .nav-link,
+    .app-subnav .nav-link {
+        padding-left: 0.5rem;
+        padding-right: 0.5rem;
+    }
+
+    .table {
+        font-size: 0.875rem;
+    }
+}

--- a/app/operators/home-main.php
+++ b/app/operators/home-main.php
@@ -71,13 +71,19 @@
     }
 
     function print_dashboard_table_head($headers) {
-        echo '<table class="table table-hover table-striped"><tr>';
+        echo '<div class="table-responsive dashboard-table-wrapper mb-3">';
+        echo '<table class="table table-hover table-striped dashboard-table"><tr>';
         
         foreach ($headers as $header) {
             printf('<th>%s</th>', $header);
         }
 
         echo '</tr>';
+    }
+
+    function print_dashboard_table_bottom() {
+        echo '</table>';
+        echo '</div>';
     }
 
     function print_dashboard_table_row($items) {
@@ -180,7 +186,7 @@ HTML;
     $res = $dbSocket->query($sql);
     $numrows = $res->numRows();
 
-    echo '<div class="col-sm-12 col-md-6 m-0 px-3">';
+    echo '<div class="col-12 col-xl-6 m-0 px-3">';
     $title = t('button', 'LastConnectionAttempts');
     print_title($title, "rep-lastconnect.php", "bi-box-arrow-up-right");
 
@@ -201,7 +207,7 @@ HTML;
             print_dashboard_table_row(array($user, $reply, $datetime));
         }
 
-        echo '</table>';
+        print_dashboard_table_bottom();
     
     } else {
         print_dashboard_info_message('no data to show');
@@ -215,7 +221,7 @@ HTML;
     $res = $dbSocket->query($sql);
     $numrows = $res->numRows();
 
-    echo '<div class="col-sm-12 col-md-6 m-0 px-3">';
+    echo '<div class="col-12 col-xl-6 m-0 px-3">';
     print_title('Currently online', "rep-online.php?orderBy=acctstarttime&orderType=desc", "bi-box-arrow-up-right");
 
     if ($numrows > 0) {
@@ -230,7 +236,7 @@ HTML;
             print_dashboard_table_row($row);
         }
 
-        echo '</table>';
+        print_dashboard_table_bottom();
     
     } else {
         print_dashboard_info_message('no data to show');
@@ -280,7 +286,7 @@ HTML;
             print_dashboard_table_row(array($username, $session_time, $uploaded_bytes, $downloaded_bytes));
         }
 
-        echo '</table>';
+        print_dashboard_table_bottom();
     
     } else {
         print_dashboard_info_message('no data to show');

--- a/app/operators/include/management/userReports.php
+++ b/app/operators/include/management/userReports.php
@@ -62,6 +62,14 @@ function close_accordion_item() {
 EOF;
 }
 
+function open_accordion_table_wrapper() {
+    echo '<div class="accordion-table-wrapper">';
+}
+
+function close_accordion_table_wrapper() {
+    echo '</div>';
+}
+
 /*
  *********************************************************************************************************
  * userSubscriptionAnalysis
@@ -293,6 +301,7 @@ function userSubscriptionAnalysis($username, $drawTable) {
         $d = array( 'label' => 'Subscription Analysis', 'parent_id' => 'accordion-parent', 'open' => false );
         open_accordion_item($d);
 
+        open_accordion_table_wrapper();
         echo '<table class="table table-striped">'
            . '<tr>';
 
@@ -322,8 +331,10 @@ function userSubscriptionAnalysis($username, $drawTable) {
         }
 
         echo '</table>';
+        close_accordion_table_wrapper();
 
         // print other table
+        open_accordion_table_wrapper();
         echo '<table class="table table-striped">';
 
         foreach ($data2 as $label => $value) {
@@ -333,6 +344,7 @@ function userSubscriptionAnalysis($username, $drawTable) {
         }
 
         echo '</table>';
+        close_accordion_table_wrapper();
 
         close_accordion_item();
     }
@@ -429,6 +441,7 @@ function userPlanInformation($username, $drawTable) {
         $d = array( 'label' => 'Plan Information', 'parent_id' => 'accordion-parent', 'open' => false );
         open_accordion_item($d);
 
+        open_accordion_table_wrapper();
         echo '<table class="table table-striped">'
            . '<tr>';
 
@@ -452,8 +465,10 @@ function userPlanInformation($username, $drawTable) {
         }
 
         echo '</table>';
+        close_accordion_table_wrapper();
 
         // print other table
+        open_accordion_table_wrapper();
         echo '<table class="table table-striped">';
 
         foreach ($data2 as $field => $arr) {
@@ -464,6 +479,7 @@ function userPlanInformation($username, $drawTable) {
         }
 
         echo '</table>';
+        close_accordion_table_wrapper();
 
         close_accordion_item();
     }
@@ -540,6 +556,7 @@ function userConnectionStatus($username, $drawTable) {
         $d = array( 'label' => 'Session Information', 'parent_id' => 'accordion-parent', 'open' => true );
         open_accordion_item($d);
 
+        open_accordion_table_wrapper();
         echo '<table class="table table-striped">';
 
         foreach ($data as $field => $arr) {
@@ -550,6 +567,7 @@ function userConnectionStatus($username, $drawTable) {
         }
 
         echo '</table>';
+        close_accordion_table_wrapper();
 
         close_accordion_item();
     }

--- a/app/operators/include/menu/nav.php
+++ b/app/operators/include/menu/nav.php
@@ -48,14 +48,19 @@ if (!in_array($detect_category, array_keys($nav))) {
 
 ?>
 
-<header class="border-bottom">
-    <div class="row p-2">
-        <div class="d-flex align-items-center justify-content-center justify-content-lg-start">
-            <a href="index.php" class="d-flex align-items-center mb-1 mb-lg-0 text-dark text-decoration-none">
-                <img src="static/images/daloradius_small.png">
+<header class="app-header border-bottom">
+    <div class="container-fluid px-2 px-lg-3">
+        <div class="d-flex flex-wrap align-items-center gap-2 py-2">
+            <button class="btn btn-outline-secondary btn-sm d-lg-none" type="button" data-bs-toggle="offcanvas"
+                    data-bs-target="#sidebarOffcanvas" aria-controls="sidebarOffcanvas" aria-label="Open menu">
+                <i class="bi bi-list"></i>
+            </button>
+
+            <a href="index.php" class="app-brand d-flex align-items-center text-dark text-decoration-none">
+                <img src="static/images/daloradius_small.png" alt="daloRADIUS">
             </a>
       
-            <ul class="nav col-12 col-lg-auto mx-2 me-lg-auto mb-1 justify-content-center mb-md-0">
+            <ul class="nav app-primary-nav flex-nowrap flex-lg-wrap overflow-auto mx-lg-2 me-lg-auto order-3 order-lg-0 w-100 w-lg-auto">
 <?php
                 foreach ($nav as $category => $arr) {
                     list($label, $href) = $arr;
@@ -68,7 +73,7 @@ if (!in_array($detect_category, array_keys($nav))) {
 ?>
             </ul>
       
-            <form class="col-12 col-lg-auto mb-3 mb-lg-0 me-lg-3" role="search" action="mng-search.php" method="GET">
+            <form class="app-search col-12 col-lg-auto me-lg-3 order-4 order-lg-0" role="search" action="mng-search.php" method="GET">
                 <div class="input-group">
                     <button class="input-group-text btn btn-outline-secondary" id="search-icon">
                         <i class="bi bi-search"></i>
@@ -79,7 +84,7 @@ if (!in_array($detect_category, array_keys($nav))) {
                 </div>
             </form>
             
-            <div class="dropdown text-end dropstart">
+            <div class="dropdown text-end dropstart ms-auto order-2 order-lg-0">
                 <a href="#" class="d-block link-dark text-decoration-none dropdown-toggle"
                     data-bs-toggle="dropdown" aria-expanded="false">
                     <i class="bi bi-person-circle"></i>
@@ -101,5 +106,5 @@ if (!in_array($detect_category, array_keys($nav))) {
                 </ul>
             </div><!-- -dropdown text-end -->
         </div>
-    </div><!-- .container -->
+    </div><!-- .container-fluid -->
 </header>

--- a/app/operators/include/menu/subnav.php
+++ b/app/operators/include/menu/subnav.php
@@ -110,9 +110,9 @@ if (!empty($detect_category) && count($subnav[$detect_category]) > 0) {
 
 ?>
 
-<nav class="border-bottom text-bg-light py-1">
-    <div class="d-flex">
-        <ul class="nav ms-4">
+<nav class="app-subnav border-bottom text-bg-light py-1">
+    <div class="container-fluid px-2 px-lg-3">
+        <ul class="nav flex-nowrap overflow-auto">
 <?php
             foreach ($subnav[$detect_category] as $label => $href) {
                 $label = htmlspecialchars(strip_tags(trim(t('submenu', $label))), ENT_QUOTES, 'UTF-8');

--- a/app/operators/page-footer.php
+++ b/app/operators/page-footer.php
@@ -27,4 +27,4 @@ if (strpos($_SERVER['PHP_SELF'], '/page-footer.php') !== false) {
     exit;
 }
 ?>
-<div style="margin: 15px auto; text-align: right"><?= t('all','copyright2') ?></div>
+<div class="app-footer-text"><?= t('all','copyright2') ?></div>

--- a/app/users/include/management/userReports.php
+++ b/app/users/include/management/userReports.php
@@ -61,6 +61,14 @@ function close_accordion_item() {
 EOF;
 }
 
+function open_accordion_table_wrapper() {
+    echo '<div class="accordion-table-wrapper">';
+}
+
+function close_accordion_table_wrapper() {
+    echo '</div>';
+}
+
 /*
  *********************************************************************************************************
  * userSubscriptionAnalysis
@@ -292,6 +300,7 @@ function userSubscriptionAnalysis($username, $drawTable, $openAccordion=false) {
         $d = array( 'label' => 'Subscription Analysis', 'parent_id' => 'accordion-parent', 'open' => $openAccordion );
         open_accordion_item($d);
 
+        open_accordion_table_wrapper();
         echo '<table class="table table-striped">'
            . '<tr>';
 
@@ -321,8 +330,10 @@ function userSubscriptionAnalysis($username, $drawTable, $openAccordion=false) {
         }
 
         echo '</table>';
+        close_accordion_table_wrapper();
 
         // print other table
+        open_accordion_table_wrapper();
         echo '<table class="table table-striped">';
 
         foreach ($data2 as $label => $value) {
@@ -332,6 +343,7 @@ function userSubscriptionAnalysis($username, $drawTable, $openAccordion=false) {
         }
 
         echo '</table>';
+        close_accordion_table_wrapper();
 
         close_accordion_item();
     }
@@ -428,6 +440,7 @@ function userPlanInformation($username, $drawTable, $openAccordion=false) {
         $d = array( 'label' => 'Plan Information', 'parent_id' => 'accordion-parent', 'open' => $openAccordion );
         open_accordion_item($d);
 
+        open_accordion_table_wrapper();
         echo '<table class="table table-striped">'
            . '<tr>';
 
@@ -451,8 +464,10 @@ function userPlanInformation($username, $drawTable, $openAccordion=false) {
         }
 
         echo '</table>';
+        close_accordion_table_wrapper();
 
         // print other table
+        open_accordion_table_wrapper();
         echo '<table class="table table-striped">';
 
         foreach ($data2 as $field => $arr) {
@@ -463,6 +478,7 @@ function userPlanInformation($username, $drawTable, $openAccordion=false) {
         }
 
         echo '</table>';
+        close_accordion_table_wrapper();
 
         close_accordion_item();
     }
@@ -539,6 +555,7 @@ function userConnectionStatus($username, $drawTable, $openAccordion=false) {
         $d = array( 'label' => 'Session Information', 'parent_id' => 'accordion-parent', 'open' => $openAccordion );
         open_accordion_item($d);
 
+        open_accordion_table_wrapper();
         echo '<table class="table table-striped">';
 
         foreach ($data as $field => $arr) {
@@ -549,6 +566,7 @@ function userConnectionStatus($username, $drawTable, $openAccordion=false) {
         }
 
         echo '</table>';
+        close_accordion_table_wrapper();
 
         close_accordion_item();
     }

--- a/app/users/include/menu/nav.php
+++ b/app/users/include/menu/nav.php
@@ -45,14 +45,19 @@ if (!in_array($detect_category, array_keys($nav))) {
 
 ?>
 
-<header class="border-bottom">
-    <div class="row p-2">
-        <div class="d-flex align-items-center justify-content-center justify-content-lg-start">
-            <a href="index.php" class="d-flex align-items-center mb-1 mb-lg-0 text-dark text-decoration-none">
-                <img src="static/images/daloradius_small.png">
+<header class="app-header border-bottom">
+    <div class="container-fluid px-2 px-lg-3">
+        <div class="d-flex flex-wrap align-items-center gap-2 py-2">
+            <button class="btn btn-outline-secondary btn-sm d-lg-none" type="button" data-bs-toggle="offcanvas"
+                    data-bs-target="#sidebarOffcanvas" aria-controls="sidebarOffcanvas" aria-label="Open menu">
+                <i class="bi bi-list"></i>
+            </button>
+
+            <a href="index.php" class="app-brand d-flex align-items-center text-dark text-decoration-none">
+                <img src="static/images/daloradius_small.png" alt="daloRADIUS">
             </a>
       
-            <ul class="nav col-12 col-lg-auto mx-2 me-lg-auto mb-1 justify-content-center mb-md-0">
+            <ul class="nav app-primary-nav flex-nowrap flex-lg-wrap overflow-auto mx-lg-2 me-lg-auto order-3 order-lg-0 w-100 w-lg-auto">
 <?php
                 foreach ($nav as $category => $arr) {
                     list($label, $href) = $arr;
@@ -65,7 +70,7 @@ if (!in_array($detect_category, array_keys($nav))) {
 ?>
             </ul>
       
-            <div class="dropdown text-end dropstart">
+            <div class="dropdown text-end dropstart ms-auto order-2 order-lg-0">
                 <a href="#" class="d-block link-dark text-decoration-none dropdown-toggle"
                     data-bs-toggle="dropdown" aria-expanded="false">
                     <i class="bi bi-person-circle"></i>
@@ -82,6 +87,6 @@ if (!in_array($detect_category, array_keys($nav))) {
                 </ul>
             </div><!-- -dropdown text-end -->
         </div>
-    </div><!-- .container -->
+    </div><!-- .container-fluid -->
 </header>
 

--- a/app/users/page-footer.php
+++ b/app/users/page-footer.php
@@ -27,4 +27,4 @@ if (strpos($_SERVER['PHP_SELF'], '/page-footer.php') !== false) {
     exit;
 }
 ?>
-<div style="margin: 15px auto; text-align: right"><?= t('all','copyright2') ?></div>
+<div class="app-footer-text"><?= t('all','copyright2') ?></div>


### PR DESCRIPTION
## Summary
- Add a responsive app shell stylesheet and load it through the shared layout so operator and user pages adapt across mobile, tablet, and desktop widths.
- Improve mobile navigation, subnavigation, footer wrapping, table controls, and dense table behavior to avoid clipped content and overlapping UI.
- Stack dashboard table columns on mobile/tablet and isolate horizontal scrolling per table inside accordion report sections.

## Verification
- Ran `git diff --check master..HEAD`.
- Ran `php -l app/operators/include/management/userReports.php` with `php:8.3-cli`.
- Ran `php -l app/users/include/management/userReports.php` with `php:8.3-cli`.
- Rebuilt and recreated the Docker stack with `docker compose up -d --build --force-recreate` after the latest UI changes.
- Verified the accordion report table scroll behavior in a narrow browser viewport before opening this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a responsive app shell with an off-canvas sidebar, scrollable nav, and responsive tables so operator and user pages work cleanly on mobile, tablet, and desktop. This removes UI clipping and makes navigation and tables easier to use on small screens.

- New Features
  - Added a responsive stylesheet and loaded it via the shared layout.
  - Introduced an app shell: container-fluid layout, off-canvas sidebar on mobile, sticky sidebar on desktop.
  - Updated header and subnav with a menu button and scrollable nav items; adjusted brand sizing.
  - Wrapped tables with responsive containers; stacked dashboard tables on tablets; isolated horizontal scroll inside accordion report sections.

- Bug Fixes
  - Prevented horizontal overflow and clipped controls; table controls now wrap with responsive pagination.
  - Fixed footer wrapping on mobile and added image alt text.
  - Ensured simple and report tables don’t overflow; content now wraps safely.

<sup>Written for commit d50d830459597877241cd2719f44a8ca1d81e4b9. Summary will update on new commits. <a href="https://cubic.dev/pr/lirantal/daloradius/pull/704?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

