### PR TITLE
Refactor mng-rad-ippool: portable includes, accounting tooltips and improved cell rendering

### DIFF
--- a/app/operators/mng-rad-ippool-del.php
+++ b/app/operators/mng-rad-ippool-del.php
@@ -21,16 +21,15 @@
  *********************************************************************************************************
  */
 
-    include("library/checklogin.php");
+    include_once implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', 'common', 'includes', 'config_read.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'checklogin.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'check_operator_perm.php' ]);
     $operator = $_SESSION['operator_user'];
 
-    include('library/check_operator_perm.php');
-    include_once('../common/includes/config_read.php');
-
-    include_once("lang/main.php");
-    include_once("../common/includes/validation.php");
-    include("../common/includes/layout.php");
-    include_once("include/management/populate_selectbox.php");
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LANG'], 'main.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'validation.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'layout.php' ]);
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'populate_selectbox.php' ]);
 
     // init logging variables
     $log = "visited page: ";
@@ -45,7 +44,7 @@
     } else {
         $item = (array_key_exists('item', $_REQUEST) && !empty($_REQUEST['item'])) ? $_REQUEST['item'] : "";
     }
-    
+
     $arr = array();
     $tmp = (!is_array($item)) ? array( $item ) : $item;
     foreach ($tmp as $tmp_item) {
@@ -55,7 +54,7 @@
 
         $arr[] = $tmp_item;
     }
-    
+
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if (array_key_exists('csrf_token', $_POST) && isset($_POST['csrf_token']) && dalo_check_csrf_token($_POST['csrf_token'])) {
 
@@ -64,7 +63,7 @@
                 $failureMsg = "Empty or invalid ippool item(s)";
                 $logAction .= sprintf("Failed deleting ippool item(s) [%s] on page: ", $failureMsg);
             } else {
-                include('../common/includes/db_open.php');
+                include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
 
                 $deleted = 0;
                 foreach ($arr as $arr_item) {
@@ -91,7 +90,7 @@
                     $logAction .= sprintf("Failed deleting ippool item(s) [%s] on page: ", $failureMsg);
                 }
 
-                include('../common/includes/db_close.php');
+                include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
             }
         } else {
             // csrf
@@ -104,15 +103,15 @@
     // print HTML prologue
     $title = t('Intro','mngradippooldel.php');
     $help = t('helpPage','mngradippooldel');
-    
+
     print_html_prologue($title, $langCode);
 
-    
-    
+
+
 
     print_title_and_help($title, $help);
 
-    include_once('include/management/actionMessages.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'actionMessages.php' ]);
 
     if (!isset($successMsg)) {
         $options = $valid_ippools;
@@ -134,7 +133,7 @@
                                         "title" => t('title','IPPoolInfo'),
                                         "disabled" => (count($options) == 0)
                                      );
-                                     
+
         open_form();
 
         open_fieldset($fieldset0_descriptor);
@@ -168,7 +167,7 @@
 
     print_back_to_previous_page();
 
-    include('include/config/logging.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_CONFIG'], 'logging.php' ]);
     print_footer_and_html_epilogue();
 
 ?>

--- a/app/operators/mng-rad-ippool-edit.php
+++ b/app/operators/mng-rad-ippool-edit.php
@@ -21,25 +21,24 @@
  *********************************************************************************************************
  */
 
-    include("library/checklogin.php");
+    include_once implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', 'common', 'includes', 'config_read.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'checklogin.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'check_operator_perm.php' ]);
     $operator = $_SESSION['operator_user'];
 
-    include('library/check_operator_perm.php');
-    include_once('../common/includes/config_read.php');
-
-    include_once("lang/main.php");
-    include_once("../common/includes/validation.php");
-    include("../common/includes/layout.php");
-    include_once("include/management/populate_selectbox.php");
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LANG'], 'main.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'validation.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'layout.php' ]);
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'populate_selectbox.php' ]);
 
     // init logging variables
     $log = "visited page: ";
     $logAction = "";
     $logDebugSQL = "";
-    
+
     // load valid ippools
     $valid_ippools = get_ippools();
-    
+
 
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $item = (array_key_exists('item', $_POST) && !empty(str_replace("%", "", trim($_POST['item']))))
@@ -50,7 +49,7 @@
     }
 
     $exists = in_array($item, array_keys($valid_ippools));
-    
+
     if (!$exists) {
         // we reset the rate if it does not exist
         $item = "";
@@ -63,7 +62,7 @@
     $selected_ippool = $item;
 
 
-    include('../common/includes/db_open.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
 
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
@@ -74,20 +73,20 @@
                 $failureMsg = sprintf("Selected an empty/invalid ippool item");
                 $logAction .= "$failureMsg on page: ";
             } else {
-            
+
                 $pool_name = (array_key_exists('pool_name', $_POST) && !empty(str_replace("%", "", trim($_POST['pool_name']))))
                            ? str_replace("%", "", trim($_POST['pool_name'])) : "";
-                          
+
                 $framedipaddress = (array_key_exists('framedipaddress', $_POST) && !empty(trim($_POST['framedipaddress'])) &&
                                     filter_var(trim($_POST['framedipaddress']), FILTER_VALIDATE_IP) !== false)
                                  ? trim($_POST['framedipaddress']) : "";
-                
+
                 if (empty($framedipaddress) || empty($pool_name)) {
                     // required
                     $failureMsg = sprintf("Empty/invalid %s and/or %s", t('all','PoolName'), t('all','IPAddress'));
                     $logAction .= "$failureMsg on page: ";
                 } else {
-                
+
                     $sql = sprintf("SELECT COUNT(id)
                                       FROM %s
                                      WHERE framedipaddress=? AND id<>?", $configValues['CONFIG_DB_TBL_RADIPPOOL']);
@@ -127,7 +126,7 @@
             $logAction .= "$failureMsg on page: ";
         }
     }
-    
+
     if (empty($internal_id)) {
         $failureMsg = sprintf("Selected an empty/invalid ippool element");
         $logAction .= "Failed updating ippool element (possible empty or invalid ippool element id) on page: ";
@@ -143,23 +142,19 @@
         list( $pool_name, $framedipaddress ) = $res->fetchrow();
     }
 
-    include('../common/includes/db_close.php');
-    
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
+
 
     // print HTML prologue
     $title = t('Intro','mngradippoolnew.php');
     $help = t('helpPage','mngradippoolnew');
-    
+
     print_html_prologue($title, $langCode);
-
-    
-
-
     print_title_and_help($title, $help);
 
-    include_once('include/management/actionMessages.php');
-    
-    
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'actionMessages.php' ]);
+
+
     if (!empty($internal_id)) {
 
         // descriptors 0
@@ -172,7 +167,7 @@
                                         'value' => $pool_name,
                                         'required' => true
                                      );
-                                     
+
         $input_descriptors0[] = array(
                                         'name' => 'framedipaddress',
                                         'caption' => t('all','IPAddress'),
@@ -181,7 +176,7 @@
                                         'pattern' => trim(IP_REGEX, '/'),
                                         'required' => true
                                      );
-                                     
+
         // descriptors 1
         $input_descriptors1 = array();
 
@@ -227,7 +222,7 @@
 
     print_back_to_previous_page();
 
-    include('include/config/logging.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_CONFIG'], 'logging.php' ]);
     print_footer_and_html_epilogue();
-    
+
 ?>

--- a/app/operators/mng-rad-ippool-list.php
+++ b/app/operators/mng-rad-ippool-list.php
@@ -29,6 +29,7 @@
     include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LANG'], 'main.php' ]);
     include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'validation.php' ]);
     include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'layout.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'functions.php' ]);
 
     // init logging variables
     $log = "visited page: ";
@@ -66,10 +67,15 @@
 
 
     // print HTML prologue
+    $extra_js = array(
+        "static/js/ajax.js",
+        "static/js/ajaxGeneric.js",
+    );
+
     $title = t('Intro','mngradippoollist.php');
     $help = t('helpPage','mngradippoollist');
 
-    print_html_prologue($title, $langCode);
+    print_html_prologue($title, $langCode, array(), $extra_js);
 
     // start printing content
     print_title_and_help($title, $help);
@@ -196,11 +202,37 @@
                 $tooltip3 = (!empty($nasipaddress)) ? $nasipaddress : "(n/a)";
             }
 
-
+            // username tooltip
+            if (!empty($username)) {
+                $ajax_id = "divContainerUserInfo_" . $count;
+                $param = sprintf('username=%s', urlencode($username));
+                $onclick = "ajaxGeneric('library/ajax/user_info.php','retBandwidthInfo','$ajax_id','$param')";
+                $tooltip4 = [
+                    'subject' => $username,
+                    'onclick' => $onclick,
+                    'ajax_id' => $ajax_id,
+                    'actions' => [],
+                ];
+                if (user_exists($dbSocket, $username, 'CONFIG_DB_TBL_RADACCT')) {
+                    $tooltip4['actions'][] = [
+                        'href'  => sprintf('acct-username.php?username=%s', urlencode($username)),
+                        'label' => t('button', 'UserAccounting'),
+                    ];
+                }
+                if (user_exists($dbSocket, $username, 'CONFIG_DB_TBL_RADCHECK')) {
+                    $tooltip4['actions'][] = [
+                        'href'  => sprintf('mng-edit.php?username=%s', urlencode($username)),
+                        'label' => t('Tooltip', 'UserEdit'),
+                    ];
+                }
+                $tooltip4 = get_tooltip_list_str($tooltip4);
+            } else {
+                $tooltip4 = "(n/a)";
+            }
 
             // build table row
             $table_row = array( $checkbox, $tooltip1, $tooltip2, $tooltip3, $calledstationid,
-                                $callingstationid, $expiry_time, $username, $pool_key );
+                                $callingstationid, $expiry_time, $tooltip4, $pool_key );
 
             // print table row
             print_table_row($table_row);

--- a/app/operators/mng-rad-ippool-list.php
+++ b/app/operators/mng-rad-ippool-list.php
@@ -166,8 +166,22 @@
             $d = array( 'name' => 'item[]', 'value' => $item_id, 'label' => $id );
             $checkbox = get_checkbox_str($d);
 
+            if (preg_match(IP_REGEX, $nasipaddress, $m) || preg_match(HOSTNAME_REGEX, $nasipaddress, $m)) {
+                $tooltip2 = [
+                    'subject' => $nasipaddress,
+                    'actions' => [],
+                ];
+                $tooltip2['actions'][] = [
+                    'href'  => sprintf('acct-nasipaddress.php?ipaddress=%s', urlencode($nasipaddress)),
+                    'label' => t('button', 'NASIPAccounting'),
+                ];
+                $tooltip2 = get_tooltip_list_str($tooltip2);
+            } else {
+                $tooltip2 = (!empty($nasipaddress)) ? $nasipaddress : "(n/a)";
+            }
+
             // build table row
-            $table_row = array( $checkbox, $tooltip, $framedipaddress, $nasipaddress, $calledstationid,
+            $table_row = array( $checkbox, $tooltip, $framedipaddress, $tooltip2, $calledstationid,
                                 $callingstationid, $expiry_time, $username, $pool_key );
 
             // print table row

--- a/app/operators/mng-rad-ippool-list.php
+++ b/app/operators/mng-rad-ippool-list.php
@@ -150,7 +150,6 @@
                 $row[$i] = htmlspecialchars($row[$i], ENT_QUOTES, 'UTF-8');
             }
 
-
             list($id, $pool_name, $framedipaddress, $nasipaddress, $calledstationid,
                  $callingstationid, $expiry_time, $username, $pool_key) = $row;
 
@@ -230,9 +229,18 @@
                 $tooltip4 = "(n/a)";
             }
 
+            // expiry time badge
+            if (!empty($expiry_time)) {
+                $is_future = strtotime($expiry_time) > time();
+                $badge_class = $is_future ? "text-bg-success" : "text-bg-danger";
+                $badge1 = sprintf('<span class="badge %s">%s</span>', $badge_class, $expiry_time);
+            } else {
+                $badge1 = "(n/a)";
+            }
+
             // build table row
             $table_row = array( $checkbox, $tooltip1, $tooltip2, $tooltip3, $calledstationid,
-                                $callingstationid, $expiry_time, $tooltip4, $pool_key );
+                                $callingstationid, $badge1, $tooltip4, $pool_key );
 
             // print table row
             print_table_row($table_row);

--- a/app/operators/mng-rad-ippool-list.php
+++ b/app/operators/mng-rad-ippool-list.php
@@ -21,14 +21,15 @@
  *********************************************************************************************************
  */
 
-    include("library/checklogin.php");
+    include_once implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', 'common', 'includes', 'config_read.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'checklogin.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'check_operator_perm.php' ]);
     $operator = $_SESSION['operator_user'];
 
-    include('library/check_operator_perm.php');
-    include_once("lang/main.php");
-    include_once("../common/includes/validation.php");
-    include("../common/includes/layout.php");
-    
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LANG'], 'main.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'validation.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'layout.php' ]);
+
     // init logging variables
     $log = "visited page: ";
     $logAction = "";
@@ -50,10 +51,10 @@
                  );
     $colspan = count($cols);
     $half_colspan = intval($colspan / 2);
-                 
+
     $param_cols = array();
     foreach ($cols as $k => $v) { if (!is_int($k)) { $param_cols[$k] = $v; } }
-    
+
     // whenever possible we use a whitelist approach
     $orderBy = (array_key_exists('orderBy', $_GET) && isset($_GET['orderBy']) &&
                 in_array($_GET['orderBy'], array_keys($param_cols)))
@@ -62,19 +63,19 @@
     $orderType = (array_key_exists('orderType', $_GET) && isset($_GET['orderType']) &&
                   in_array(strtolower($_GET['orderType']), array( "desc", "asc" )))
                ? strtolower($_GET['orderType']) : "asc";
-    
+
 
     // print HTML prologue
     $title = t('Intro','mngradippoollist.php');
     $help = t('helpPage','mngradippoollist');
-    
+
     print_html_prologue($title, $langCode);
 
     // start printing content
     print_title_and_help($title, $help);
 
-    include('../common/includes/db_open.php');
-    include('include/management/pages_common.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'pages_common.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
 
     // we use this simplified query just to initialize $numrows
     $sql = sprintf("SELECT COUNT(id) FROM %s", $configValues['CONFIG_DB_TBL_RADIPPOOL']);
@@ -83,16 +84,17 @@
 
     if ($numrows > 0) {
         /* START - Related to pages_numbering.php */
-        
+
         // when $numrows is set, $maxPage is calculated inside this include file
-        include('include/management/pages_numbering.php');    // must be included after opendb because it needs to read
-                                                              // the CONFIG_IFACE_TABLES_LISTING variable from the config file
-        
+        // must be included after opendb because it needs to read
+        // the CONFIG_IFACE_TABLES_LISTING variable from the config file
+        include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'pages_numbering.php' ]);
+
         // here we decide if page numbers should be shown
         $drawNumberLinks = strtolower($configValues['CONFIG_IFACE_TABLES_LISTING_NUM']) == "yes" && $maxPage > 1;
-        
+
         /* END */
-                     
+
         // we execute and log the actual query
         $sql = sprintf("SELECT id, pool_name, framedipaddress, nasipaddress, calledstationid,
                                callingstationid, expiry_time, username, pool_key
@@ -100,13 +102,13 @@
         $sql .= sprintf(" ORDER BY %s %s LIMIT %s, %s", $orderBy, $orderType, $offset, $rowsPerPage);
         $res = $dbSocket->query($sql);
         $logDebugSQL = "$sql;\n";
-        
+
         $per_page_numrows = $res->numRows();
-        
-        // this can be passed as form attribute and 
+
+        // this can be passed as form attribute and
         // printTableFormControls function parameter
         $action = "mng-rad-ippool-del.php";
-        
+
         // we prepare the "controls bar" (aka the table prologue bar)
         $params = array(
                             'num_rows' => $numrows,
@@ -115,14 +117,14 @@
                             'order_by' => $orderBy,
                             'order_type' => $orderType,
                         );
-        
+
         $descriptors = array();
         $descriptors['start'] = array( 'common_controls' => 'item[]', );
         $descriptors['center'] = array( 'draw' => $drawNumberLinks, 'params' => $params );
         print_table_prologue($descriptors);
-        
+
         $form_descriptor = array( 'form' => array( 'action' => $action, 'method' => 'POST', 'name' => 'listall' ), );
-        
+
         // print table top
         print_table_top($form_descriptor);
 
@@ -131,35 +133,35 @@
 
         // closes table header, opens table body
         print_table_middle();
-   
+
         // table content
         $count = 0;
         while ($row = $res->fetchRow()) {
             $rowlen = count($row);
-        
+
             // escape row elements
             for ($i = 0; $i < $rowlen; $i++) {
                 $row[$i] = htmlspecialchars($row[$i], ENT_QUOTES, 'UTF-8');
             }
-            
-            
+
+
             list($id, $pool_name, $framedipaddress, $nasipaddress, $calledstationid,
                  $callingstationid, $expiry_time, $username, $pool_key) = $row;
-            
+
             // preparing checkbox
             $id = intval($id);
             $item_id = sprintf("ippool-%d", $id);
-            
+
             $tooltip = array(
                                 'subject' => $pool_name,
                                 'actions' => array(),
                             );
             $tooltip['actions'][] = array( 'href' => sprintf('mng-rad-ippool-edit.php?item=%s', $item_id, ), 'label' => t('Tooltip','EditIPAddress'), );
             $tooltip['actions'][] = array( 'href' => sprintf('mng-rad-ippool-del.php?item[]=%s', $item_id, ), 'label' => t('Tooltip','RemoveIPAddress'), );
-            
+
             // create tooltip
             $tooltip = get_tooltip_list_str($tooltip);
-            
+
             // create checkbox
             $d = array( 'name' => 'item[]', 'value' => $item_id, 'label' => $id );
             $checkbox = get_checkbox_str($d);
@@ -170,11 +172,11 @@
 
             // print table row
             print_table_row($table_row);
-            
+
             $count++;
 
         }
-        
+
         // close tbody,
         // print tfoot
         // and close table + form (if any)
@@ -191,15 +193,15 @@
         // get and print "links"
         $links = setupLinks_str($pageNum, $maxPage, $orderBy, $orderType);
         printLinks($links, $drawNumberLinks);
-        
+
     } else {
         $failureMsg = "Nothing to display";
-        include_once("include/management/actionMessages.php");
+        include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'actionMessages.php' ]);
     }
-    
-    include('../common/includes/db_close.php');
 
-    include('include/config/logging.php');
-    
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
+
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_CONFIG'], 'logging.php' ]);
+
     print_footer_and_html_epilogue();
 ?>

--- a/app/operators/mng-rad-ippool-list.php
+++ b/app/operators/mng-rad-ippool-list.php
@@ -152,36 +152,54 @@
             $id = intval($id);
             $item_id = sprintf("ippool-%d", $id);
 
-            $tooltip = array(
+            $tooltip1 = array(
                                 'subject' => $pool_name,
                                 'actions' => array(),
                             );
-            $tooltip['actions'][] = array( 'href' => sprintf('mng-rad-ippool-edit.php?item=%s', $item_id, ), 'label' => t('Tooltip','EditIPAddress'), );
+            $tooltip1['actions'][] = array( 'href' => sprintf('mng-rad-ippool-edit.php?item=%s', $item_id, ), 'label' => t('Tooltip','EditIPAddress'), );
             $tooltip['actions'][] = array( 'href' => sprintf('mng-rad-ippool-del.php?item[]=%s', $item_id, ), 'label' => t('Tooltip','RemoveIPAddress'), );
 
             // create tooltip
-            $tooltip = get_tooltip_list_str($tooltip);
+            $tooltip1 = get_tooltip_list_str($tooltip1);
 
             // create checkbox
             $d = array( 'name' => 'item[]', 'value' => $item_id, 'label' => $id );
             $checkbox = get_checkbox_str($d);
 
-            if (preg_match(IP_REGEX, $nasipaddress, $m) || preg_match(HOSTNAME_REGEX, $nasipaddress, $m)) {
+            // framed IP address accounting tooltip
+            if (preg_match(LOOSE_IP_REGEX, $framedipaddress, $m)) {
                 $tooltip2 = [
-                    'subject' => $nasipaddress,
+                    'subject' => $framedipaddress,
                     'actions' => [],
                 ];
                 $tooltip2['actions'][] = [
-                    'href'  => sprintf('acct-nasipaddress.php?ipaddress=%s', urlencode($nasipaddress)),
-                    'label' => t('button', 'NASIPAccounting'),
+                    'href'  => sprintf('acct-ipaddress.php?ipaddress=%s', urlencode($framedipaddress)),
+                    'label' => t('button', 'IPAccounting'),
                 ];
                 $tooltip2 = get_tooltip_list_str($tooltip2);
             } else {
-                $tooltip2 = (!empty($nasipaddress)) ? $nasipaddress : "(n/a)";
+                $tooltip2 = (!empty($framedipaddress)) ? $framedipaddress : "(n/a)";
             }
 
+            // NAS IP accounting tooltip
+            if (preg_match(IP_REGEX, $nasipaddress, $m) || preg_match(HOSTNAME_REGEX, $nasipaddress, $m)) {
+                $tooltip3 = [
+                    'subject' => $nasipaddress,
+                    'actions' => [],
+                ];
+                $tooltip3['actions'][] = [
+                    'href'  => sprintf('acct-nasipaddress.php?ipaddress=%s', urlencode($nasipaddress)),
+                    'label' => t('button', 'NASIPAccounting'),
+                ];
+                $tooltip3 = get_tooltip_list_str($tooltip3);
+            } else {
+                $tooltip3 = (!empty($nasipaddress)) ? $nasipaddress : "(n/a)";
+            }
+
+
+
             // build table row
-            $table_row = array( $checkbox, $tooltip, $framedipaddress, $tooltip2, $calledstationid,
+            $table_row = array( $checkbox, $tooltip1, $tooltip2, $tooltip3, $calledstationid,
                                 $callingstationid, $expiry_time, $username, $pool_key );
 
             // print table row

--- a/app/operators/mng-rad-ippool-list.php
+++ b/app/operators/mng-rad-ippool-list.php
@@ -239,8 +239,17 @@
             }
 
             // build table row
-            $table_row = array( $checkbox, $tooltip1, $tooltip2, $tooltip3, $calledstationid,
-                                $callingstationid, $badge1, $tooltip4, $pool_key );
+            $table_row = array(
+                $checkbox,
+                $tooltip1,
+                $tooltip2,
+                $tooltip3,
+                (!empty($calledstationid)) ? $calledstationid : "(n/a)",
+                (!empty($callingstationid)) ? $callingstationid : "(n/a)",
+                $badge1,
+                $tooltip4,
+                (!empty($pool_key)) ? $pool_key : "(n/a)",
+            );
 
             // print table row
             print_table_row($table_row);

--- a/app/operators/mng-rad-ippool-new.php
+++ b/app/operators/mng-rad-ippool-new.php
@@ -20,17 +20,16 @@
  *
  *********************************************************************************************************
  */
- 
-    include("library/checklogin.php");
+
+    include_once implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', 'common', 'includes', 'config_read.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'checklogin.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'check_operator_perm.php' ]);
     $operator = $_SESSION['operator_user'];
 
-    include('library/check_operator_perm.php');
-    include_once('../common/includes/config_read.php');
-
-    include_once("lang/main.php");
-    include_once("../common/includes/validation.php");
-    include("../common/includes/layout.php");
-    include_once("include/management/populate_selectbox.php");
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LANG'], 'main.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'validation.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'layout.php' ]);
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'populate_selectbox.php' ]);
 
     // init logging variables
     $log = "visited page: ";
@@ -39,26 +38,26 @@
 
     // load valid ippools
     $valid_ippools = get_ippools();
-    
-    include('../common/includes/db_open.php');
+
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
 
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    
+
         if (array_key_exists('csrf_token', $_POST) && isset($_POST['csrf_token']) && dalo_check_csrf_token($_POST['csrf_token'])) {
-        
+
             $pool_name = (array_key_exists('pool_name', $_POST) && !empty(str_replace("%", "", trim($_POST['pool_name']))))
                        ? str_replace("%", "", trim($_POST['pool_name'])) : "";
-                      
+
             $framedipaddress = (array_key_exists('framedipaddress', $_POST) && !empty(trim($_POST['framedipaddress'])) &&
                                 filter_var(trim($_POST['framedipaddress']), FILTER_VALIDATE_IP) !== false)
                              ? trim($_POST['framedipaddress']) : "";
-            
+
             if (empty($framedipaddress) || empty($pool_name)) {
                 // required
                 $failureMsg = sprintf("Empty/invalid %s and/or %s", t('all','PoolName'), t('all','IPAddress'));
                 $logAction .= "$failureMsg on page: ";
             } else {
-                
+
                 $sql = sprintf("SELECT COUNT(id)
                                   FROM %s
                                  WHERE framedipaddress=?", $configValues['CONFIG_DB_TBL_RADIPPOOL']);
@@ -66,9 +65,9 @@
                 $values = array( $framedipaddress, );
                 $res = $dbSocket->execute($prep, $values);
                 $logDebugSQL .= "$sql;\n";
-                
+
                 $exists = $res->fetchrow()[0] > 0;
-                
+
                 if ($exists) {
                     // invalid
                     $failureMsg = sprintf("The chosen %s is already contained in a pool", t('all','IPAddress'));
@@ -80,13 +79,13 @@
                     $values = array( $pool_name, $framedipaddress );
                     $res = $dbSocket->execute($prep, $values);
                     $logDebugSQL .= "$sql;\n";
-                    
+
                     if (!DB::isError($res)) {
                         // retrieve item id
                         $sql = sprintf("SELECT CONCAT('ippool-', LAST_INSERT_ID()) FROM %s",
                                        $configValues['CONFIG_DB_TBL_RADIPPOOL']);
                         $item_id = $dbSocket->getOne($sql);
-                        
+
                         $successMsg = sprintf("Successfully added a new ippool item (item id: %s)", $item_id)
                                     . sprintf(' [<a href="mng-rad-ippool-edit.php?item=%s" title="Edit">Edit</a>]',
                                               urlencode($item_id));
@@ -96,9 +95,9 @@
                         $logAction .= "$failureMsg on page: ";
                     }
                 }
-                
+
             }
-        
+
         } else {
             // csrf
             $failureMsg = "CSRF token error";
@@ -106,21 +105,19 @@
         }
     }
 
-    include('../common/includes/db_close.php');
-    
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
+
 
     // print HTML prologue
     $title = t('Intro','mngradippoolnew.php');
     $help = t('helpPage','mngradippoolnew');
-    
+
     print_html_prologue($title, $langCode);
 
-    
-
     print_title_and_help($title, $help);
-    
-    include_once('include/management/actionMessages.php');
-    
+
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'actionMessages.php' ]);
+
     if (!isset($successMsg)) {
          // descriptors 0
         $input_descriptors0 = array();
@@ -132,7 +129,7 @@
                                         'value' => (isset($pool_name) ? $pool_name : ""),
                                         'required' => true
                                      );
-                                     
+
         $input_descriptors0[] = array(
                                         'name' => 'framedipaddress',
                                         'caption' => t('all','IPAddress'),
@@ -141,7 +138,7 @@
                                         'pattern' => trim(IP_REGEX, '/'),
                                         'required' => true
                                      );
-                                     
+
         // descriptors 1
         $input_descriptors1 = array();
 
@@ -181,7 +178,7 @@
 
     print_back_to_previous_page();
 
-    include('include/config/logging.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_CONFIG'], 'logging.php' ]);
     print_footer_and_html_epilogue();
-    
+
 ?>

--- a/app/operators/mng-rad-ippool.php
+++ b/app/operators/mng-rad-ippool.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /*
  *********************************************************************************************************
  * daloRADIUS - RADIUS Web Platform
@@ -21,29 +21,24 @@
  *********************************************************************************************************
  */
 
-    include ("library/checklogin.php");
+    include_once implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', 'common', 'includes', 'config_read.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'checklogin.php' ]);
     $operator = $_SESSION['operator_user'];
 
-    include_once('../common/includes/config_read.php');
-    $log = "visited page: ";
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LANG'], 'main.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'layout.php' ]);
 
-    include_once("lang/main.php");
-    
-    include("../common/includes/layout.php");
+    // init logging variables
+    $log = "visited page: ";
 
     // print HTML prologue
     $title = t('Intro','mngradippool.php');
     $help = t('helpPage','mngradippool');
-    
+
     print_html_prologue($title, $langCode);
-
-    
-    
-
     print_title_and_help($title, $help);
-    
-    include('include/config/logging.php');
 
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_CONFIG'], 'logging.php' ]);
     print_footer_and_html_epilogue();
 
 ?>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored IP pool operator pages to use portable include paths and upgraded the IP pool list with accounting tooltips and clearer cell rendering. Adds quick links for IP/user accounting, an expiry badge, and AJAX user info to speed up operations.

- **New Features**
  - Tooltips with quick links for framed IP, NAS IP, and username (accounting and user edit).
  - On-demand user info via AJAX in the list.
  - Expiry time shown as a green/red badge; empty cells now display “(n/a)”.

- **Refactors**
  - Replaced hardcoded includes with `implode(DIRECTORY_SEPARATOR, ...)` using `$configValues` paths.
  - Standardized includes for login, permissions, layout, validation, and logging across pages.
  - Consistent DB open/close and management include usage; added required JS (`static/js/ajax.js`, `static/js/ajaxGeneric.js`).

<sup>Written for commit 0cc99fd5a50f76248a1c46ceeb6afa5f1653ca08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

