### PR TITLE
Feat/operator totp mfa

### DIFF
--- a/README.docker-standalone.md
+++ b/README.docker-standalone.md
@@ -73,6 +73,18 @@ RADIUS authentication and accounting listen on host UDP ports `1812` and `1813`.
 
 MariaDB data remains in `./data/mysql`, FreeRADIUS init state remains in `./data/freeradius`, and daloRADIUS init state remains in `./data/daloradius`.
 
+
+## Database migrations for upgrades
+
+Fresh Docker deployments initialize the database from the bundled schema. When upgrading an existing Docker deployment, check `contrib/db/migrations/` in the updated source tree and apply the relevant SQL migrations before using newly added features.
+
+For example, to apply the operator MFA migration from the directory that contains `docker-compose.yml`:
+
+```bash
+docker compose exec -T radius-mysql sh -lc 'mariadb -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE"' \
+  < contrib/db/migrations/2026-06-operator-totp-mfa.sql
+```
+
 ## Import an existing database backup
 
 To initialize a new Docker stack from an existing MariaDB dump, copy one or more `.sql` or `.sql.gz` files into `./var/backup` before the first startup:

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ daloRADIUS supports Operators for complete management of the entire platform. Di
 - **Create New Operator**
 - **Edit Operator**
 - **Delete Operator**
+- **Two-Factor Authentication**: Operators can enable TOTP-based MFA for their own account. Administrators can reset an operator's MFA from the UI or from the server command line; see [Operator two-factor authentication recovery](doc/setup/operator-mfa.md).
 
 
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ daloRADIUS supports Operators for complete management of the entire platform. Di
 - **Delete Operator**
 - **Two-Factor Authentication**: Operators can enable TOTP-based MFA for their own account. Administrators can reset an operator's MFA from the UI or from the server command line; see [Operator two-factor authentication recovery](doc/setup/operator-mfa.md).
 
+### Database migrations
+
+Fresh installations use the schema in `contrib/db/mariadb-daloradius.sql`. When upgrading an existing daloRADIUS installation, check `contrib/db/migrations/` and apply the relevant SQL migrations to your database before using newly added features.
+
 
 
 # Credits

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Fresh installations use the schema in `contrib/db/mariadb-daloradius.sql`. When 
 * htmlpurifier - [https://github.com/ezyang/htmlpurifier](https://github.com/ezyang/htmlpurifier)
 * jpgraph - [https://jpgraph.net/](https://jpgraph.net/)
 * phpmailer - [https://github.com/PHPMailer/PHPMailer](https://github.com/PHPMailer/PHPMailer)
+* totp-php - [https://github.com/remotemerge/totp-php](https://github.com/remotemerge/totp-php)
 
 
 # Support

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Fresh installations use the schema in `contrib/db/mariadb-daloradius.sql`. When 
 * htmlpurifier - [https://github.com/ezyang/htmlpurifier](https://github.com/ezyang/htmlpurifier)
 * jpgraph - [https://jpgraph.net/](https://jpgraph.net/)
 * phpmailer - [https://github.com/PHPMailer/PHPMailer](https://github.com/PHPMailer/PHPMailer)
+* php-svg-qrcode - [https://github.com/philronan/php-svg-qrcode](https://github.com/philronan/php-svg-qrcode)
 * totp-php - [https://github.com/remotemerge/totp-php](https://github.com/remotemerge/totp-php)
 
 

--- a/app/common/library/php-svg-qrcode/LICENSE
+++ b/app/common/library/php-svg-qrcode/LICENSE
@@ -1,0 +1,24 @@
+The MIT License (MIT)
+
+Copyright (c) 2016-2018 Kreative Software
+Copyright (c) 2019 Pyson
+Copyright (c) 2025 Phil Ronan
+
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/app/common/library/php-svg-qrcode/ORIGIN.md
+++ b/app/common/library/php-svg-qrcode/ORIGIN.md
@@ -1,0 +1,8 @@
+# php-svg-qrcode origin
+
+Vendored from: https://github.com/philronan/php-svg-qrcode
+Commit: 7a37cc758a666ad905a70e9d36800ea295eb7847
+Date vendored: 2026-06-03
+License: MIT; see LICENSE.
+
+This library is used to render local SVG QR codes for TOTP setup without sending MFA secrets to an external QR-code service.

--- a/app/common/library/php-svg-qrcode/qrcode.php
+++ b/app/common/library/php-svg-qrcode/qrcode.php
@@ -1,0 +1,1286 @@
+<?php
+/****************************************************************************\
+
+qrcode.php - Generate QR Codes. MIT license.
+
+Copyright for portions of this project are held by Kreative Software, 2016-2018.
+All other copyright for the project are held by Donald Becker, 2019
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+\****************************************************************************/
+
+if (realpath(__FILE__) == realpath($_SERVER['SCRIPT_FILENAME'])) {
+	$generator = new QRCode($_REQUEST['d'], $_REQUEST);
+	$generator->output_image();
+	exit(0);
+}
+
+class QRCode {
+	protected $data;
+	protected $options;
+
+	public function __construct($data, $options = []) {
+		$defaults = [
+			's' => 'qrl'
+		];
+
+		if(!is_array($options)) $options = [];
+
+		$this->data    = $data;
+		$this->options = array_merge($defaults, $options);
+	}
+
+	public function output_image() {
+		$image = $this->render_image();
+
+		header('Content-Type: image/png');
+		imagepng($image);
+		imagedestroy($image);
+	}
+
+	public function render_image() {
+		list($code, $widths, $width, $height, $x, $y, $w, $h) = $this->encode_and_calculate_size($this->data, $this->options);
+
+		$image = imagecreatetruecolor($width, $height);
+		imagesavealpha($image, true);
+
+		$bgcolor = (isset($this->options['bc']) ? $this->options['bc'] : 'FFFFFF');
+		$bgcolor = $this->allocate_color($image, $bgcolor);
+		imagefill($image, 0, 0, $bgcolor);
+
+		$fgcolor = (isset($this->options['fc']) ? $this->options['fc'] : '000000');
+		$fgcolor = $this->allocate_color($image, $fgcolor);
+
+		$colors = array($bgcolor, $fgcolor);
+
+		$density = (isset($this->options['md']) ? (float)$this->options['md'] : 1);
+		list($width, $height) = $this->calculate_size($code, $widths);
+		if ($width && $height) {
+			$scale = min($w / $width, $h / $height);
+			$scale = (($scale > 1) ? floor($scale) : 1);
+			$x = floor($x + ($w - $width * $scale) / 2);
+			$y = floor($y + ($h - $height * $scale) / 2);
+		} else {
+			$scale = 1;
+			$x = floor($x + $w / 2);
+			$y = floor($y + $h / 2);
+		}
+
+		$x += $code['q'][3] * $widths[0] * $scale;
+		$y += $code['q'][0] * $widths[0] * $scale;
+		$wh = $widths[1] * $scale;
+		foreach ($code['b'] as $by => $row) {
+			$y1 = $y + $by * $wh;
+			foreach ($row as $bx => $color) {
+				$x1 = $x + $bx * $wh;
+				$mc = $colors[$color ? 1 : 0];
+				$rx = floor($x1 + (1 - $density) * $wh / 2);
+				$ry = floor($y1 + (1 - $density) * $wh / 2);
+				$rw = ceil($wh * $density);
+				$rh = ceil($wh * $density);
+				imagefilledrectangle($image, $rx, $ry, $rx+$rw-1, $ry+$rh-1, $mc);
+			}
+		}
+
+		return $image;
+	}
+
+	/* - - - - INTERNAL FUNCTIONS - - - - */
+
+	protected function encode_and_calculate_size($data, $options) {
+		$code = $this->dispatch_encode($data, $options);
+		$widths = array(
+			(isset($options['wq']) ? (int)$options['wq'] : 1),
+			(isset($options['wm']) ? (int)$options['wm'] : 1),
+		);
+
+		$size     = $this->calculate_size($code, $widths);
+		$dscale   = 4;
+		$scale    = (isset($options['sf']) ? (float)$options['sf'] : $dscale);
+		$scalex   = (isset($options['sx']) ? (float)$options['sx'] : $scale);
+		$scaley   = (isset($options['sy']) ? (float)$options['sy'] : $scale);
+		$dpadding = 0;
+		$padding  = (isset($options['p']) ? (int)$options['p'] : $dpadding);
+		$vert     = (isset($options['pv']) ? (int)$options['pv'] : $padding);
+		$horiz    = (isset($options['ph']) ? (int)$options['ph'] : $padding);
+		$top      = (isset($options['pt']) ? (int)$options['pt'] : $vert);
+		$left     = (isset($options['pl']) ? (int)$options['pl'] : $horiz);
+		$right    = (isset($options['pr']) ? (int)$options['pr'] : $horiz);
+		$bottom   = (isset($options['pb']) ? (int)$options['pb'] : $vert);
+		$dwidth   = ceil($size[0] * $scalex) + $left + $right;
+		$dheight  = ceil($size[1] * $scaley) + $top + $bottom;
+		$iwidth   = (isset($options['w']) ? (int)$options['w'] : $dwidth);
+		$iheight  = (isset($options['h']) ? (int)$options['h'] : $dheight);
+		$swidth   = $iwidth - $left - $right;
+		$sheight  = $iheight - $top - $bottom;
+
+		return array($code, $widths, $iwidth, $iheight, $left, $top, $swidth, $sheight);
+	}
+
+	private function allocate_color($image, $color) {
+		$color = preg_replace('/[^0-9A-Fa-f]/', '', $color);
+		$r = hexdec(substr($color, 0, 2));
+		$g = hexdec(substr($color, 2, 2));
+		$b = hexdec(substr($color, 4, 2));
+		return imagecolorallocate($image, $r, $g, $b);
+	}
+
+	/* - - - - DISPATCH - - - - */
+
+	private function dispatch_encode($data, $options) {
+		switch (strtolower(preg_replace('/[^A-Za-z0-9]/', '', $options['s']))) {
+			case 'qrl': return $this->qr_encode($data, 0);
+			case 'qrm': return $this->qr_encode($data, 1);
+			case 'qrq': return $this->qr_encode($data, 2);
+			case 'qrh': return $this->qr_encode($data, 3);
+			default:    return $this->qr_encode($data, 0);
+		}
+		return null;
+	}
+
+	/* - - - - MATRIX BARCODE RENDERER - - - - */
+
+	private function calculate_size($code, $widths) {
+		$width = (
+			$code['q'][3] * $widths[0] +
+			$code['s'][0] * $widths[1] +
+			$code['q'][1] * $widths[0]
+		);
+		$height = (
+			$code['q'][0] * $widths[0] +
+			$code['s'][1] * $widths[1] +
+			$code['q'][2] * $widths[0]
+		);
+		return array($width, $height);
+	}
+
+	/* - - - - QR ENCODER - - - - */
+
+	private function qr_encode($data, $ecl) {
+		list($mode, $vers, $ec, $data) = $this->qr_encode_data($data, $ecl);
+		$data = $this->qr_encode_ec($data, $ec, $vers);
+		list($size, $mtx) = $this->qr_create_matrix($vers, $data);
+		list($mask, $mtx) = $this->qr_apply_best_mask($mtx, $size);
+		$mtx = $this->qr_finalize_matrix($mtx, $size, $ecl, $mask, $vers);
+		return array(
+			'q' => array(4, 4, 4, 4),
+			's' => array($size, $size),
+			'b' => $mtx
+		);
+	}
+
+	private function qr_encode_data($data, $ecl) {
+		$mode = $this->qr_detect_mode($data);
+		$version = $this->qr_detect_version($data, $mode, $ecl);
+		$version_group = (($version < 10) ? 0 : (($version < 27) ? 1 : 2));
+		$ec_params = $this->qr_ec_params[($version - 1) * 4 + $ecl];
+
+		/* Don't cut off mid-character if exceeding capacity. */
+		$max_chars = $this->qr_capacity[$version - 1][$ecl][$mode];
+		if ($mode == 3) $max_chars <<= 1;
+		$data = substr($data, 0, $max_chars);
+
+		/* Convert from character level to bit level. */
+		switch ($mode) {
+			case 0:
+				$code = $this->qr_encode_numeric($data, $version_group);
+				break;
+			case 1:
+				$code = $this->qr_encode_alphanumeric($data, $version_group);
+				break;
+			case 2:
+				$code = $this->qr_encode_binary($data, $version_group);
+				break;
+			case 3:
+				$code = $this->qr_encode_kanji($data, $version_group);
+				break;
+		}
+
+		for ($i = 0; $i < 4; $i++) $code[] = 0;
+		while (count($code) % 8) $code[] = 0;
+
+		/* Convert from bit level to byte level. */
+		$data = array();
+		for ($i = 0, $n = count($code); $i < $n; $i += 8) {
+			$byte = 0;
+			if ($code[$i + 0]) $byte |= 0x80;
+			if ($code[$i + 1]) $byte |= 0x40;
+			if ($code[$i + 2]) $byte |= 0x20;
+			if ($code[$i + 3]) $byte |= 0x10;
+			if ($code[$i + 4]) $byte |= 0x08;
+			if ($code[$i + 5]) $byte |= 0x04;
+			if ($code[$i + 6]) $byte |= 0x02;
+			if ($code[$i + 7]) $byte |= 0x01;
+			$data[] = $byte;
+		}
+
+		for ($i = count($data), $a = 1, $n = $ec_params[0]; $i < $n; $i++, $a ^= 1) {
+			$data[] = $a ? 236 : 17;
+		}
+
+		/* Return. */
+		return array($mode, $version, $ec_params, $data);
+	}
+
+	private function qr_detect_mode($data) {
+		$numeric = '/^[0-9]*$/';
+		$alphanumeric = '/^[0-9A-Z .\/:$%*+-]*$/';
+		$kanji = '/^([\x81-\x9F\xE0-\xEA][\x40-\xFC]|[\xEB][\x40-\xBF])*$/';
+		if (preg_match($numeric, $data)) return 0;
+		if (preg_match($alphanumeric, $data)) return 1;
+		if (preg_match($kanji, $data)) return 3;
+		return 2;
+	}
+
+	private function qr_detect_version($data, $mode, $ecl) {
+		$length = strlen($data);
+		if ($mode == 3) $length >>= 1;
+		for ($v = 0; $v < 40; $v++) {
+			if ($length <= $this->qr_capacity[$v][$ecl][$mode]) {
+				return $v + 1;
+			}
+		}
+		return 40;
+	}
+
+	private function qr_encode_numeric($data, $version_group) {
+		$code = array(0, 0, 0, 1);
+		$length = strlen($data);
+		switch ($version_group) {
+			case 2:  /* 27 - 40 */
+				$code[] = $length & 0x2000;
+				$code[] = $length & 0x1000;
+			case 1:  /* 10 - 26 */
+				$code[] = $length & 0x0800;
+				$code[] = $length & 0x0400;
+			case 0:  /* 1 - 9 */
+				$code[] = $length & 0x0200;
+				$code[] = $length & 0x0100;
+				$code[] = $length & 0x0080;
+				$code[] = $length & 0x0040;
+				$code[] = $length & 0x0020;
+				$code[] = $length & 0x0010;
+				$code[] = $length & 0x0008;
+				$code[] = $length & 0x0004;
+				$code[] = $length & 0x0002;
+				$code[] = $length & 0x0001;
+		}
+		for ($i = 0; $i < $length; $i += 3) {
+			$group = substr($data, $i, 3);
+			switch (strlen($group)) {
+				case 3:
+					$code[] = $group & 0x200;
+					$code[] = $group & 0x100;
+					$code[] = $group & 0x080;
+				case 2:
+					$code[] = $group & 0x040;
+					$code[] = $group & 0x020;
+					$code[] = $group & 0x010;
+				case 1:
+					$code[] = $group & 0x008;
+					$code[] = $group & 0x004;
+					$code[] = $group & 0x002;
+					$code[] = $group & 0x001;
+			}
+		}
+		return $code;
+	}
+
+	private function qr_encode_alphanumeric($data, $version_group) {
+		$alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:';
+		$code = array(0, 0, 1, 0);
+		$length = strlen($data);
+		switch ($version_group) {
+			case 2:  /* 27 - 40 */
+				$code[] = $length & 0x1000;
+				$code[] = $length & 0x0800;
+			case 1:  /* 10 - 26 */
+				$code[] = $length & 0x0400;
+				$code[] = $length & 0x0200;
+			case 0:  /* 1 - 9 */
+				$code[] = $length & 0x0100;
+				$code[] = $length & 0x0080;
+				$code[] = $length & 0x0040;
+				$code[] = $length & 0x0020;
+				$code[] = $length & 0x0010;
+				$code[] = $length & 0x0008;
+				$code[] = $length & 0x0004;
+				$code[] = $length & 0x0002;
+				$code[] = $length & 0x0001;
+		}
+		for ($i = 0; $i < $length; $i += 2) {
+			$group = substr($data, $i, 2);
+			if (strlen($group) > 1) {
+				$c1 = strpos($alphabet, substr($group, 0, 1));
+				$c2 = strpos($alphabet, substr($group, 1, 1));
+				$ch = $c1 * 45 + $c2;
+				$code[] = $ch & 0x400;
+				$code[] = $ch & 0x200;
+				$code[] = $ch & 0x100;
+				$code[] = $ch & 0x080;
+				$code[] = $ch & 0x040;
+				$code[] = $ch & 0x020;
+				$code[] = $ch & 0x010;
+				$code[] = $ch & 0x008;
+				$code[] = $ch & 0x004;
+				$code[] = $ch & 0x002;
+				$code[] = $ch & 0x001;
+			} else {
+				$ch = strpos($alphabet, $group);
+				$code[] = $ch & 0x020;
+				$code[] = $ch & 0x010;
+				$code[] = $ch & 0x008;
+				$code[] = $ch & 0x004;
+				$code[] = $ch & 0x002;
+				$code[] = $ch & 0x001;
+			}
+		}
+		return $code;
+	}
+
+	private function qr_encode_binary($data, $version_group) {
+		$code = array(0, 1, 0, 0);
+		$length = strlen($data);
+		switch ($version_group) {
+			case 2:  /* 27 - 40 */
+			case 1:  /* 10 - 26 */
+				$code[] = $length & 0x8000;
+				$code[] = $length & 0x4000;
+				$code[] = $length & 0x2000;
+				$code[] = $length & 0x1000;
+				$code[] = $length & 0x0800;
+				$code[] = $length & 0x0400;
+				$code[] = $length & 0x0200;
+				$code[] = $length & 0x0100;
+			case 0:  /* 1 - 9 */
+				$code[] = $length & 0x0080;
+				$code[] = $length & 0x0040;
+				$code[] = $length & 0x0020;
+				$code[] = $length & 0x0010;
+				$code[] = $length & 0x0008;
+				$code[] = $length & 0x0004;
+				$code[] = $length & 0x0002;
+				$code[] = $length & 0x0001;
+		}
+		for ($i = 0; $i < $length; $i++) {
+			$ch = ord(substr($data, $i, 1));
+			$code[] = $ch & 0x80;
+			$code[] = $ch & 0x40;
+			$code[] = $ch & 0x20;
+			$code[] = $ch & 0x10;
+			$code[] = $ch & 0x08;
+			$code[] = $ch & 0x04;
+			$code[] = $ch & 0x02;
+			$code[] = $ch & 0x01;
+		}
+		return $code;
+	}
+
+	private function qr_encode_kanji($data, $version_group) {
+		$code = array(1, 0, 0, 0);
+		$length = strlen($data);
+		switch ($version_group) {
+			case 2:  /* 27 - 40 */
+				$code[] = $length & 0x1000;
+				$code[] = $length & 0x0800;
+			case 1:  /* 10 - 26 */
+				$code[] = $length & 0x0400;
+				$code[] = $length & 0x0200;
+			case 0:  /* 1 - 9 */
+				$code[] = $length & 0x0100;
+				$code[] = $length & 0x0080;
+				$code[] = $length & 0x0040;
+				$code[] = $length & 0x0020;
+				$code[] = $length & 0x0010;
+				$code[] = $length & 0x0008;
+				$code[] = $length & 0x0004;
+				$code[] = $length & 0x0002;
+		}
+		for ($i = 0; $i < $length; $i += 2) {
+			$group = substr($data, $i, 2);
+			$c1 = ord(substr($group, 0, 1));
+			$c2 = ord(substr($group, 1, 1));
+			if ($c1 >= 0x81 && $c1 <= 0x9F && $c2 >= 0x40 && $c2 <= 0xFC) {
+				$ch = ($c1 - 0x81) * 0xC0 + ($c2 - 0x40);
+			} else if (
+				($c1 >= 0xE0 && $c1 <= 0xEA && $c2 >= 0x40 && $c2 <= 0xFC) ||
+				($c1 == 0xEB && $c2 >= 0x40 && $c2 <= 0xBF)
+			) {
+				$ch = ($c1 - 0xC1) * 0xC0 + ($c2 - 0x40);
+			} else {
+				$ch = 0;
+			}
+			$code[] = $ch & 0x1000;
+			$code[] = $ch & 0x0800;
+			$code[] = $ch & 0x0400;
+			$code[] = $ch & 0x0200;
+			$code[] = $ch & 0x0100;
+			$code[] = $ch & 0x0080;
+			$code[] = $ch & 0x0040;
+			$code[] = $ch & 0x0020;
+			$code[] = $ch & 0x0010;
+			$code[] = $ch & 0x0008;
+			$code[] = $ch & 0x0004;
+			$code[] = $ch & 0x0002;
+			$code[] = $ch & 0x0001;
+		}
+		return $code;
+	}
+
+	private function qr_encode_ec($data, $ec_params, $version) {
+		$blocks = $this->qr_ec_split($data, $ec_params);
+		$ec_blocks = array();
+		for ($i = 0, $n = count($blocks); $i < $n; $i++) {
+			$ec_blocks[] = $this->qr_ec_divide($blocks[$i], $ec_params);
+		}
+		$data = $this->qr_ec_interleave($blocks);
+		$ec_data = $this->qr_ec_interleave($ec_blocks);
+		$code = array();
+		foreach ($data as $ch) {
+			$code[] = $ch & 0x80;
+			$code[] = $ch & 0x40;
+			$code[] = $ch & 0x20;
+			$code[] = $ch & 0x10;
+			$code[] = $ch & 0x08;
+			$code[] = $ch & 0x04;
+			$code[] = $ch & 0x02;
+			$code[] = $ch & 0x01;
+		}
+		foreach ($ec_data as $ch) {
+			$code[] = $ch & 0x80;
+			$code[] = $ch & 0x40;
+			$code[] = $ch & 0x20;
+			$code[] = $ch & 0x10;
+			$code[] = $ch & 0x08;
+			$code[] = $ch & 0x04;
+			$code[] = $ch & 0x02;
+			$code[] = $ch & 0x01;
+		}
+		for ($n = $this->qr_remainder_bits[$version - 1]; $n > 0; $n--) {
+			$code[] = 0;
+		}
+		return $code;
+	}
+
+	private function qr_ec_split($data, $ec_params) {
+		$blocks = array();
+		$offset = 0;
+		for ($i = $ec_params[2], $length = $ec_params[3]; $i > 0; $i--) {
+			$blocks[] = array_slice($data, $offset, $length);
+			$offset += $length;
+		}
+		for ($i = $ec_params[4], $length = $ec_params[5]; $i > 0; $i--) {
+			$blocks[] = array_slice($data, $offset, $length);
+			$offset += $length;
+		}
+		return $blocks;
+	}
+
+	private function qr_ec_divide($data, $ec_params) {
+		$num_data = count($data);
+		$num_error = $ec_params[1];
+		$generator = $this->qr_ec_polynomials[$num_error];
+		$message = $data;
+		for ($i = 0; $i < $num_error; $i++) {
+			$message[] = 0;
+		}
+		for ($i = 0; $i < $num_data; $i++) {
+			if ($message[$i]) {
+				$leadterm = $this->qr_log[$message[$i]];
+				for ($j = 0; $j <= $num_error; $j++) {
+					$term = ($generator[$j] + $leadterm) % 255;
+					$message[$i + $j] ^= $this->qr_exp[$term];
+				}
+			}
+		}
+		return array_slice($message, $num_data, $num_error);
+	}
+
+	private function qr_ec_interleave($blocks) {
+		$data = array();
+		$num_blocks = count($blocks);
+		for ($offset = 0; true; $offset++) {
+			$break = true;
+			for ($i = 0; $i < $num_blocks; $i++) {
+				if (isset($blocks[$i][$offset])) {
+					$data[] = $blocks[$i][$offset];
+					$break = false;
+				}
+			}
+			if ($break) break;
+		}
+		return $data;
+	}
+
+	private function qr_create_matrix($version, $data) {
+		$size = $version * 4 + 17;
+		$matrix = array();
+		for ($i = 0; $i < $size; $i++) {
+			$row = array();
+			for ($j = 0; $j < $size; $j++) {
+				$row[] = 0;
+			}
+			$matrix[] = $row;
+		}
+
+		/* Finder patterns. */
+		for ($i = 0; $i < 8; $i++) {
+			for ($j = 0; $j < 8; $j++) {
+				$m = (($i == 7 || $j == 7) ? 2 :
+				     (($i == 0 || $j == 0 || $i == 6 || $j == 6) ? 3 :
+				     (($i == 1 || $j == 1 || $i == 5 || $j == 5) ? 2 : 3)));
+				$matrix[$i][$j] = $m;
+				$matrix[$size - $i - 1][$j] = $m;
+				$matrix[$i][$size - $j - 1] = $m;
+			}
+		}
+
+		/* Alignment patterns. */
+		if ($version >= 2) {
+			$alignment = $this->qr_alignment_patterns[$version - 2];
+			foreach ($alignment as $i) {
+				foreach ($alignment as $j) {
+					if (!$matrix[$i][$j]) {
+						for ($ii = -2; $ii <= 2; $ii++) {
+							for ($jj = -2; $jj <= 2; $jj++) {
+								$m = (max(abs($ii), abs($jj)) & 1) ^ 3;
+								$matrix[$i + $ii][$j + $jj] = $m;
+							}
+						}
+					}
+				}
+			}
+		}
+
+		/* Timing patterns. */
+		for ($i = $size - 9; $i >= 8; $i--) {
+			$matrix[$i][6] = ($i & 1) ^ 3;
+			$matrix[6][$i] = ($i & 1) ^ 3;
+		}
+
+		/* Dark module. Such an ominous name for such an innocuous thing. */
+		$matrix[$size - 8][8] = 3;
+
+		/* Format information area. */
+		for ($i = 0; $i <= 8; $i++) {
+			if (!$matrix[$i][8]) $matrix[$i][8] = 1;
+			if (!$matrix[8][$i]) $matrix[8][$i] = 1;
+			if ($i && !$matrix[$size - $i][8]) $matrix[$size - $i][8] = 1;
+			if ($i && !$matrix[8][$size - $i]) $matrix[8][$size - $i] = 1;
+		}
+
+		/* Version information area. */
+		if ($version >= 7) {
+			for ($i = 9; $i < 12; $i++) {
+				for ($j = 0; $j < 6; $j++) {
+					$matrix[$size - $i][$j] = 1;
+					$matrix[$j][$size - $i] = 1;
+				}
+			}
+		}
+
+		/* Data. */
+		$col = $size - 1;
+		$row = $size - 1;
+		$dir = -1;
+		$offset = 0;
+		$length = count($data);
+		while ($col > 0 && $offset < $length) {
+			if (!$matrix[$row][$col]) {
+				$matrix[$row][$col] = $data[$offset] ? 5 : 4;
+				$offset++;
+			}
+			if (!$matrix[$row][$col - 1]) {
+				$matrix[$row][$col - 1] = $data[$offset] ? 5 : 4;
+				$offset++;
+			}
+			$row += $dir;
+			if ($row < 0 || $row >= $size) {
+				$dir = -$dir;
+				$row += $dir;
+				$col -= 2;
+				if ($col == 6) $col--;
+			}
+		}
+		return array($size, $matrix);
+	}
+
+	private function qr_apply_best_mask($matrix, $size) {
+		$best_mask = 0;
+		$best_matrix = $this->qr_apply_mask($matrix, $size, $best_mask);
+		$best_penalty = $this->qr_penalty($best_matrix, $size);
+		for ($test_mask = 1; $test_mask < 8; $test_mask++) {
+			$test_matrix = $this->qr_apply_mask($matrix, $size, $test_mask);
+			$test_penalty = $this->qr_penalty($test_matrix, $size);
+			if ($test_penalty < $best_penalty) {
+				$best_mask = $test_mask;
+				$best_matrix = $test_matrix;
+				$best_penalty = $test_penalty;
+			}
+		}
+		return array($best_mask, $best_matrix);
+	}
+
+	private function qr_apply_mask($matrix, $size, $mask) {
+		for ($i = 0; $i < $size; $i++) {
+			for ($j = 0; $j < $size; $j++) {
+				if ($matrix[$i][$j] >= 4) {
+					if ($this->qr_mask($mask, $i, $j)) {
+						$matrix[$i][$j] ^= 1;
+					}
+				}
+			}
+		}
+		return $matrix;
+	}
+
+	private function qr_mask($mask, $r, $c) {
+		switch ($mask) {
+			case 0: return !( ($r + $c) % 2 );
+			case 1: return !( ($r     ) % 2 );
+			case 2: return !( (     $c) % 3 );
+			case 3: return !( ($r + $c) % 3 );
+			case 4: return !( (floor(($r) / 2) + floor(($c) / 3)) % 2 );
+			case 5: return !( ((($r * $c) % 2) + (($r * $c) % 3))     );
+			case 6: return !( ((($r * $c) % 2) + (($r * $c) % 3)) % 2 );
+			case 7: return !( ((($r + $c) % 2) + (($r * $c) % 3)) % 2 );
+		}
+	}
+
+	private function qr_penalty(&$matrix, $size) {
+		$score  = $this->qr_penalty_1($matrix, $size);
+		$score += $this->qr_penalty_2($matrix, $size);
+		$score += $this->qr_penalty_3($matrix, $size);
+		$score += $this->qr_penalty_4($matrix, $size);
+		return $score;
+	}
+
+	private function qr_penalty_1(&$matrix, $size) {
+		$score = 0;
+		for ($i = 0; $i < $size; $i++) {
+			$rowvalue = 0;
+			$rowcount = 0;
+			$colvalue = 0;
+			$colcount = 0;
+			for ($j = 0; $j < $size; $j++) {
+				$rv = ($matrix[$i][$j] == 5 || $matrix[$i][$j] == 3) ? 1 : 0;
+				$cv = ($matrix[$j][$i] == 5 || $matrix[$j][$i] == 3) ? 1 : 0;
+				if ($rv == $rowvalue) {
+					$rowcount++;
+				} else {
+					if ($rowcount >= 5) $score += $rowcount - 2;
+					$rowvalue = $rv;
+					$rowcount = 1;
+				}
+				if ($cv == $colvalue) {
+					$colcount++;
+				} else {
+					if ($colcount >= 5) $score += $colcount - 2;
+					$colvalue = $cv;
+					$colcount = 1;
+				}
+			}
+			if ($rowcount >= 5) $score += $rowcount - 2;
+			if ($colcount >= 5) $score += $colcount - 2;
+		}
+		return $score;
+	}
+
+	private function qr_penalty_2(&$matrix, $size) {
+		$score = 0;
+		for ($i = 1; $i < $size; $i++) {
+			for ($j = 1; $j < $size; $j++) {
+				$v1 = $matrix[$i - 1][$j - 1];
+				$v2 = $matrix[$i - 1][$j    ];
+				$v3 = $matrix[$i    ][$j - 1];
+				$v4 = $matrix[$i    ][$j    ];
+				$v1 = ($v1 == 5 || $v1 == 3) ? 1 : 0;
+				$v2 = ($v2 == 5 || $v2 == 3) ? 1 : 0;
+				$v3 = ($v3 == 5 || $v3 == 3) ? 1 : 0;
+				$v4 = ($v4 == 5 || $v4 == 3) ? 1 : 0;
+				if ($v1 == $v2 && $v2 == $v3 && $v3 == $v4) $score += 3;
+			}
+		}
+		return $score;
+	}
+
+	private function qr_penalty_3(&$matrix, $size) {
+		$score = 0;
+		for ($i = 0; $i < $size; $i++) {
+			$rowvalue = 0;
+			$colvalue = 0;
+			for ($j = 0; $j < 11; $j++) {
+				$rv = ($matrix[$i][$j] == 5 || $matrix[$i][$j] == 3) ? 1 : 0;
+				$cv = ($matrix[$j][$i] == 5 || $matrix[$j][$i] == 3) ? 1 : 0;
+				$rowvalue = (($rowvalue << 1) & 0x7FF) | $rv;
+				$colvalue = (($colvalue << 1) & 0x7FF) | $cv;
+			}
+			if ($rowvalue == 0x5D0 || $rowvalue == 0x5D) $score += 40;
+			if ($colvalue == 0x5D0 || $colvalue == 0x5D) $score += 40;
+			for ($j = 11; $j < $size; $j++) {
+				$rv = ($matrix[$i][$j] == 5 || $matrix[$i][$j] == 3) ? 1 : 0;
+				$cv = ($matrix[$j][$i] == 5 || $matrix[$j][$i] == 3) ? 1 : 0;
+				$rowvalue = (($rowvalue << 1) & 0x7FF) | $rv;
+				$colvalue = (($colvalue << 1) & 0x7FF) | $cv;
+				if ($rowvalue == 0x5D0 || $rowvalue == 0x5D) $score += 40;
+				if ($colvalue == 0x5D0 || $colvalue == 0x5D) $score += 40;
+			}
+		}
+		return $score;
+	}
+
+	private function qr_penalty_4(&$matrix, $size) {
+		$dark = 0;
+		for ($i = 0; $i < $size; $i++) {
+			for ($j = 0; $j < $size; $j++) {
+				if ($matrix[$i][$j] == 5 || $matrix[$i][$j] == 3) {
+					$dark++;
+				}
+			}
+		}
+		$dark *= 20;
+		$dark /= $size * $size;
+		$a = abs(floor($dark) - 10);
+		$b = abs(ceil($dark) - 10);
+		return min($a, $b) * 10;
+	}
+
+	private function qr_finalize_matrix($matrix, $size, $ecl, $mask, $version) {
+		/* Format Info */
+		$format = $this->qr_format_info[$ecl * 8 + $mask];
+		$matrix[8][0] = $format[0];
+		$matrix[8][1] = $format[1];
+		$matrix[8][2] = $format[2];
+		$matrix[8][3] = $format[3];
+		$matrix[8][4] = $format[4];
+		$matrix[8][5] = $format[5];
+		$matrix[8][7] = $format[6];
+		$matrix[8][8] = $format[7];
+		$matrix[7][8] = $format[8];
+		$matrix[5][8] = $format[9];
+		$matrix[4][8] = $format[10];
+		$matrix[3][8] = $format[11];
+		$matrix[2][8] = $format[12];
+		$matrix[1][8] = $format[13];
+		$matrix[0][8] = $format[14];
+		$matrix[$size - 1][8] = $format[0];
+		$matrix[$size - 2][8] = $format[1];
+		$matrix[$size - 3][8] = $format[2];
+		$matrix[$size - 4][8] = $format[3];
+		$matrix[$size - 5][8] = $format[4];
+		$matrix[$size - 6][8] = $format[5];
+		$matrix[$size - 7][8] = $format[6];
+		$matrix[8][$size - 8] = $format[7];
+		$matrix[8][$size - 7] = $format[8];
+		$matrix[8][$size - 6] = $format[9];
+		$matrix[8][$size - 5] = $format[10];
+		$matrix[8][$size - 4] = $format[11];
+		$matrix[8][$size - 3] = $format[12];
+		$matrix[8][$size - 2] = $format[13];
+		$matrix[8][$size - 1] = $format[14];
+
+		/* Version Info */
+		if ($version >= 7) {
+			$version = $this->qr_version_info[$version - 7];
+			for ($i = 0; $i < 18; $i++) {
+				$r = $size - 9 - ($i % 3);
+				$c = 5 - floor($i / 3);
+				$matrix[$r][$c] = $version[$i];
+				$matrix[$c][$r] = $version[$i];
+			}
+		}
+
+		/* Patterns & Data */
+		for ($i = 0; $i < $size; $i++) {
+			for ($j = 0; $j < $size; $j++) {
+				$matrix[$i][$j] &= 1;
+			}
+		}
+		return $matrix;
+	}
+
+	/*  maximum encodable characters = $qr_capacity [ (version - 1) ]  */
+	/*    [ (0 for L, 1 for M, 2 for Q, 3 for H)                    ]  */
+	/*    [ (0 for numeric, 1 for alpha, 2 for binary, 3 for kanji) ]  */
+	private $qr_capacity = array(
+		array(array(  41,   25,   17,   10), array(  34,   20,   14,    8), array(  27,   16,   11,    7), array(  17,   10,    7,    4)),
+		array(array(  77,   47,   32,   20), array(  63,   38,   26,   16), array(  48,   29,   20,   12), array(  34,   20,   14,    8)),
+		array(array( 127,   77,   53,   32), array( 101,   61,   42,   26), array(  77,   47,   32,   20), array(  58,   35,   24,   15)),
+		array(array( 187,  114,   78,   48), array( 149,   90,   62,   38), array( 111,   67,   46,   28), array(  82,   50,   34,   21)),
+		array(array( 255,  154,  106,   65), array( 202,  122,   84,   52), array( 144,   87,   60,   37), array( 106,   64,   44,   27)),
+		array(array( 322,  195,  134,   82), array( 255,  154,  106,   65), array( 178,  108,   74,   45), array( 139,   84,   58,   36)),
+		array(array( 370,  224,  154,   95), array( 293,  178,  122,   75), array( 207,  125,   86,   53), array( 154,   93,   64,   39)),
+		array(array( 461,  279,  192,  118), array( 365,  221,  152,   93), array( 259,  157,  108,   66), array( 202,  122,   84,   52)),
+		array(array( 552,  335,  230,  141), array( 432,  262,  180,  111), array( 312,  189,  130,   80), array( 235,  143,   98,   60)),
+		array(array( 652,  395,  271,  167), array( 513,  311,  213,  131), array( 364,  221,  151,   93), array( 288,  174,  119,   74)),
+		array(array( 772,  468,  321,  198), array( 604,  366,  251,  155), array( 427,  259,  177,  109), array( 331,  200,  137,   85)),
+		array(array( 883,  535,  367,  226), array( 691,  419,  287,  177), array( 489,  296,  203,  125), array( 374,  227,  155,   96)),
+		array(array(1022,  619,  425,  262), array( 796,  483,  331,  204), array( 580,  352,  241,  149), array( 427,  259,  177,  109)),
+		array(array(1101,  667,  458,  282), array( 871,  528,  362,  223), array( 621,  376,  258,  159), array( 468,  283,  194,  120)),
+		array(array(1250,  758,  520,  320), array( 991,  600,  412,  254), array( 703,  426,  292,  180), array( 530,  321,  220,  136)),
+		array(array(1408,  854,  586,  361), array(1082,  656,  450,  277), array( 775,  470,  322,  198), array( 602,  365,  250,  154)),
+		array(array(1548,  938,  644,  397), array(1212,  734,  504,  310), array( 876,  531,  364,  224), array( 674,  408,  280,  173)),
+		array(array(1725, 1046,  718,  442), array(1346,  816,  560,  345), array( 948,  574,  394,  243), array( 746,  452,  310,  191)),
+		array(array(1903, 1153,  792,  488), array(1500,  909,  624,  384), array(1063,  644,  442,  272), array( 813,  493,  338,  208)),
+		array(array(2061, 1249,  858,  528), array(1600,  970,  666,  410), array(1159,  702,  482,  297), array( 919,  557,  382,  235)),
+		array(array(2232, 1352,  929,  572), array(1708, 1035,  711,  438), array(1224,  742,  509,  314), array( 969,  587,  403,  248)),
+		array(array(2409, 1460, 1003,  618), array(1872, 1134,  779,  480), array(1358,  823,  565,  348), array(1056,  640,  439,  270)),
+		array(array(2620, 1588, 1091,  672), array(2059, 1248,  857,  528), array(1468,  890,  611,  376), array(1108,  672,  461,  284)),
+		array(array(2812, 1704, 1171,  721), array(2188, 1326,  911,  561), array(1588,  963,  661,  407), array(1228,  744,  511,  315)),
+		array(array(3057, 1853, 1273,  784), array(2395, 1451,  997,  614), array(1718, 1041,  715,  440), array(1286,  779,  535,  330)),
+		array(array(3283, 1990, 1367,  842), array(2544, 1542, 1059,  652), array(1804, 1094,  751,  462), array(1425,  864,  593,  365)),
+		array(array(3517, 2132, 1465,  902), array(2701, 1637, 1125,  692), array(1933, 1172,  805,  496), array(1501,  910,  625,  385)),
+		array(array(3669, 2223, 1528,  940), array(2857, 1732, 1190,  732), array(2085, 1263,  868,  534), array(1581,  958,  658,  405)),
+		array(array(3909, 2369, 1628, 1002), array(3035, 1839, 1264,  778), array(2181, 1322,  908,  559), array(1677, 1016,  698,  430)),
+		array(array(4158, 2520, 1732, 1066), array(3289, 1994, 1370,  843), array(2358, 1429,  982,  604), array(1782, 1080,  742,  457)),
+		array(array(4417, 2677, 1840, 1132), array(3486, 2113, 1452,  894), array(2473, 1499, 1030,  634), array(1897, 1150,  790,  486)),
+		array(array(4686, 2840, 1952, 1201), array(3693, 2238, 1538,  947), array(2670, 1618, 1112,  684), array(2022, 1226,  842,  518)),
+		array(array(4965, 3009, 2068, 1273), array(3909, 2369, 1628, 1002), array(2805, 1700, 1168,  719), array(2157, 1307,  898,  553)),
+		array(array(5253, 3183, 2188, 1347), array(4134, 2506, 1722, 1060), array(2949, 1787, 1228,  756), array(2301, 1394,  958,  590)),
+		array(array(5529, 3351, 2303, 1417), array(4343, 2632, 1809, 1113), array(3081, 1867, 1283,  790), array(2361, 1431,  983,  605)),
+		array(array(5836, 3537, 2431, 1496), array(4588, 2780, 1911, 1176), array(3244, 1966, 1351,  832), array(2524, 1530, 1051,  647)),
+		array(array(6153, 3729, 2563, 1577), array(4775, 2894, 1989, 1224), array(3417, 2071, 1423,  876), array(2625, 1591, 1093,  673)),
+		array(array(6479, 3927, 2699, 1661), array(5039, 3054, 2099, 1292), array(3599, 2181, 1499,  923), array(2735, 1658, 1139,  701)),
+		array(array(6743, 4087, 2809, 1729), array(5313, 3220, 2213, 1362), array(3791, 2298, 1579,  972), array(2927, 1774, 1219,  750)),
+		array(array(7089, 4296, 2953, 1817), array(5596, 3391, 2331, 1435), array(3993, 2420, 1663, 1024), array(3057, 1852, 1273,  784)),
+	);
+
+	/*  $qr_ec_params[                                              */
+	/*    4 * (version - 1) + (0 for L, 1 for M, 2 for Q, 3 for H)  */
+	/*  ] = array(                                                  */
+	/*    total number of data codewords,                           */
+	/*    number of error correction codewords per block,           */
+	/*    number of blocks in first group,                          */
+	/*    number of data codewords per block in first group,        */
+	/*    number of blocks in second group,                         */
+	/*    number of data codewords per block in second group        */
+	/*  );                                                          */
+	private $qr_ec_params = array(
+		array(   19,  7,  1,  19,  0,   0 ),
+		array(   16, 10,  1,  16,  0,   0 ),
+		array(   13, 13,  1,  13,  0,   0 ),
+		array(    9, 17,  1,   9,  0,   0 ),
+		array(   34, 10,  1,  34,  0,   0 ),
+		array(   28, 16,  1,  28,  0,   0 ),
+		array(   22, 22,  1,  22,  0,   0 ),
+		array(   16, 28,  1,  16,  0,   0 ),
+		array(   55, 15,  1,  55,  0,   0 ),
+		array(   44, 26,  1,  44,  0,   0 ),
+		array(   34, 18,  2,  17,  0,   0 ),
+		array(   26, 22,  2,  13,  0,   0 ),
+		array(   80, 20,  1,  80,  0,   0 ),
+		array(   64, 18,  2,  32,  0,   0 ),
+		array(   48, 26,  2,  24,  0,   0 ),
+		array(   36, 16,  4,   9,  0,   0 ),
+		array(  108, 26,  1, 108,  0,   0 ),
+		array(   86, 24,  2,  43,  0,   0 ),
+		array(   62, 18,  2,  15,  2,  16 ),
+		array(   46, 22,  2,  11,  2,  12 ),
+		array(  136, 18,  2,  68,  0,   0 ),
+		array(  108, 16,  4,  27,  0,   0 ),
+		array(   76, 24,  4,  19,  0,   0 ),
+		array(   60, 28,  4,  15,  0,   0 ),
+		array(  156, 20,  2,  78,  0,   0 ),
+		array(  124, 18,  4,  31,  0,   0 ),
+		array(   88, 18,  2,  14,  4,  15 ),
+		array(   66, 26,  4,  13,  1,  14 ),
+		array(  194, 24,  2,  97,  0,   0 ),
+		array(  154, 22,  2,  38,  2,  39 ),
+		array(  110, 22,  4,  18,  2,  19 ),
+		array(   86, 26,  4,  14,  2,  15 ),
+		array(  232, 30,  2, 116,  0,   0 ),
+		array(  182, 22,  3,  36,  2,  37 ),
+		array(  132, 20,  4,  16,  4,  17 ),
+		array(  100, 24,  4,  12,  4,  13 ),
+		array(  274, 18,  2,  68,  2,  69 ),
+		array(  216, 26,  4,  43,  1,  44 ),
+		array(  154, 24,  6,  19,  2,  20 ),
+		array(  122, 28,  6,  15,  2,  16 ),
+		array(  324, 20,  4,  81,  0,   0 ),
+		array(  254, 30,  1,  50,  4,  51 ),
+		array(  180, 28,  4,  22,  4,  23 ),
+		array(  140, 24,  3,  12,  8,  13 ),
+		array(  370, 24,  2,  92,  2,  93 ),
+		array(  290, 22,  6,  36,  2,  37 ),
+		array(  206, 26,  4,  20,  6,  21 ),
+		array(  158, 28,  7,  14,  4,  15 ),
+		array(  428, 26,  4, 107,  0,   0 ),
+		array(  334, 22,  8,  37,  1,  38 ),
+		array(  244, 24,  8,  20,  4,  21 ),
+		array(  180, 22, 12,  11,  4,  12 ),
+		array(  461, 30,  3, 115,  1, 116 ),
+		array(  365, 24,  4,  40,  5,  41 ),
+		array(  261, 20, 11,  16,  5,  17 ),
+		array(  197, 24, 11,  12,  5,  13 ),
+		array(  523, 22,  5,  87,  1,  88 ),
+		array(  415, 24,  5,  41,  5,  42 ),
+		array(  295, 30,  5,  24,  7,  25 ),
+		array(  223, 24, 11,  12,  7,  13 ),
+		array(  589, 24,  5,  98,  1,  99 ),
+		array(  453, 28,  7,  45,  3,  46 ),
+		array(  325, 24, 15,  19,  2,  20 ),
+		array(  253, 30,  3,  15, 13,  16 ),
+		array(  647, 28,  1, 107,  5, 108 ),
+		array(  507, 28, 10,  46,  1,  47 ),
+		array(  367, 28,  1,  22, 15,  23 ),
+		array(  283, 28,  2,  14, 17,  15 ),
+		array(  721, 30,  5, 120,  1, 121 ),
+		array(  563, 26,  9,  43,  4,  44 ),
+		array(  397, 28, 17,  22,  1,  23 ),
+		array(  313, 28,  2,  14, 19,  15 ),
+		array(  795, 28,  3, 113,  4, 114 ),
+		array(  627, 26,  3,  44, 11,  45 ),
+		array(  445, 26, 17,  21,  4,  22 ),
+		array(  341, 26,  9,  13, 16,  14 ),
+		array(  861, 28,  3, 107,  5, 108 ),
+		array(  669, 26,  3,  41, 13,  42 ),
+		array(  485, 30, 15,  24,  5,  25 ),
+		array(  385, 28, 15,  15, 10,  16 ),
+		array(  932, 28,  4, 116,  4, 117 ),
+		array(  714, 26, 17,  42,  0,   0 ),
+		array(  512, 28, 17,  22,  6,  23 ),
+		array(  406, 30, 19,  16,  6,  17 ),
+		array( 1006, 28,  2, 111,  7, 112 ),
+		array(  782, 28, 17,  46,  0,   0 ),
+		array(  568, 30,  7,  24, 16,  25 ),
+		array(  442, 24, 34,  13,  0,   0 ),
+		array( 1094, 30,  4, 121,  5, 122 ),
+		array(  860, 28,  4,  47, 14,  48 ),
+		array(  614, 30, 11,  24, 14,  25 ),
+		array(  464, 30, 16,  15, 14,  16 ),
+		array( 1174, 30,  6, 117,  4, 118 ),
+		array(  914, 28,  6,  45, 14,  46 ),
+		array(  664, 30, 11,  24, 16,  25 ),
+		array(  514, 30, 30,  16,  2,  17 ),
+		array( 1276, 26,  8, 106,  4, 107 ),
+		array( 1000, 28,  8,  47, 13,  48 ),
+		array(  718, 30,  7,  24, 22,  25 ),
+		array(  538, 30, 22,  15, 13,  16 ),
+		array( 1370, 28, 10, 114,  2, 115 ),
+		array( 1062, 28, 19,  46,  4,  47 ),
+		array(  754, 28, 28,  22,  6,  23 ),
+		array(  596, 30, 33,  16,  4,  17 ),
+		array( 1468, 30,  8, 122,  4, 123 ),
+		array( 1128, 28, 22,  45,  3,  46 ),
+		array(  808, 30,  8,  23, 26,  24 ),
+		array(  628, 30, 12,  15, 28,  16 ),
+		array( 1531, 30,  3, 117, 10, 118 ),
+		array( 1193, 28,  3,  45, 23,  46 ),
+		array(  871, 30,  4,  24, 31,  25 ),
+		array(  661, 30, 11,  15, 31,  16 ),
+		array( 1631, 30,  7, 116,  7, 117 ),
+		array( 1267, 28, 21,  45,  7,  46 ),
+		array(  911, 30,  1,  23, 37,  24 ),
+		array(  701, 30, 19,  15, 26,  16 ),
+		array( 1735, 30,  5, 115, 10, 116 ),
+		array( 1373, 28, 19,  47, 10,  48 ),
+		array(  985, 30, 15,  24, 25,  25 ),
+		array(  745, 30, 23,  15, 25,  16 ),
+		array( 1843, 30, 13, 115,  3, 116 ),
+		array( 1455, 28,  2,  46, 29,  47 ),
+		array( 1033, 30, 42,  24,  1,  25 ),
+		array(  793, 30, 23,  15, 28,  16 ),
+		array( 1955, 30, 17, 115,  0,   0 ),
+		array( 1541, 28, 10,  46, 23,  47 ),
+		array( 1115, 30, 10,  24, 35,  25 ),
+		array(  845, 30, 19,  15, 35,  16 ),
+		array( 2071, 30, 17, 115,  1, 116 ),
+		array( 1631, 28, 14,  46, 21,  47 ),
+		array( 1171, 30, 29,  24, 19,  25 ),
+		array(  901, 30, 11,  15, 46,  16 ),
+		array( 2191, 30, 13, 115,  6, 116 ),
+		array( 1725, 28, 14,  46, 23,  47 ),
+		array( 1231, 30, 44,  24,  7,  25 ),
+		array(  961, 30, 59,  16,  1,  17 ),
+		array( 2306, 30, 12, 121,  7, 122 ),
+		array( 1812, 28, 12,  47, 26,  48 ),
+		array( 1286, 30, 39,  24, 14,  25 ),
+		array(  986, 30, 22,  15, 41,  16 ),
+		array( 2434, 30,  6, 121, 14, 122 ),
+		array( 1914, 28,  6,  47, 34,  48 ),
+		array( 1354, 30, 46,  24, 10,  25 ),
+		array( 1054, 30,  2,  15, 64,  16 ),
+		array( 2566, 30, 17, 122,  4, 123 ),
+		array( 1992, 28, 29,  46, 14,  47 ),
+		array( 1426, 30, 49,  24, 10,  25 ),
+		array( 1096, 30, 24,  15, 46,  16 ),
+		array( 2702, 30,  4, 122, 18, 123 ),
+		array( 2102, 28, 13,  46, 32,  47 ),
+		array( 1502, 30, 48,  24, 14,  25 ),
+		array( 1142, 30, 42,  15, 32,  16 ),
+		array( 2812, 30, 20, 117,  4, 118 ),
+		array( 2216, 28, 40,  47,  7,  48 ),
+		array( 1582, 30, 43,  24, 22,  25 ),
+		array( 1222, 30, 10,  15, 67,  16 ),
+		array( 2956, 30, 19, 118,  6, 119 ),
+		array( 2334, 28, 18,  47, 31,  48 ),
+		array( 1666, 30, 34,  24, 34,  25 ),
+		array( 1276, 30, 20,  15, 61,  16 ),
+	);
+
+	private $qr_ec_polynomials = array(
+		7 => array(
+			0, 87, 229, 146, 149, 238, 102, 21
+		),
+		10 => array(
+			0, 251, 67, 46, 61, 118, 70, 64, 94, 32, 45
+		),
+		13 => array(
+			0, 74, 152, 176, 100, 86, 100,
+			106, 104, 130, 218, 206, 140, 78
+		),
+		15 => array(
+			0, 8, 183, 61, 91, 202, 37, 51,
+			58, 58, 237, 140, 124, 5, 99, 105
+		),
+		16 => array(
+			0, 120, 104, 107, 109, 102, 161, 76, 3,
+			91, 191, 147, 169, 182, 194, 225, 120
+		),
+		17 => array(
+			0, 43, 139, 206, 78, 43, 239, 123, 206,
+			214, 147, 24, 99, 150, 39, 243, 163, 136
+		),
+		18 => array(
+			0, 215, 234, 158, 94, 184, 97, 118, 170, 79,
+			187, 152, 148, 252, 179, 5, 98, 96, 153
+		),
+		20 => array(
+			0, 17, 60, 79, 50, 61, 163, 26, 187, 202, 180,
+			221, 225, 83, 239, 156, 164, 212, 212, 188, 190
+		),
+		22 => array(
+			0, 210, 171, 247, 242, 93, 230, 14, 109, 221, 53, 200,
+			74, 8, 172, 98, 80, 219, 134, 160, 105, 165, 231
+		),
+		24 => array(
+			0, 229, 121, 135, 48, 211, 117, 251, 126, 159, 180, 169,
+			152, 192, 226, 228, 218, 111, 0, 117, 232, 87, 96, 227, 21
+		),
+		26 => array(
+			0, 173, 125, 158, 2, 103, 182, 118, 17,
+			145, 201, 111, 28, 165, 53, 161, 21, 245,
+			142, 13, 102, 48, 227, 153, 145, 218, 70
+		),
+		28 => array(
+			0, 168, 223, 200, 104, 224, 234, 108, 180,
+			110, 190, 195, 147, 205, 27, 232, 201, 21, 43,
+			245, 87, 42, 195, 212, 119, 242, 37, 9, 123
+		),
+		30 => array(
+			0, 41, 173, 145, 152, 216, 31, 179, 182, 50, 48,
+			110, 86, 239, 96, 222, 125, 42, 173, 226, 193,
+			224, 130, 156, 37, 251, 216, 238, 40, 192, 180
+		),
+	);
+
+	private $qr_log = array(
+		  0,   0,   1,  25,   2,  50,  26, 198,
+		  3, 223,  51, 238,  27, 104, 199,  75,
+		  4, 100, 224,  14,  52, 141, 239, 129,
+		 28, 193, 105, 248, 200,   8,  76, 113,
+		  5, 138, 101,  47, 225,  36,  15,  33,
+		 53, 147, 142, 218, 240,  18, 130,  69,
+		 29, 181, 194, 125, 106,  39, 249, 185,
+		201, 154,   9, 120,  77, 228, 114, 166,
+		  6, 191, 139,  98, 102, 221,  48, 253,
+		226, 152,  37, 179,  16, 145,  34, 136,
+		 54, 208, 148, 206, 143, 150, 219, 189,
+		241, 210,  19,  92, 131,  56,  70,  64,
+		 30,  66, 182, 163, 195,  72, 126, 110,
+		107,  58,  40,  84, 250, 133, 186,  61,
+		202,  94, 155, 159,  10,  21, 121,  43,
+		 78, 212, 229, 172, 115, 243, 167,  87,
+		  7, 112, 192, 247, 140, 128,  99,  13,
+		103,  74, 222, 237,  49, 197, 254,  24,
+		227, 165, 153, 119,  38, 184, 180, 124,
+		 17,  68, 146, 217,  35,  32, 137,  46,
+		 55,  63, 209,  91, 149, 188, 207, 205,
+		144, 135, 151, 178, 220, 252, 190,  97,
+		242,  86, 211, 171,  20,  42,  93, 158,
+		132,  60,  57,  83,  71, 109,  65, 162,
+		 31,  45,  67, 216, 183, 123, 164, 118,
+		196,  23,  73, 236, 127,  12, 111, 246,
+		108, 161,  59,  82,  41, 157,  85, 170,
+		251,  96, 134, 177, 187, 204,  62,  90,
+		203,  89,  95, 176, 156, 169, 160,  81,
+		 11, 245,  22, 235, 122, 117,  44, 215,
+		 79, 174, 213, 233, 230, 231, 173, 232,
+		116, 214, 244, 234, 168,  80,  88, 175,
+	);
+
+	private $qr_exp = array(
+		  1,   2,   4,   8,  16,  32,  64, 128,
+		 29,  58, 116, 232, 205, 135,  19,  38,
+		 76, 152,  45,  90, 180, 117, 234, 201,
+		143,   3,   6,  12,  24,  48,  96, 192,
+		157,  39,  78, 156,  37,  74, 148,  53,
+		106, 212, 181, 119, 238, 193, 159,  35,
+		 70, 140,   5,  10,  20,  40,  80, 160,
+		 93, 186, 105, 210, 185, 111, 222, 161,
+		 95, 190,  97, 194, 153,  47,  94, 188,
+		101, 202, 137,  15,  30,  60, 120, 240,
+		253, 231, 211, 187, 107, 214, 177, 127,
+		254, 225, 223, 163,  91, 182, 113, 226,
+		217, 175,  67, 134,  17,  34,  68, 136,
+		 13,  26,  52, 104, 208, 189, 103, 206,
+		129,  31,  62, 124, 248, 237, 199, 147,
+		 59, 118, 236, 197, 151,  51, 102, 204,
+		133,  23,  46,  92, 184, 109, 218, 169,
+		 79, 158,  33,  66, 132,  21,  42,  84,
+		168,  77, 154,  41,  82, 164,  85, 170,
+		 73, 146,  57, 114, 228, 213, 183, 115,
+		230, 209, 191,  99, 198, 145,  63, 126,
+		252, 229, 215, 179, 123, 246, 241, 255,
+		227, 219, 171,  75, 150,  49,  98, 196,
+		149,  55, 110, 220, 165,  87, 174,  65,
+		130,  25,  50, 100, 200, 141,   7,  14,
+		 28,  56, 112, 224, 221, 167,  83, 166,
+		 81, 162,  89, 178, 121, 242, 249, 239,
+		195, 155,  43,  86, 172,  69, 138,   9,
+		 18,  36,  72, 144,  61, 122, 244, 245,
+		247, 243, 251, 235, 203, 139,  11,  22,
+		 44,  88, 176, 125, 250, 233, 207, 131,
+		 27,  54, 108, 216, 173,  71, 142,   1,
+	);
+
+	private $qr_remainder_bits = array(
+		0, 7, 7, 7, 7, 7, 0, 0, 0, 0, 0, 0, 0, 3, 3, 3, 3, 3, 3, 3,
+		4, 4, 4, 4, 4, 4, 4, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0, 0,
+	);
+
+	protected $qr_alignment_patterns = array(
+		array(6, 18),
+		array(6, 22),
+		array(6, 26),
+		array(6, 30),
+		array(6, 34),
+		array(6, 22, 38),
+		array(6, 24, 42),
+		array(6, 26, 46),
+		array(6, 28, 50),
+		array(6, 30, 54),
+		array(6, 32, 58),
+		array(6, 34, 62),
+		array(6, 26, 46, 66),
+		array(6, 26, 48, 70),
+		array(6, 26, 50, 74),
+		array(6, 30, 54, 78),
+		array(6, 30, 56, 82),
+		array(6, 30, 58, 86),
+		array(6, 34, 62, 90),
+		array(6, 28, 50, 72,  94),
+		array(6, 26, 50, 74,  98),
+		array(6, 30, 54, 78, 102),
+		array(6, 28, 54, 80, 106),
+		array(6, 32, 58, 84, 110),
+		array(6, 30, 58, 86, 114),
+		array(6, 34, 62, 90, 118),
+		array(6, 26, 50, 74,  98, 122),
+		array(6, 30, 54, 78, 102, 126),
+		array(6, 26, 52, 78, 104, 130),
+		array(6, 30, 56, 82, 108, 134),
+		array(6, 34, 60, 86, 112, 138),
+		array(6, 30, 58, 86, 114, 142),
+		array(6, 34, 62, 90, 118, 146),
+		array(6, 30, 54, 78, 102, 126, 150),
+		array(6, 24, 50, 76, 102, 128, 154),
+		array(6, 28, 54, 80, 106, 132, 158),
+		array(6, 32, 58, 84, 110, 136, 162),
+		array(6, 26, 54, 82, 110, 138, 166),
+		array(6, 30, 58, 86, 114, 142, 170),
+	);
+
+	/*  format info string = $qr_format_info[            */
+	/*    (0 for L, 8 for M, 16 for Q, 24 for H) + mask  */
+	/*  ];                                               */
+	private $qr_format_info = array(
+		array( 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0 ),
+		array( 1, 1, 1, 0, 0, 1, 0, 1, 1, 1, 1, 0, 0, 1, 1 ),
+		array( 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 0 ),
+		array( 1, 1, 1, 1, 0, 0, 0, 1, 0, 0, 1, 1, 1, 0, 1 ),
+		array( 1, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 1, 1, 1, 1 ),
+		array( 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 1, 1, 0, 0, 0 ),
+		array( 1, 1, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1 ),
+		array( 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 0 ),
+		array( 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0 ),
+		array( 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1 ),
+		array( 1, 0, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 0, 0 ),
+		array( 1, 0, 1, 1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1 ),
+		array( 1, 0, 0, 0, 1, 0, 1, 1, 1, 1, 1, 1, 0, 0, 1 ),
+		array( 1, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0 ),
+		array( 1, 0, 0, 1, 1, 1, 1, 1, 0, 0, 1, 0, 1, 1, 1 ),
+		array( 1, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0 ),
+		array( 0, 1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 1, 1, 1 ),
+		array( 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0 ),
+		array( 0, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1 ),
+		array( 0, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 1, 0 ),
+		array( 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0 ),
+		array( 0, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1 ),
+		array( 0, 1, 0, 1, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 0 ),
+		array( 0, 1, 0, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1 ),
+		array( 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1 ),
+		array( 0, 0, 1, 0, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0 ),
+		array( 0, 0, 1, 1, 1, 0, 0, 1, 1, 1, 0, 0, 1, 1, 1 ),
+		array( 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, 1, 0, 0, 0, 0 ),
+		array( 0, 0, 0, 0, 1, 1, 1, 0, 1, 1, 0, 0, 0, 1, 0 ),
+		array( 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 1 ),
+		array( 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0 ),
+		array( 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 1 ),
+	);
+
+	/*  version info string = $qr_version_info[ (version - 7) ]  */
+	private $qr_version_info = array(
+		array( 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0 ),
+		array( 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 1, 1, 1, 1, 0, 0 ),
+		array( 0, 0, 1, 0, 0, 1, 1, 0, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1 ),
+		array( 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1, 1 ),
+		array( 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0 ),
+		array( 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 1, 0, 0, 0, 1, 0 ),
+		array( 0, 0, 1, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 1 ),
+		array( 0, 0, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 1 ),
+		array( 0, 0, 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0 ),
+		array( 0, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0 ),
+		array( 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 1, 1, 0, 1 ),
+		array( 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 1, 1 ),
+		array( 0, 1, 0, 0, 1, 1, 0, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0 ),
+		array( 0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1, 1, 0 ),
+		array( 0, 1, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 1, 1 ),
+		array( 0, 1, 0, 1, 1, 0, 1, 0, 0, 0, 1, 1, 0, 0, 1, 0, 0, 1 ),
+		array( 0, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 0 ),
+		array( 0, 1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 1, 0, 0, 0, 1, 0, 0 ),
+		array( 0, 1, 1, 0, 0, 1, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 1 ),
+		array( 0, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 1, 1 ),
+		array( 0, 1, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 1, 0 ),
+		array( 0, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0 ),
+		array( 0, 1, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1 ),
+		array( 0, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0, 1, 1, 1, 0, 1, 0, 1 ),
+		array( 0, 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0 ),
+		array( 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 1, 0, 1, 0, 1, 0, 1 ),
+		array( 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0, 0 ),
+		array( 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 1, 1, 0, 1, 0 ),
+		array( 1, 0, 0, 0, 1, 1, 0, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1 ),
+		array( 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1 ),
+		array( 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 1, 1, 0 ),
+		array( 1, 0, 0, 1, 1, 0, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0 ),
+		array( 1, 0, 0, 1, 1, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1 ),
+		array( 1, 0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 1, 1, 0, 1, 0, 0, 1 ),
+	);
+}

--- a/app/common/library/php-svg-qrcode/svg-qrcode.php
+++ b/app/common/library/php-svg-qrcode/svg-qrcode.php
@@ -1,0 +1,130 @@
+<?php
+/****************************************************************************\
+
+svg-qrcode.php - Generate SVG QR Codes. MIT license.
+
+(c) Phil Ronan, 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+\****************************************************************************/
+
+require(__DIR__ . '/qrcode.php');
+
+class SVGQRCode extends QRCode {
+
+    public function output_svg() {
+        $image = $this->render_svg();
+        header('Content-Type: image/svg+xml');
+        die($image);
+    }
+
+    public function render_svg() {
+        list($code, $widths, $width, $height, $x, $y, $w, $h) = $this->encode_and_calculate_size($this->data, $this->options);
+        // We only care about the array $code['b'] at this stage. This contains the
+        // ones and zeros corresponding to the QR image.
+        $fgcolor = "000";
+        $bgcolor = "fff";
+        $scale = 10;
+        $safe_zone = 2;
+        $code_size = count($code['b']);
+        $qr_version = ($code_size - 17) >> 2;
+        $canvas_size = ($code_size + 2 * $safe_zone) * $scale;
+
+        $xml = "<?xml version=\"1.0\" standalone=\"no\"?>\n";
+        $xml .= "<svg width=\"$canvas_size\" height=\"$canvas_size\" version=\"1.1\" ";
+        $xml .= "viewBox=\"0 0 $canvas_size $canvas_size\" xmlns=\"http://www.w3.org/2000/svg\">\n";
+        $xml .= "<defs>\n";
+        $xml .= "<symbol id=\"finder\" width=\"70\" height=\"70\" viewBox=\"0 0 70 70\">\n";
+        $xml .= "<path d=\"M69.375,20L69.375,50C69.375,60.694 60.694,69.375 50,69.375L20,69.375C9.306,69.375 0.625,60.694 0.625,50L0.625,20C0.625,9.306 9.306,0.625 20,0.625L50,0.625C60.694,0.625 69.375,9.306 69.375,20ZM60.625,20C60.625,14.136 55.864,9.375 50,9.375L20,9.375C14.136,9.375 9.375,14.136 9.375,20L9.375,50C9.375,55.864 14.136,60.625 20,60.625L50,60.625C55.864,60.625 60.625,55.864 60.625,50L60.625,20ZM49.375,25L49.375,45C49.375,47.416 47.416,49.375 45,49.375L25,49.375C22.584,49.375 20.625,47.416 20.625,45L20.625,25C20.625,22.584 22.584,20.625 25,20.625L45,20.625C47.416,20.625 49.375,22.584 49.375,25Z\"/>\n";
+        $xml .= "</symbol>\n";
+        $xml .= "<symbol id=\"alignment\" width=\"50\" height=\"50\" viewBox=\"0 0 50 50\">\n";
+        $xml .= "<path d=\"M48.75,19L48.75,31C48.75,40.796 40.796,48.75 31,48.75L19,48.75C9.204,48.75 1.25,40.796 1.25,31L1.25,19C1.25,9.204 9.204,1.25 19,1.25L31,1.25C40.796,1.25 48.75,9.204 48.75,19ZM41.25,19C41.25,13.343 36.658,8.75 31,8.75L19,8.75C13.343,8.75 8.75,13.343 8.75,19L8.75,31C8.75,36.658 13.343,41.25 19,41.25L31,41.25C36.658,41.25 41.25,36.658 41.25,31L41.25,19ZM25,18.75C28.45,18.75 31.25,21.55 31.25,25C31.25,28.45 28.45,31.25 25,31.25C21.55,31.25 18.75,28.45 18.75,25C18.75,21.55 21.55,18.75 25,18.75Z\"/>\n";
+        $xml .= "</symbol>\n";
+        $xml .= "</defs>\n";
+        $xml .= "<g id=\"qr-code\"><g>\n";
+        // $xml .= "<rect x=\"0\" y=\"0\" width=\"$canvas_size\" height=\"$canvas_size\" fill=\"#$bgcolor\"/>\n";
+        $xml .= "<g fill=\"#000\">\n";
+
+        // Add the alignment patterns
+        if ($qr_version >= 2) {
+			$alignment = $this->qr_alignment_patterns[$qr_version - 2];
+            $n = count($alignment);
+            for ($p=0; $p<$n; $p++) {
+                for ($q=0; $q<$n; $q++) {
+                    if (($p==0 && $q==0) || ($p==$n-1 && $q==0) || ($p==0 && $q==$n-1)) continue;
+                    $tx = $alignment[$p];
+                    $ty = $alignment[$q];
+
+                    // blank out the pixels set under this pattern
+                    for ($xx =-2; $xx <= 2; $xx++) {
+                        for ($yy =-2; $yy <= 2; $yy++) {
+                            $code['b'][$ty+$yy][$tx+$xx] = 0;
+                        }
+                    }
+
+                    // Add this shape as a replacement
+                    $cx = ($safe_zone + $tx - 2) * $scale;
+                    $cy = ($safe_zone + $ty - 2) * $scale;
+                    $xml .= "<use href=\"#alignment\" x=\"$cx\" y=\"$cy\"/>\n";
+                }
+            }
+        }
+
+        // Drop in the finder patterns at three corners
+        for ($dy=0; $dy<7; $dy++) {
+            for ($dx=0; $dx<7; $dx++) {
+                $code['b'][$dy][$dx] = 0;
+                $code['b'][$dy + $code_size - 7][$dx] = 0;
+                $code['b'][$dy][$dx + $code_size - 7] = 0;
+            }
+        }
+        $x0 = $y0 = $safe_zone * $scale;
+        $x1 = $y1 = ($safe_zone + $code_size - 7) * $scale;
+        $xml .= "<use href=\"#finder\" x=\"$x0\" y=\"$y0\"/>\n";
+        $xml .= "<use href=\"#finder\" x=\"$x1\" y=\"$y0\"/>\n";
+        $xml .= "<use href=\"#finder\" x=\"$x0\" y=\"$y1\"/>\n";
+        $xml .= "</g>\n";
+        $xml .= "<g fill=\"#$fgcolor\">\n";
+        for ($y=0; $y<$code_size; $y++) {
+            for ($x=0; $x<$code_size; $x++) {
+                if ($code['b'][$y][$x]) {
+                    $cx = ($safe_zone + $x + 0.5) * $scale;
+                    $cy = ($safe_zone + $y + 0.5) * $scale;
+                    $r = 0.4 * $scale;
+                    $xml .= "<circle cx=\"$cx\" cy=\"$cy\" r=\"$r\"/>\n";
+                }
+            }
+        }
+        $xml .= "</g>\n";
+        $xml .= "</g></g>\n";
+        $xml .= "</svg>\n";
+        return $xml;
+    }
+}
+
+if (realpath(__FILE__) == realpath($_SERVER['SCRIPT_FILENAME'])) {
+    // Test
+    $data = @$_GET['d'] or "https://github.com/philronan/php-svg-qrcode";
+    $gen = new SVGQRCode($data, $options=array('s'=>'qrm'));
+    $svg = $gen->render_svg();
+    die($svg);
+}
+
+

--- a/app/common/library/totp-php/LICENSE
+++ b/app/common/library/totp-php/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Madan Sapkota
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/app/common/library/totp-php/ORIGIN.md
+++ b/app/common/library/totp-php/ORIGIN.md
@@ -1,0 +1,9 @@
+# totp-php vendored snapshot
+
+Vendored from: https://github.com/remotemerge/totp-php
+Snapshot: `ca915f2da8676cb3a89c82d10d543883ea11d74a`
+License: MIT License, copyright Madan Sapkota.
+
+Only the runtime `src/` files are included. Demo, test, Docker, Composer, and CI files are intentionally omitted.
+
+Local note: `AbstractTotp::packTimeSlice()` is patched to use explicit big-endian packing (`pack('N2', 0, $timeSlice)`) for RFC 6238 portability.

--- a/app/common/library/totp-php/autoload.php
+++ b/app/common/library/totp-php/autoload.php
@@ -1,0 +1,15 @@
+<?php
+/*
+ * Minimal autoloader for the vendored remotemerge/totp-php runtime files.
+ * daloRADIUS intentionally vendors this small dependency instead of requiring Composer.
+ */
+
+require_once __DIR__ . '/src/Data/messages.php';
+require_once __DIR__ . '/src/Message/MessageInterface.php';
+require_once __DIR__ . '/src/Message/MessageStore.php';
+require_once __DIR__ . '/src/Totp/TotpException.php';
+require_once __DIR__ . '/src/Utils/Base32.php';
+require_once __DIR__ . '/src/Totp/TotpInterface.php';
+require_once __DIR__ . '/src/Totp/AbstractTotp.php';
+require_once __DIR__ . '/src/Totp/Totp.php';
+require_once __DIR__ . '/src/Totp/TotpFactory.php';

--- a/app/common/library/totp-php/src/Data/messages.php
+++ b/app/common/library/totp-php/src/Data/messages.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Message definitions for the TOTP library.
+ */
+
+return [
+    /**
+     * Validation error messages.
+     */
+    'validation' => [
+        'secret_empty' => 'The secret key cannot be empty.',
+        'secret_length' => 'The secret key is invalid. Its length must be a multiple of 8.',
+        'secret_characters' => 'The secret key contains invalid characters.',
+        'code_format' => 'The code must be a %d-digit number.',
+    ],
+
+    /**
+     * Configuration error messages.
+     */
+    'configuration' => [
+        'unsupported_algorithm' => 'Unsupported hash algorithm.',
+        'invalid_digits' => 'Digits must be either 6 or 8.',
+        'invalid_period' => 'Period must be a positive integer.',
+        'invalid_discrepancy' => 'Discrepancy must be between 0 and %d.',
+    ],
+
+    /**
+     * Encoding and decoding error messages.
+     */
+    'encoding' => [
+        'invalid_base32_char' => 'Invalid Base32 character: %s',
+    ],
+
+    /**
+     * Security warning messages.
+     */
+    'security' => [
+        'weak_secret_log' => 'TOTP Security Warning: Weak secret detected (%d bytes, recommend >= 20 bytes)',
+        'audit_secret_empty' => 'Secret is empty (0 bytes).',
+        'audit_invalid_base32' => 'Secret is not valid Base32 format.',
+        'audit_weak_secret' => 'Secret is weak (%d bytes); recommend >= 20 bytes for adequate security.',
+    ],
+];

--- a/app/common/library/totp-php/src/Message/MessageInterface.php
+++ b/app/common/library/totp-php/src/Message/MessageInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RemoteMerge\Message;
+
+/**
+ * Interface for message retrieval services.
+ */
+interface MessageInterface
+{
+    /**
+     * Retrieves a message by its key with optional parameter substitution.
+     *
+     * @param string $key The message key using dot notation (e.g., 'validation.secret_empty').
+     * @param mixed ...$params Optional parameters for sprintf-style message formatting.
+     */
+    public static function get(string $key, ...$params): string;
+
+    /**
+     * Checks if a message key exists in the message store.
+     *
+     * @param string $key The message key to check using dot notation.
+     */
+    public static function has(string $key): bool;
+}

--- a/app/common/library/totp-php/src/Message/MessageStore.php
+++ b/app/common/library/totp-php/src/Message/MessageStore.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RemoteMerge\Message;
+
+/**
+ * Static message store for centralized message management.
+ */
+final class MessageStore implements MessageInterface
+{
+    /**
+     * Cached messages array loaded from the messages file.
+     *
+     * @var array<string, mixed>
+     */
+    private static array $messages = [];
+
+    /**
+     * Default fallback message when a key is not found.
+     */
+    private const DEFAULT_MESSAGE = 'Message not found';
+
+    /**
+     * Retrieves a message by key with optional sprintf-style formatting.
+     *
+     * @param string $key The message key using dot notation (e.g., 'error.validation.required').
+     * @param mixed ...$params Optional parameters for sprintf-style formatting.
+     */
+    public static function get(string $key, ...$params): string
+    {
+        self::loadMessages();
+
+        $message = self::getNestedValue(self::$messages, $key);
+
+        return $params === [] ? $message : sprintf($message, ...$params);
+    }
+
+    /**
+     * Checks if a message key exists in the message store.
+     *
+     * @param string $key The message key to check using dot notation.
+     */
+    public static function has(string $key): bool
+    {
+        self::loadMessages();
+
+        return self::keyExists(self::$messages, $key);
+    }
+
+    /**
+     * Loads messages from the messages.php file if not already loaded.
+     */
+    private static function loadMessages(): void
+    {
+        if (self::$messages === []) {
+            // Note: Using `require` to get the returned array from the file.
+            self::$messages = require dirname(__DIR__) . '/Data/messages.php'; //NOSONAR
+        }
+    }
+
+    /**
+     * Retrieves a nested value from an array using dot notation.
+     *
+     * @param array<string, mixed> $array The array to search in.
+     * @param string $key The dot-separated key path (e.g., 'level1.level2.key').
+     */
+    private static function getNestedValue(array $array, string $key): string
+    {
+        $value = self::traverseNestedArray($array, $key);
+
+        if ($value === null) {
+            return self::DEFAULT_MESSAGE . ': ' . $key;
+        }
+
+        return is_string($value) ? $value : self::DEFAULT_MESSAGE . ': ' . $key;
+    }
+
+    /**
+     * Checks if a nested key exists and points to a string value.
+     *
+     * @param array<string, mixed> $array The array to search in.
+     * @param string $key The dot-separated key path to check.
+     */
+    private static function keyExists(array $array, string $key): bool
+    {
+        $value = self::traverseNestedArray($array, $key);
+
+        return is_string($value);
+    }
+
+    /**
+     * Traverses a nested array using dot notation and returns the value or null if not found.
+     *
+     * @param array<string, mixed> $array The array to search in.
+     * @param string $pathKey The dot-separated key path to traverse.
+     */
+    private static function traverseNestedArray(array $array, string $pathKey): mixed
+    {
+        $keys = explode('.', $pathKey);
+        $value = $array;
+
+        foreach ($keys as $key) {
+            if (!is_array($value) || !array_key_exists($key, $value)) {
+                return null;
+            }
+
+            $value = $value[$key];
+        }
+
+        return $value;
+    }
+}

--- a/app/common/library/totp-php/src/Totp/AbstractTotp.php
+++ b/app/common/library/totp-php/src/Totp/AbstractTotp.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RemoteMerge\Totp;
+
+use RemoteMerge\Message\MessageStore;
+use RemoteMerge\Utils\Base32;
+
+abstract class AbstractTotp
+{
+    /**
+     * The hash algorithm to use for HMAC.
+     */
+    protected string $algorithm = 'sha1';
+
+    /**
+     * The length of the TOTP code.
+     */
+    protected int $digits = 6;
+
+    /**
+     * The duration of a time slice in seconds.
+     */
+    protected int $period = 30;
+
+    /**
+     * The maximum allowed discrepancy value.
+     */
+    protected int $maxDiscrepancy = 10;
+
+    /**
+     * The supported hash algorithms.
+     */
+    protected const SUPPORTED_ALGORITHMS = ['sha1', 'sha256', 'sha512'];
+
+    /**
+     * Initializes the TOTP instance with optional configuration options.
+     *
+     * @param array<string, mixed> $options An associative array of configuration options.
+     *        Supported options: 'max_discrepancy' (int).
+     */
+    public function __construct(array $options = [])
+    {
+        if (isset($options['max_discrepancy'])) {
+            $this->maxDiscrepancy = (int) $options['max_discrepancy'];
+        }
+    }
+
+    /**
+     * Validates the secret key.
+     *
+     * @param string $secret The secret key to validate.
+     * @throws TotpException If the secret key is invalid.
+     */
+    protected function validateSecret(string $secret): void
+    {
+        // Check if the secret is empty
+        if ($secret === '') {
+            throw new TotpException(MessageStore::get('validation.secret_empty'));
+        }
+
+        // Check length divisibility by 8 (existing validation)
+        if (strlen($secret) % 8 !== 0) {
+            throw new TotpException(MessageStore::get('validation.secret_length'));
+        }
+
+        // Base32 validation: A-Z, 2-7, and RFC 4648 padding
+        if (!Base32::isValidUpper($secret)) {
+            throw new TotpException(MessageStore::get('validation.secret_characters'));
+        }
+
+        // Warn about weak secrets without throwing
+        $decoded = Base32::decodeUpper($secret);
+        $byteLength = strlen($decoded);
+
+        if ($byteLength < 20) {
+            error_log(MessageStore::get('security.weak_secret_log', $byteLength));
+        }
+    }
+
+    /**
+     * Validates the TOTP code.
+     *
+     * @param string $code The TOTP code to validate.
+     * @throws TotpException If the code is invalid.
+     */
+    protected function validateCode(string $code): void
+    {
+        if (preg_match('/^\d{' . $this->digits . '}$/', $code) !== 1) {
+            throw new TotpException(MessageStore::get('validation.code_format', $this->digits));
+        }
+    }
+
+    /**
+     * Gets the current time slice based on the current time and the time slice duration.
+     *
+     * @return int The current time slice.
+     */
+    protected function getCurrentTimeSlice(): int
+    {
+        return (int) floor(time() / $this->period);
+    }
+
+    /**
+     * Packs the time slice into a binary string.
+     *
+     * @param int $timeSlice The time slice to pack.
+     * @return string The packed binary string (8 bytes, big-endian unsigned 64-bit integer).
+     */
+    protected function packTimeSlice(int $timeSlice): string
+    {
+        return pack('N2', 0, $timeSlice);
+    }
+
+    /**
+     * Extracts the TOTP code from the HMAC hash.
+     *
+     * @param string $hash The HMAC hash.
+     * @param int $offset The offset to start extracting the code from.
+     * @return int The extracted TOTP code.
+     */
+    protected function extractCodeFromHash(string $hash, int $offset): int
+    {
+        // Extract the hash values
+        $hash1 = ord($hash[$offset]) & 0x7f;
+        $hash2 = ord($hash[$offset + 1]) & 0xff;
+        $hash3 = ord($hash[$offset + 2]) & 0xff;
+        $hash4 = ord($hash[$offset + 3]) & 0xff;
+
+        return (($hash1 << 24) | ($hash2 << 16) | ($hash3 << 8) | $hash4) % (10 ** $this->digits);
+    }
+}

--- a/app/common/library/totp-php/src/Totp/Totp.php
+++ b/app/common/library/totp-php/src/Totp/Totp.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RemoteMerge\Totp;
+
+use Exception;
+use RemoteMerge\Message\MessageStore;
+use RemoteMerge\Utils\Base32;
+
+final class Totp extends AbstractTotp implements TotpInterface
+{
+    /**
+     * Configures the TOTP parameters.
+     *
+     * @param array<string, mixed> $options An associative array of configuration options.
+     *        Supported options: 'algorithm' (string), 'digits' (int), 'period' (int).
+     * @throws TotpException If an unsupported algorithm is provided or if options are invalid.
+     */
+    public function configure(array $options): void
+    {
+        if (isset($options['algorithm'])) {
+            $selectedAlgorithm = strtolower((string) $options['algorithm']);
+
+            if (!in_array($selectedAlgorithm, self::SUPPORTED_ALGORITHMS, true)) {
+                throw new TotpException(MessageStore::get('configuration.unsupported_algorithm'));
+            }
+
+            $this->algorithm = $selectedAlgorithm;
+        }
+
+        if (isset($options['digits'])) {
+            if (!in_array($options['digits'], [6, 8], true)) {
+                throw new TotpException(MessageStore::get('configuration.invalid_digits'));
+            }
+
+            $this->digits = $options['digits'];
+        }
+
+        if (isset($options['period'])) {
+            if (!is_int($options['period']) || $options['period'] <= 0) {
+                throw new TotpException(MessageStore::get('configuration.invalid_period'));
+            }
+
+            $this->period = $options['period'];
+        }
+    }
+
+    /**
+     * Gets the hash algorithm to use for HMAC.
+     *
+     * @return string The hash algorithm.
+     */
+    public function getAlgorithm(): string
+    {
+        return $this->algorithm;
+    }
+
+    /**
+     * Gets the length of the TOTP code.
+     *
+     * @return int The length of the TOTP code.
+     */
+    public function getDigits(): int
+    {
+        return $this->digits;
+    }
+
+    /**
+     * Gets the duration of a time slice in seconds.
+     *
+     * @return int The duration of a time slice.
+     */
+    public function getPeriod(): int
+    {
+        return $this->period;
+    }
+
+    /**
+     * Generates a secret key for TOTP.
+     *
+     * @throws Exception If an error occurs generating the secret key.
+     * @return string The generated secret key in Base32 format.
+     */
+    public function generateSecret(): string
+    {
+        return Base32::encodeUpper(random_bytes(20));
+    }
+
+    /**
+     * Gets the TOTP code for the given secret.
+     *
+     * @param string $secret The secret key in Base32 format.
+     * @param int|null $timeSlice The time slice to generate the code for. Defaults to the current time slice.
+     * @throws TotpException If the secret key is invalid.
+     * @return string The generated TOTP code.
+     */
+    public function getCode(string $secret, ?int $timeSlice = null): string
+    {
+        $this->validateSecret($secret);
+
+        $timeSlice ??= $this->getCurrentTimeSlice();
+        $decodedSecret = Base32::decodeUpper($secret);
+
+        return $this->getCodeFromDecodedSecret($decodedSecret, $timeSlice);
+    }
+
+    /**
+     * Gets the TOTP code for an already decoded secret.
+     *
+     * @param string $decodedSecret The decoded binary secret key.
+     * @param int $timeSlice The time slice to generate the code for.
+     * @return string The generated TOTP code.
+     */
+    private function getCodeFromDecodedSecret(string $decodedSecret, int $timeSlice): string
+    {
+        $time = $this->packTimeSlice($timeSlice);
+
+        $hash = hash_hmac($this->algorithm, $time, $decodedSecret, true);
+        $offset = ord($hash[strlen($hash) - 1]) & 0x0f;
+
+        $code = $this->extractCodeFromHash($hash, $offset);
+
+        return str_pad((string) $code, $this->digits, '0', STR_PAD_LEFT);
+    }
+
+    /**
+     * Verifies the TOTP code for the given secret.
+     *
+     * @param string $secret The secret key in Base32 format.
+     * @param string $code The code to verify.
+     * @param int $discrepancy The allowed discrepancy in the code. Defaults to 1.
+     * @param int|null $timeSlice The time slice to verify the code for. Defaults to the current time slice.
+     * @throws TotpException If the secret key is invalid or discrepancy is out of range.
+     * @return bool True if the code is valid, false otherwise.
+     */
+    public function verifyCode(string $secret, string $code, int $discrepancy = 1, ?int $timeSlice = null): bool
+    {
+        if ($discrepancy < 0 || $discrepancy > $this->maxDiscrepancy) {
+            throw new TotpException(MessageStore::get('configuration.invalid_discrepancy', $this->maxDiscrepancy));
+        }
+
+        $this->validateSecret($secret);
+        $this->validateCode($code);
+
+        $currentSlice = $timeSlice ?? $this->getCurrentTimeSlice();
+        $decodedSecret = Base32::decodeUpper($secret);
+
+        for ($offset = -$discrepancy; $offset <= $discrepancy; ++$offset) {
+            if (hash_equals($this->getCodeFromDecodedSecret($decodedSecret, $currentSlice + $offset), $code)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Verifies the TOTP code while preventing replay attacks.
+     *
+     * Skips any time slices at or below the last accepted slice, ensuring a
+     * previously used code cannot be reused.
+     *
+     * @param string $secret The secret key in Base32 format.
+     * @param string $code The code to verify.
+     * @param int $lastAcceptedSlice The last time slice that was successfully accepted.
+     * @param int $discrepancy The allowed discrepancy in time slices. Defaults to 1.
+     * @throws TotpException If the secret key is invalid or discrepancy is out of range.
+     * @return int|null The matched time slice if valid, or null if invalid or replay detected.
+     */
+    public function verifyCodeOnce(string $secret, string $code, int $lastAcceptedSlice, int $discrepancy = 1): ?int
+    {
+        if ($discrepancy < 0 || $discrepancy > $this->maxDiscrepancy) {
+            throw new TotpException(MessageStore::get('configuration.invalid_discrepancy', $this->maxDiscrepancy));
+        }
+
+        $this->validateSecret($secret);
+        $this->validateCode($code);
+
+        $currentSlice = $this->getCurrentTimeSlice();
+        $decodedSecret = Base32::decodeUpper($secret);
+
+        for ($offset = -$discrepancy; $offset <= $discrepancy; ++$offset) {
+            $candidateSlice = $currentSlice + $offset;
+
+            if ($candidateSlice <= $lastAcceptedSlice) {
+                continue;
+            }
+
+            if (hash_equals($this->getCodeFromDecodedSecret($decodedSecret, $candidateSlice), $code)) {
+                return $candidateSlice;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Audits a secret key and returns diagnostic security information.
+     *
+     * This method never throws exceptions; all issues are reported via the
+     * returned array so callers can handle them gracefully.
+     *
+     * @param string $secret The secret key in Base32 format to audit.
+     * @return array{length_bytes: int, is_strong: bool, warnings: list<string>} Diagnostic information.
+     */
+    public function auditSecret(string $secret): array
+    {
+        $warnings = [];
+        $lengthBytes = 0;
+
+        if ($secret === '') {
+            $warnings[] = MessageStore::get('security.audit_secret_empty');
+
+            return [
+                'length_bytes' => 0,
+                'is_strong' => false,
+                'warnings' => $warnings,
+            ];
+        }
+
+        // Validate a Base32 format without throwing
+        if (!Base32::isValidUpper($secret)) {
+            $warnings[] = MessageStore::get('security.audit_invalid_base32');
+
+            return [
+                'length_bytes' => 0,
+                'is_strong' => false,
+                'warnings' => $warnings,
+            ];
+        }
+
+        $decoded = Base32::decodeUpper($secret);
+        $lengthBytes = strlen($decoded);
+
+        if ($lengthBytes < 20) {
+            $warnings[] = MessageStore::get('security.audit_weak_secret', $lengthBytes);
+        }
+
+        return [
+            'length_bytes' => $lengthBytes,
+            'is_strong' => $lengthBytes >= 20,
+            'warnings' => $warnings,
+        ];
+    }
+
+    /**
+     * Generates a TOTP URI for QR code generation.
+     *
+     * @param string $secret The secret key in Base32 format.
+     * @param string $label The label for the account (e.g., user@example.com).
+     * @param string $issuer The issuer of the TOTP (e.g., the service name).
+     * @throws TotpException If the secret key is invalid.
+     * @return string The TOTP URI in the format `otpauth://totp/{issuer}:{label}?secret={secret}&issuer={issuer}&algorithm={ALGORITHM}&digits={digits}&period={period}`.
+     *               The algorithm is returned in uppercase (e.g., SHA1, SHA256, SHA512) per the Key URI Format specification.
+     */
+    public function generateUri(string $secret, string $label, string $issuer): string
+    {
+        $this->validateSecret($secret);
+
+        $strUri = 'otpauth://totp/%s:%s?secret=%s&issuer=%s&algorithm=%s&digits=%d&period=%d';
+        $encodedLabel = rawurlencode($label);
+        $encodedIssuer = rawurlencode($issuer);
+
+        return sprintf($strUri, $encodedIssuer, $encodedLabel, $secret, $encodedIssuer, strtoupper($this->algorithm), $this->digits, $this->period);
+    }
+}

--- a/app/common/library/totp-php/src/Totp/TotpException.php
+++ b/app/common/library/totp-php/src/Totp/TotpException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RemoteMerge\Totp;
+
+use Exception;
+
+class TotpException extends Exception
+{
+    // Exception class for TOTP
+}

--- a/app/common/library/totp-php/src/Totp/TotpFactory.php
+++ b/app/common/library/totp-php/src/Totp/TotpFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RemoteMerge\Totp;
+
+final class TotpFactory
+{
+    /**
+     * Creates a new instance of the TOTP class.
+     *
+     * @param array<string, mixed> $options Configuration options for the TOTP instance.
+     *        Supported options: 'algorithm' (string), 'digits' (int), 'period' (int), 'max_discrepancy' (int).
+     * @throws TotpException If the configuration options are invalid.
+     * @return TotpInterface A configured TOTP instance.
+     */
+    public static function create(array $options = []): TotpInterface
+    {
+        $totp = new Totp($options);
+        $totp->configure($options);
+
+        return $totp;
+    }
+}

--- a/app/common/library/totp-php/src/Totp/TotpInterface.php
+++ b/app/common/library/totp-php/src/Totp/TotpInterface.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RemoteMerge\Totp;
+
+interface TotpInterface
+{
+    /**
+     * Configures the TOTP parameters.
+     *
+     * @param array<string, mixed> $options An associative array of configuration options.
+     *        Supported options: 'algorithm' (string), 'digits' (int), 'period' (int).
+     */
+    public function configure(array $options): void;
+
+    /**
+     * Gets the hash algorithm to use for HMAC.
+     */
+    public function getAlgorithm(): string;
+
+    /**
+     * Gets the length of the TOTP code.
+     */
+    public function getDigits(): int;
+
+    /**
+     * Gets the duration of a time slice in seconds.
+     */
+    public function getPeriod(): int;
+
+    /**
+     * Generates a new secret key for TOTP.
+     *
+     * @return string The generated secret key, typically in Base32 format.
+     */
+    public function generateSecret(): string;
+
+    /**
+     * Generates a TOTP code for the given secret and optional time slice.
+     *
+     * @param string $secret The secret key.
+     * @param int|null $timeSlice The time slice to use for code generation.
+     *        If null, the current time slice is used.
+     * @return string The generated TOTP code.
+     */
+    public function getCode(string $secret, ?int $timeSlice = null): string;
+
+    /**
+     * Verifies a TOTP code against the given secret.
+     *
+     * @param string $secret The secret key.
+     * @param string $code The TOTP code to verify.
+     * @param int $discrepancy The allowed number of time slices for discrepancy.
+     *        For example, a discrepancy of 1 allows the code to be valid for the previous,
+     *        current, and next time slices.
+     * @param int|null $timeSlice The time slice to use for verification.
+     *        If null, the current time slice is used.
+     * @return bool True if the code is valid, false otherwise.
+     */
+    public function verifyCode(string $secret, string $code, int $discrepancy = 1, ?int $timeSlice = null): bool;
+
+    /**
+     * Generates a TOTP URI for QR code generation.
+     *
+     * @param string $secret The secret key.
+     * @param string $label The label for the account (e.g., user@example.com).
+     * @param string $issuer The issuer of the TOTP (e.g., Abc Corp).
+     * @return string The TOTP URI in the format `otpauth://totp/{issuer}:{label}?secret={secret}&issuer={issuer}&algorithm={ALGORITHM}&digits={digits}&period={period}`.
+     *               The algorithm is returned in uppercase (e.g., SHA1, SHA256, SHA512) per the Key URI Format specification.
+     */
+    public function generateUri(string $secret, string $label, string $issuer): string;
+}

--- a/app/common/library/totp-php/src/Utils/Base32.php
+++ b/app/common/library/totp-php/src/Utils/Base32.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RemoteMerge\Utils;
+
+use RemoteMerge\Message\MessageStore;
+use RemoteMerge\Totp\TotpException;
+
+final class Base32
+{
+    /**
+     * Base32 character set (RFC 4648)
+     */
+    private const ENCODE_MAP = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+    /**
+     * Pre-computed decode lookup table for O(1) character mapping.
+     */
+    private const DECODE_MAP = [
+        'A' => 0, 'B' => 1, 'C' => 2, 'D' => 3, 'E' => 4, 'F' => 5, 'G' => 6, 'H' => 7,
+        'I' => 8, 'J' => 9, 'K' => 10, 'L' => 11, 'M' => 12, 'N' => 13, 'O' => 14, 'P' => 15,
+        'Q' => 16, 'R' => 17, 'S' => 18, 'T' => 19, 'U' => 20, 'V' => 21, 'W' => 22, 'X' => 23,
+        'Y' => 24, 'Z' => 25, '2' => 26, '3' => 27, '4' => 28, '5' => 29, '6' => 30, '7' => 31,
+    ];
+
+    /** Mask to extract 8 bits (1 byte) from a buffer */
+    private const BYTE_MASK = 0xFF;
+
+    /** Mask to extract 5 bits for Base32 character mapping */
+    private const BASE32_MASK = 0x1F;
+
+    /** Number of bits in a standard byte */
+    private const BITS_PER_BYTE = 8;
+
+    /** Number of bits represented by each Base32 character */
+    private const BITS_PER_BASE32 = 5;
+
+    /** Standard Base32 block size for padding calculations */
+    private const BASE32_BLOCK_SIZE = 8;
+
+    /** Valid padding lengths per RFC 4648 (0, 1, 3, 4, or 6 '=' characters) */
+    private const BASE32_VALID_PADDING = [0, 1, 3, 4, 6];
+
+    /**
+     * Encodes binary data to Base32 using optimized bit manipulation.
+     *
+     * @param string $data The binary data to encode.
+     * @return string The Base32 encoded string.
+     */
+    public static function encodeUpper(string $data): string
+    {
+        if ($data === '') {
+            return '';
+        }
+
+        $length = strlen($data);
+        $output = '';
+        $buffer = 0;
+        $bufferLength = 0;
+
+        // Process input byte by byte using bit manipulation
+        for ($i = 0; $i < $length; $i++) {
+            $buffer = ($buffer << self::BITS_PER_BYTE) | ord($data[$i]);
+            $bufferLength += self::BITS_PER_BYTE;
+
+            // Extract 5-bit chunks and encode them
+            while ($bufferLength >= self::BITS_PER_BASE32) {
+                $bufferLength -= self::BITS_PER_BASE32;
+                $output .= self::ENCODE_MAP[($buffer >> $bufferLength) & self::BASE32_MASK];
+            }
+        }
+
+        // Handle remaining bits if any
+        if ($bufferLength > 0) {
+            $output .= self::ENCODE_MAP[($buffer << (self::BITS_PER_BASE32 - $bufferLength)) & self::BASE32_MASK];
+        }
+
+        // Add RFC 4648 compliant padding
+        $padLength = (self::BASE32_BLOCK_SIZE - (strlen($output) % self::BASE32_BLOCK_SIZE)) % self::BASE32_BLOCK_SIZE;
+        if ($padLength > 0) {
+            $output .= str_repeat('=', $padLength);
+        }
+
+        return $output;
+    }
+
+    /**
+     * Decodes a Base32 encoded string to binary data using optimized lookup.
+     *
+     * @param string $data The Base32 encoded string.
+     * @throws TotpException If the input is not a valid Base32 string.
+     * @return string The decoded binary data.
+     */
+    public static function decodeUpper(string $data): string
+    {
+        if ($data === '') {
+            return '';
+        }
+
+        // Validate input
+        if (!self::isValidUpper($data)) {
+            throw new TotpException(MessageStore::get('encoding.invalid_base32_char', '='));
+        }
+
+        // Remove padding
+        $data = rtrim($data, '=');
+        $length = strlen($data);
+        $output = '';
+        $buffer = 0;
+        $bufferLength = 0;
+
+        // Process each character using a pre-computed lookup table
+        for ($i = 0; $i < $length; $i++) {
+            $buffer = ($buffer << self::BITS_PER_BASE32) | self::DECODE_MAP[$data[$i]];
+            $bufferLength += self::BITS_PER_BASE32;
+
+            // Extract complete bytes
+            if ($bufferLength >= self::BITS_PER_BYTE) {
+                $bufferLength -= self::BITS_PER_BYTE;
+                $output .= chr(($buffer >> $bufferLength) & self::BYTE_MASK);
+            }
+        }
+
+        return $output;
+    }
+
+    /**
+     * Checks whether a string is valid uppercase RFC 4648 Base32.
+     *
+     * @param string $data The Base32 encoded string.
+     */
+    public static function isValidUpper(string $data): bool
+    {
+        // Encoded output is always a multiple of 8 characters
+        if (strlen($data) % self::BASE32_BLOCK_SIZE !== 0) {
+            return false;
+        }
+
+        $unpadded = rtrim($data, '=');
+        $paddingCount = strlen($data) - strlen($unpadded);
+
+        // Check padding chars are valid per RFC 4648 §6
+        if (!in_array($paddingCount, self::BASE32_VALID_PADDING, true)) {
+            return false;
+        }
+
+        // Validate against the Base32 alphabet
+        return preg_match('/^[A-Z2-7]*$/', $unpadded) === 1;
+    }
+}

--- a/app/operators/config-operator-2fa.php
+++ b/app/operators/config-operator-2fa.php
@@ -83,6 +83,7 @@ include('../common/includes/db_close.php');
 $totp_enabled = is_array($row) && intval($row['totp_enabled']) === 1;
 $pending_secret = $_SESSION['operator_totp_pending_secret'] ?? '';
 $pending_uri = !empty($pending_secret) ? dalo_totp_generate_uri($pending_secret, $operator) : '';
+$csrf_token = dalo_csrf_token();
 
 $title = "Two-factor authentication";
 $help = "Configure TOTP two-factor authentication for your operator account. This is compatible with Google Authenticator and other RFC 6238 authenticator apps.";
@@ -116,7 +117,7 @@ include_once('include/management/actionMessages.php');
 
 <?php if (!$totp_enabled && empty($pending_secret)): ?>
 <form method="POST" action="config-operator-2fa.php">
-    <input type="hidden" name="csrf_token" value="<?= dalo_csrf_token() ?>">
+    <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
     <input type="hidden" name="action" value="start_enable">
     <button type="submit" class="btn btn-primary">Enable two-factor authentication</button>
 </form>
@@ -137,7 +138,7 @@ include_once('include/management/actionMessages.php');
 </div>
 
 <form method="POST" action="config-operator-2fa.php" class="mb-3">
-    <input type="hidden" name="csrf_token" value="<?= dalo_csrf_token() ?>">
+    <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
     <input type="hidden" name="action" value="confirm_enable">
     <div class="mb-3">
         <label for="otp_code" class="form-label">Verification code</label>
@@ -146,7 +147,7 @@ include_once('include/management/actionMessages.php');
     <button type="submit" class="btn btn-success">Confirm and enable</button>
 </form>
 <form method="POST" action="config-operator-2fa.php">
-    <input type="hidden" name="csrf_token" value="<?= dalo_csrf_token() ?>">
+    <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
     <input type="hidden" name="action" value="cancel_enable">
     <button type="submit" class="btn btn-outline-secondary">Cancel setup</button>
 </form>
@@ -155,12 +156,12 @@ include_once('include/management/actionMessages.php');
 <?php if ($totp_enabled): ?>
 <div class="d-flex gap-2">
     <form method="POST" action="config-operator-2fa.php">
-        <input type="hidden" name="csrf_token" value="<?= dalo_csrf_token() ?>">
+        <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
         <input type="hidden" name="action" value="regenerate_recovery">
         <button type="submit" class="btn btn-outline-primary">Regenerate recovery codes</button>
     </form>
     <form method="POST" action="config-operator-2fa.php" onsubmit="return confirm('Disable two-factor authentication for your operator account?');">
-        <input type="hidden" name="csrf_token" value="<?= dalo_csrf_token() ?>">
+        <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
         <input type="hidden" name="action" value="disable">
         <button type="submit" class="btn btn-danger">Disable two-factor authentication</button>
     </form>

--- a/app/operators/config-operator-2fa.php
+++ b/app/operators/config-operator-2fa.php
@@ -83,6 +83,7 @@ include('../common/includes/db_close.php');
 $totp_enabled = is_array($row) && intval($row['totp_enabled']) === 1;
 $pending_secret = $_SESSION['operator_totp_pending_secret'] ?? '';
 $pending_uri = !empty($pending_secret) ? dalo_totp_generate_uri($pending_secret, $operator) : '';
+$pending_qr = !empty($pending_uri) ? dalo_totp_generate_qr_svg_data_uri($pending_uri) : '';
 $csrf_token = dalo_csrf_token();
 
 $title = "Two-factor authentication";
@@ -127,12 +128,17 @@ include_once('include/management/actionMessages.php');
 <div class="card mb-3">
     <div class="card-body">
         <h4 class="card-title">Set up authenticator app</h4>
-        <p>Add a new TOTP account in your authenticator app using this secret:</p>
+        <p>Scan this QR code with your authenticator app, or enter the secret manually.</p>
+        <?php if (!empty($pending_qr)): ?>
+        <div class="text-center mb-3">
+            <img src="<?= htmlspecialchars($pending_qr, ENT_QUOTES, 'UTF-8') ?>" alt="TOTP setup QR code" class="img-fluid border rounded p-2 bg-white" style="max-width: 260px;">
+        </div>
+        <?php endif; ?>
         <div class="input-group mb-3">
             <span class="input-group-text">Secret</span>
             <input type="text" class="form-control font-monospace" readonly value="<?= htmlspecialchars($pending_secret, ENT_QUOTES, 'UTF-8') ?>">
         </div>
-        <p class="text-muted">URI for QR-code tools, if you choose to generate one locally:</p>
+        <p class="text-muted">TOTP provisioning URI:</p>
         <textarea class="form-control font-monospace" rows="3" readonly><?= htmlspecialchars($pending_uri, ENT_QUOTES, 'UTF-8') ?></textarea>
     </div>
 </div>

--- a/app/operators/config-operator-2fa.php
+++ b/app/operators/config-operator-2fa.php
@@ -96,83 +96,115 @@ include_once('include/management/actionMessages.php');
 
 <div class="card mb-3">
     <div class="card-body">
-        <h4 class="card-title">Operator account</h4>
-        <p><strong><?= htmlspecialchars($operator, ENT_QUOTES, 'UTF-8') ?></strong></p>
-        <p>Status:
-            <?php if ($totp_enabled): ?>
-                <span class="badge text-bg-success">Enabled</span>
-            <?php else: ?>
-                <span class="badge text-bg-secondary">Disabled</span>
-            <?php endif; ?>
-        </p>
+        <div class="d-flex justify-content-between align-items-start gap-3">
+            <div>
+                <h4 class="card-title mb-1">Two-factor authentication</h4>
+                <p class="mb-1">Operator: <strong><?= htmlspecialchars($operator, ENT_QUOTES, 'UTF-8') ?></strong></p>
+                <p class="text-muted mb-0">Add an extra login step using an authenticator app.</p>
+                <?php if ($totp_enabled && !empty($row['totp_confirmed_at'])): ?>
+                    <p class="text-muted small mb-0">Enabled on <?= htmlspecialchars($row['totp_confirmed_at'], ENT_QUOTES, 'UTF-8') ?></p>
+                <?php endif; ?>
+            </div>
+            <div>
+                <?php if ($totp_enabled): ?>
+                    <span class="badge text-bg-success">Enabled</span>
+                <?php else: ?>
+                    <span class="badge text-bg-secondary">Disabled</span>
+                <?php endif; ?>
+            </div>
+        </div>
     </div>
 </div>
 
 <?php if (!empty($generated_recovery_codes)): ?>
 <div class="alert alert-warning">
     <h5>Recovery codes</h5>
-    <p>Save these recovery codes now. Each code can be used once if you lose access to your authenticator app.</p>
+    <p class="mb-2">Save these codes now. They will not be shown again. Each code can be used once if you lose access to your authenticator app.</p>
     <pre class="mb-0"><?php foreach ($generated_recovery_codes as $code) { echo htmlspecialchars($code, ENT_QUOTES, 'UTF-8') . "\n"; } ?></pre>
 </div>
 <?php endif; ?>
 
 <?php if (!$totp_enabled && empty($pending_secret)): ?>
-<form method="POST" action="config-operator-2fa.php">
-    <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
-    <input type="hidden" name="action" value="start_enable">
-    <button type="submit" class="btn btn-primary">Enable two-factor authentication</button>
-</form>
+<div class="card mb-3">
+    <div class="card-body">
+        <h4 class="card-title">Protect your operator account</h4>
+        <p class="card-text">Two-factor authentication requires a 6-digit code from your authenticator app after your password.</p>
+        <form method="POST" action="config-operator-2fa.php">
+            <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
+            <input type="hidden" name="action" value="start_enable">
+            <button type="submit" class="btn btn-primary">Enable two-factor authentication</button>
+        </form>
+    </div>
+</div>
 <?php endif; ?>
 
 <?php if (!$totp_enabled && !empty($pending_secret)): ?>
 <div class="card mb-3">
     <div class="card-body">
-        <h4 class="card-title">Set up authenticator app</h4>
-        <p>Scan this QR code with your authenticator app, or enter the secret manually.</p>
-        <?php if (!empty($pending_qr)): ?>
-        <div class="text-center mb-3">
-            <img src="<?= htmlspecialchars($pending_qr, ENT_QUOTES, 'UTF-8') ?>" alt="TOTP setup QR code" class="img-fluid border rounded p-2 bg-white" style="max-width: 260px;">
-        </div>
-        <?php endif; ?>
-        <div class="input-group mb-3">
-            <span class="input-group-text">Secret</span>
-            <input type="text" class="form-control font-monospace" readonly value="<?= htmlspecialchars($pending_secret, ENT_QUOTES, 'UTF-8') ?>">
-        </div>
-        <p class="text-muted">TOTP provisioning URI:</p>
-        <textarea class="form-control font-monospace" rows="3" readonly><?= htmlspecialchars($pending_uri, ENT_QUOTES, 'UTF-8') ?></textarea>
-    </div>
-</div>
+        <h4 class="card-title">Set up your authenticator app</h4>
+        <p class="text-muted">Complete these steps to link your operator account to an authenticator app.</p>
 
-<div class="mb-3">
-    <label for="otp_code" class="form-label">Verification code</label>
-    <input type="text" class="form-control" id="otp_code" name="otp_code" inputmode="numeric" autocomplete="one-time-code" form="confirm-totp-form" required>
-</div>
-<div class="d-flex gap-2">
-    <form method="POST" action="config-operator-2fa.php" id="confirm-totp-form">
-        <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
-        <input type="hidden" name="action" value="confirm_enable">
-        <button type="submit" class="btn btn-success">Confirm and enable</button>
-    </form>
-    <form method="POST" action="config-operator-2fa.php">
-        <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
-        <input type="hidden" name="action" value="cancel_enable">
-        <button type="submit" class="btn btn-outline-secondary">Cancel setup</button>
-    </form>
+        <div class="row g-4 align-items-start">
+            <div class="col-lg-5 text-center">
+                <h5>1. Scan the QR code</h5>
+                <?php if (!empty($pending_qr)): ?>
+                    <img src="<?= htmlspecialchars($pending_qr, ENT_QUOTES, 'UTF-8') ?>" alt="TOTP setup QR code" class="img-fluid border rounded p-2 bg-white" style="max-width: 260px;">
+                <?php endif; ?>
+            </div>
+            <div class="col-lg-7">
+                <h5>2. Or enter this secret manually</h5>
+                <div class="input-group mb-3">
+                    <span class="input-group-text">Secret</span>
+                    <input type="text" class="form-control font-monospace" readonly value="<?= htmlspecialchars($pending_secret, ENT_QUOTES, 'UTF-8') ?>">
+                </div>
+
+                <details class="mb-3">
+                    <summary class="text-muted">Advanced: show provisioning URI</summary>
+                    <textarea class="form-control font-monospace mt-2" rows="3" readonly><?= htmlspecialchars($pending_uri, ENT_QUOTES, 'UTF-8') ?></textarea>
+                </details>
+
+                <h5>3. Confirm setup</h5>
+                <div class="mb-3">
+                    <label for="otp_code" class="form-label">Verification code</label>
+                    <input type="text" class="form-control font-monospace" id="otp_code" name="otp_code" inputmode="numeric" autocomplete="one-time-code" maxlength="6" pattern="[0-9]{6}" placeholder="123456" form="confirm-totp-form" required>
+                    <div class="form-text">Enter the 6-digit code shown in your authenticator app.</div>
+                </div>
+                <div class="d-flex gap-2">
+                    <form method="POST" action="config-operator-2fa.php" id="confirm-totp-form">
+                        <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
+                        <input type="hidden" name="action" value="confirm_enable">
+                        <button type="submit" class="btn btn-success">Confirm and enable</button>
+                    </form>
+                    <form method="POST" action="config-operator-2fa.php">
+                        <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
+                        <input type="hidden" name="action" value="cancel_enable">
+                        <button type="submit" class="btn btn-outline-secondary">Cancel setup</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 <?php endif; ?>
 
 <?php if ($totp_enabled): ?>
-<div class="d-flex gap-2">
-    <form method="POST" action="config-operator-2fa.php">
-        <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
-        <input type="hidden" name="action" value="regenerate_recovery">
-        <button type="submit" class="btn btn-outline-primary">Regenerate recovery codes</button>
-    </form>
-    <form method="POST" action="config-operator-2fa.php" onsubmit="return confirm('Disable two-factor authentication for your operator account?');">
-        <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
-        <input type="hidden" name="action" value="disable">
-        <button type="submit" class="btn btn-danger">Disable two-factor authentication</button>
-    </form>
+<div class="card mb-3">
+    <div class="card-body">
+        <h4 class="card-title">Two-factor authentication is enabled</h4>
+        <p class="card-text">Use recovery codes if you lose access to your authenticator app. Regenerating recovery codes invalidates any previous unused codes.</p>
+        <div class="d-flex gap-2">
+            <form method="POST" action="config-operator-2fa.php">
+                <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
+                <input type="hidden" name="action" value="regenerate_recovery">
+                <button type="submit" class="btn btn-outline-primary">Regenerate recovery codes</button>
+            </form>
+            <form method="POST" action="config-operator-2fa.php" onsubmit="return confirm('Disable two-factor authentication for your operator account?');">
+                <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
+                <input type="hidden" name="action" value="disable">
+                <button type="submit" class="btn btn-danger">Disable two-factor authentication</button>
+            </form>
+        </div>
+    </div>
 </div>
 <?php endif; ?>
 

--- a/app/operators/config-operator-2fa.php
+++ b/app/operators/config-operator-2fa.php
@@ -143,20 +143,22 @@ include_once('include/management/actionMessages.php');
     </div>
 </div>
 
-<form method="POST" action="config-operator-2fa.php" class="mb-3">
-    <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
-    <input type="hidden" name="action" value="confirm_enable">
-    <div class="mb-3">
-        <label for="otp_code" class="form-label">Verification code</label>
-        <input type="text" class="form-control" id="otp_code" name="otp_code" inputmode="numeric" autocomplete="one-time-code" required>
-    </div>
-    <button type="submit" class="btn btn-success">Confirm and enable</button>
-</form>
-<form method="POST" action="config-operator-2fa.php">
-    <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
-    <input type="hidden" name="action" value="cancel_enable">
-    <button type="submit" class="btn btn-outline-secondary">Cancel setup</button>
-</form>
+<div class="mb-3">
+    <label for="otp_code" class="form-label">Verification code</label>
+    <input type="text" class="form-control" id="otp_code" name="otp_code" inputmode="numeric" autocomplete="one-time-code" form="confirm-totp-form" required>
+</div>
+<div class="d-flex gap-2">
+    <form method="POST" action="config-operator-2fa.php" id="confirm-totp-form">
+        <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
+        <input type="hidden" name="action" value="confirm_enable">
+        <button type="submit" class="btn btn-success">Confirm and enable</button>
+    </form>
+    <form method="POST" action="config-operator-2fa.php">
+        <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>">
+        <input type="hidden" name="action" value="cancel_enable">
+        <button type="submit" class="btn btn-outline-secondary">Cancel setup</button>
+    </form>
+</div>
 <?php endif; ?>
 
 <?php if ($totp_enabled): ?>

--- a/app/operators/config-operator-2fa.php
+++ b/app/operators/config-operator-2fa.php
@@ -1,0 +1,173 @@
+<?php
+/*
+ *********************************************************************************************************
+ * daloRADIUS - RADIUS Web Platform
+ * Operator two-factor authentication management.
+ *********************************************************************************************************
+ */
+
+include("library/checklogin.php");
+$operator = $_SESSION['operator_user'];
+$operator_id = intval($_SESSION['operator_id']);
+
+include('library/check_operator_perm.php');
+include_once('../common/includes/config_read.php');
+include_once("lang/main.php");
+include("../common/includes/layout.php");
+include_once('library/totp.php');
+
+$log = "visited page: ";
+$logAction = "";
+$logDebugSQL = "";
+$generated_recovery_codes = array();
+
+include('../common/includes/db_open.php');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!array_key_exists('csrf_token', $_POST) || !dalo_check_csrf_token($_POST['csrf_token'])) {
+        $failureMsg = "CSRF token error";
+        $logAction .= "$failureMsg on page: ";
+    } else {
+        $action = (array_key_exists('action', $_POST) && isset($_POST['action'])) ? $_POST['action'] : '';
+
+        if ($action === 'start_enable') {
+            $_SESSION['operator_totp_pending_secret'] = dalo_totp_generate_secret();
+            $successMsg = "Scan or enter the new TOTP secret, then confirm with a verification code.";
+        } elseif ($action === 'cancel_enable') {
+            unset($_SESSION['operator_totp_pending_secret']);
+            $successMsg = "Two-factor authentication setup cancelled.";
+        } elseif ($action === 'confirm_enable') {
+            $pending_secret = $_SESSION['operator_totp_pending_secret'] ?? '';
+            $otp_code = (array_key_exists('otp_code', $_POST) && isset($_POST['otp_code'])) ? trim($_POST['otp_code']) : '';
+
+            if (empty($pending_secret) || !dalo_totp_verify($pending_secret, $otp_code)) {
+                $failureMsg = "Invalid verification code";
+            } else {
+                $generated_recovery_codes = dalo_totp_generate_recovery_codes();
+                $recovery_hashes = dalo_totp_hash_recovery_codes($generated_recovery_codes);
+                $sql = sprintf("UPDATE %s SET totp_enabled=1, totp_secret='%s', totp_last_counter=NULL, totp_confirmed_at='%s', totp_recovery_codes='%s' WHERE id=%d",
+                               $configValues['CONFIG_DB_TBL_DALOOPERATORS'], $dbSocket->escapeSimple($pending_secret),
+                               date('Y-m-d H:i:s'), $dbSocket->escapeSimple($recovery_hashes), $operator_id);
+                $dbSocket->query($sql);
+                $logDebugSQL .= "$sql;\n";
+                unset($_SESSION['operator_totp_pending_secret']);
+                $successMsg = "Two-factor authentication has been enabled. Save these recovery codes now; they will not be shown again.";
+            }
+        } elseif ($action === 'disable') {
+            $sql = sprintf("UPDATE %s SET totp_enabled=0, totp_secret=NULL, totp_last_counter=NULL, totp_confirmed_at=NULL, totp_recovery_codes=NULL WHERE id=%d",
+                           $configValues['CONFIG_DB_TBL_DALOOPERATORS'], $operator_id);
+            $dbSocket->query($sql);
+            $logDebugSQL .= "$sql;\n";
+            unset($_SESSION['operator_totp_pending_secret']);
+            $successMsg = "Two-factor authentication has been disabled.";
+        } elseif ($action === 'regenerate_recovery') {
+            $generated_recovery_codes = dalo_totp_generate_recovery_codes();
+            $recovery_hashes = dalo_totp_hash_recovery_codes($generated_recovery_codes);
+            $sql = sprintf("UPDATE %s SET totp_recovery_codes='%s' WHERE id=%d AND totp_enabled=1",
+                           $configValues['CONFIG_DB_TBL_DALOOPERATORS'], $dbSocket->escapeSimple($recovery_hashes), $operator_id);
+            $dbSocket->query($sql);
+            $logDebugSQL .= "$sql;\n";
+            $successMsg = "New recovery codes generated. Save them now; they will not be shown again.";
+        }
+    }
+}
+
+$sql = sprintf("SELECT username, totp_enabled, totp_secret, totp_confirmed_at, totp_recovery_codes FROM %s WHERE id=%d",
+               $configValues['CONFIG_DB_TBL_DALOOPERATORS'], $operator_id);
+$res = $dbSocket->query($sql);
+$logDebugSQL .= "$sql;\n";
+$row = $res->fetchRow(DB_FETCHMODE_ASSOC);
+
+include('../common/includes/db_close.php');
+
+$totp_enabled = is_array($row) && intval($row['totp_enabled']) === 1;
+$pending_secret = $_SESSION['operator_totp_pending_secret'] ?? '';
+$pending_uri = !empty($pending_secret) ? dalo_totp_generate_uri($pending_secret, $operator) : '';
+
+$title = "Two-factor authentication";
+$help = "Configure TOTP two-factor authentication for your operator account. This is compatible with Google Authenticator and other RFC 6238 authenticator apps.";
+
+print_html_prologue($title, $langCode);
+print_title_and_help($title, $help);
+include_once('include/management/actionMessages.php');
+?>
+
+<div class="card mb-3">
+    <div class="card-body">
+        <h4 class="card-title">Operator account</h4>
+        <p><strong><?= htmlspecialchars($operator, ENT_QUOTES, 'UTF-8') ?></strong></p>
+        <p>Status:
+            <?php if ($totp_enabled): ?>
+                <span class="badge text-bg-success">Enabled</span>
+            <?php else: ?>
+                <span class="badge text-bg-secondary">Disabled</span>
+            <?php endif; ?>
+        </p>
+    </div>
+</div>
+
+<?php if (!empty($generated_recovery_codes)): ?>
+<div class="alert alert-warning">
+    <h5>Recovery codes</h5>
+    <p>Save these recovery codes now. Each code can be used once if you lose access to your authenticator app.</p>
+    <pre class="mb-0"><?php foreach ($generated_recovery_codes as $code) { echo htmlspecialchars($code, ENT_QUOTES, 'UTF-8') . "\n"; } ?></pre>
+</div>
+<?php endif; ?>
+
+<?php if (!$totp_enabled && empty($pending_secret)): ?>
+<form method="POST" action="config-operator-2fa.php">
+    <input type="hidden" name="csrf_token" value="<?= dalo_csrf_token() ?>">
+    <input type="hidden" name="action" value="start_enable">
+    <button type="submit" class="btn btn-primary">Enable two-factor authentication</button>
+</form>
+<?php endif; ?>
+
+<?php if (!$totp_enabled && !empty($pending_secret)): ?>
+<div class="card mb-3">
+    <div class="card-body">
+        <h4 class="card-title">Set up authenticator app</h4>
+        <p>Add a new TOTP account in your authenticator app using this secret:</p>
+        <div class="input-group mb-3">
+            <span class="input-group-text">Secret</span>
+            <input type="text" class="form-control font-monospace" readonly value="<?= htmlspecialchars($pending_secret, ENT_QUOTES, 'UTF-8') ?>">
+        </div>
+        <p class="text-muted">URI for QR-code tools, if you choose to generate one locally:</p>
+        <textarea class="form-control font-monospace" rows="3" readonly><?= htmlspecialchars($pending_uri, ENT_QUOTES, 'UTF-8') ?></textarea>
+    </div>
+</div>
+
+<form method="POST" action="config-operator-2fa.php" class="mb-3">
+    <input type="hidden" name="csrf_token" value="<?= dalo_csrf_token() ?>">
+    <input type="hidden" name="action" value="confirm_enable">
+    <div class="mb-3">
+        <label for="otp_code" class="form-label">Verification code</label>
+        <input type="text" class="form-control" id="otp_code" name="otp_code" inputmode="numeric" autocomplete="one-time-code" required>
+    </div>
+    <button type="submit" class="btn btn-success">Confirm and enable</button>
+</form>
+<form method="POST" action="config-operator-2fa.php">
+    <input type="hidden" name="csrf_token" value="<?= dalo_csrf_token() ?>">
+    <input type="hidden" name="action" value="cancel_enable">
+    <button type="submit" class="btn btn-outline-secondary">Cancel setup</button>
+</form>
+<?php endif; ?>
+
+<?php if ($totp_enabled): ?>
+<div class="d-flex gap-2">
+    <form method="POST" action="config-operator-2fa.php">
+        <input type="hidden" name="csrf_token" value="<?= dalo_csrf_token() ?>">
+        <input type="hidden" name="action" value="regenerate_recovery">
+        <button type="submit" class="btn btn-outline-primary">Regenerate recovery codes</button>
+    </form>
+    <form method="POST" action="config-operator-2fa.php" onsubmit="return confirm('Disable two-factor authentication for your operator account?');">
+        <input type="hidden" name="csrf_token" value="<?= dalo_csrf_token() ?>">
+        <input type="hidden" name="action" value="disable">
+        <button type="submit" class="btn btn-danger">Disable two-factor authentication</button>
+    </form>
+</div>
+<?php endif; ?>
+
+<?php
+include('include/config/logging.php');
+print_footer_and_html_epilogue();
+?>

--- a/app/operators/config-operators-edit.php
+++ b/app/operators/config-operators-edit.php
@@ -114,6 +114,14 @@
                 $res = $dbSocket->query($sql);
                 $logDebugSQL .= "$sql;\n";
 
+                if (array_key_exists('reset_totp', $_POST) && $_POST['reset_totp'] === '1') {
+                    $sql = sprintf("UPDATE %s SET totp_enabled=0, totp_secret=NULL, totp_last_counter=NULL, totp_confirmed_at=NULL, totp_recovery_codes=NULL, updatedate='%s', updateby='%s' WHERE id=%d",
+                                   $configValues['CONFIG_DB_TBL_DALOOPERATORS'], $current_datetime,
+                                   $dbSocket->escapeSimple($currBy), $curr_operator_id);
+                    $dbSocket->query($sql);
+                    $logDebugSQL .= "$sql;\n";
+                }
+
                 // insert operators acl for this operator
                 foreach ($_POST as $field => $access ) {
                     
@@ -169,7 +177,7 @@
 
         $sql = sprintf("SELECT id, password, firstname, lastname, title, department, company, phone1, phone2,
                                email1, email2, messenger1, messenger2, notes, lastlogin,
-                               creationdate, creationby, updatedate, updateby
+                               creationdate, creationby, updatedate, updateby, totp_enabled, totp_confirmed_at
                           FROM %s
                          WHERE username='%s'", $configValues['CONFIG_DB_TBL_DALOOPERATORS'],
                                                $dbSocket->escapeSimple($operator_username));
@@ -180,7 +188,8 @@
                 $curr_operator_id, $operator_password, $operator_firstname, $operator_lastname,
                 $operator_title, $operator_department, $operator_company, $operator_phone1, $operator_phone2,
                 $operator_email1, $operator_email2, $operator_messenger1, $operator_messenger2, $operator_notes,
-                $operator_lastlogin, $operator_creationdate, $operator_creationby, $operator_updatedate, $operator_updateby
+                $operator_lastlogin, $operator_creationdate, $operator_creationby, $operator_updatedate, $operator_updateby,
+                $operator_totp_enabled, $operator_totp_confirmed_at
             ) = $res->fetchRow();
     }
 
@@ -240,6 +249,29 @@
                                         "value" => "",
                                         "random" => true
                                      );
+
+        $totp_status = (intval($operator_totp_enabled) === 1)
+                     ? sprintf("Enabled%s", (!empty($operator_totp_confirmed_at) ? " since " . $operator_totp_confirmed_at : ""))
+                     : "Disabled";
+
+        $input_descriptors0[] = array(
+                                        "id" => "operator_totp_status",
+                                        "name" => "operator_totp_status",
+                                        "caption" => "Two-factor authentication",
+                                        "type" => "text",
+                                        "value" => $totp_status,
+                                        "disabled" => true,
+                                     );
+
+        if (intval($operator_totp_enabled) === 1) {
+            $input_descriptors0[] = array(
+                                            "id" => "reset_totp",
+                                            "name" => "reset_totp",
+                                            "caption" => "Reset two-factor authentication for this operator",
+                                            "type" => "checkbox",
+                                            "value" => "1",
+                                         );
+        }
                                   
         // set navbar stuff
         $navkeys = array( array( 'OperatorInfo', "Operator Info" ), 'ContactInfo', array( 'ACLSettings', "ACL Settings" ), );

--- a/app/operators/dologin.php
+++ b/app/operators/dologin.php
@@ -8,6 +8,19 @@
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ *******************************************************************************
+ * Description:
+ * 		performs the logging-in authorization. First creates a random
+ *      session_id to be assigned to this session and then validates
+ *      the operators credentials in the database
+ *
+ * Authors:	Liran Tal <liran@lirantal.com>
+ *
  *******************************************************************************
  */
 

--- a/app/operators/dologin.php
+++ b/app/operators/dologin.php
@@ -8,38 +8,23 @@
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- *
- *******************************************************************************
- * Description:
- * 		performs the logging-in authorization. First creates a random
- *      session_id to be assigned to this session and then validates
- *      the operators credentials in the database
- *
- * Authors:	Liran Tal <liran@lirantal.com>
- *
  *******************************************************************************
  */
 
 include('library/sessions.php');
 include_once('../common/includes/config_read.php');
+include_once('library/totp.php');
 
 dalo_session_start();
 
+unset($_SESSION['operator_2fa_pending'], $_SESSION['operator_2fa_id'], $_SESSION['operator_2fa_user'], $_SESSION['operator_2fa_attempts']);
+
 $errorMessage = '';
 
-// we need to set location name session variable before opening the database
-// since the whole point is to authenticate to a spefific pre-defined database server
-
-// validate location
 $location_name = (array_key_exists('location', $_POST) && isset($_POST['location']))
                ? $_POST['location']
                : "default";
 
-// we initialize some session params that will be useful later
 $_SESSION['location_name'] = (array_key_exists('CONFIG_LOCATIONS', $configValues) &&
                               is_array($configValues['CONFIG_LOCATIONS']) &&
                               count($configValues['CONFIG_LOCATIONS']) > 0 &&
@@ -49,15 +34,13 @@ $_SESSION['location_name'] = (array_key_exists('CONFIG_LOCATIONS', $configValues
 
 $_SESSION['daloradius_logged_in'] = false;
 
-// we interact with the db, ONLY IF user provided
-// both operator_user and operator_pass params
 if (array_key_exists('csrf_token', $_POST) && isset($_POST['csrf_token']) &&
     dalo_check_csrf_token($_POST['csrf_token']) &&
-    array_key_exists('operator_user', $_POST) && isset($_POST['operator_user']) && 
+    array_key_exists('operator_user', $_POST) && isset($_POST['operator_user']) &&
     array_key_exists('operator_pass', $_POST) && isset($_POST['operator_pass'])) {
 
     include('../common/includes/db_open.php');
-    
+
     $operator_user = $dbSocket->escapeSimple($_POST['operator_user']);
     $operator_pass = $_POST['operator_pass'];
 
@@ -65,8 +48,7 @@ if (array_key_exists('csrf_token', $_POST) && isset($_POST['csrf_token']) &&
     $sql = sprintf($sqlFormat, $configValues['CONFIG_DB_TBL_DALOOPERATORS'], $operator_user);
     $res = $dbSocket->query($sql);
     $numRows = $res->numRows();
-    
-    // we only accept ONE AND ONLY ONE RECORD as result
+
     if ($numRows === 1) {
         $row = $res->fetchRow(DB_FETCHMODE_ASSOC);
         $stored_password = $row['password'];
@@ -74,17 +56,7 @@ if (array_key_exists('csrf_token', $_POST) && isset($_POST['csrf_token']) &&
         $legacy_verified = (!$verified && hash_equals($stored_password, $operator_pass));
 
         if ($verified || $legacy_verified) {
-            $operator_id = $row['id'];
-
-            $_SESSION['daloradius_logged_in'] = true;
-            $_SESSION['operator_user'] = $operator_user;
-            $_SESSION['operator_id'] = $operator_id;
-
-            // lets update the lastlogin time for this operator
-            $now = date("Y-m-d H:i:s");
-            $sqlFormat = "update %s set lastlogin='%s' where username='%s'";
-            $sql = sprintf($sqlFormat, $configValues['CONFIG_DB_TBL_DALOOPERATORS'], $now, $operator_user);
-            $res = $dbSocket->query($sql);
+            $operator_id = intval($row['id']);
 
             if ($legacy_verified || password_needs_rehash($stored_password, PASSWORD_DEFAULT)) {
                 $operator_pass_hash = $dbSocket->escapeSimple(password_hash($operator_pass, PASSWORD_DEFAULT));
@@ -92,16 +64,35 @@ if (array_key_exists('csrf_token', $_POST) && isset($_POST['csrf_token']) &&
                 $sql = sprintf($sqlFormat, $configValues['CONFIG_DB_TBL_DALOOPERATORS'], $operator_pass_hash, $operator_user);
                 $res = $dbSocket->query($sql);
             }
+
+            $totp_enabled = array_key_exists('totp_enabled', $row) && intval($row['totp_enabled']) === 1;
+            $totp_secret = (array_key_exists('totp_secret', $row) && !empty($row['totp_secret'])) ? $row['totp_secret'] : '';
+
+            if ($totp_enabled && !empty($totp_secret)) {
+                $_SESSION['operator_2fa_pending'] = true;
+                $_SESSION['operator_2fa_id'] = $operator_id;
+                $_SESSION['operator_2fa_user'] = $operator_user;
+                $_SESSION['operator_2fa_attempts'] = 0;
+                include('../common/includes/db_close.php');
+                header('Location: login-otp.php');
+                exit;
+            }
+
+            $_SESSION['daloradius_logged_in'] = true;
+            unset($_SESSION['operator_2fa_pending'], $_SESSION['operator_2fa_id'], $_SESSION['operator_2fa_user'], $_SESSION['operator_2fa_attempts']);
+            $_SESSION['operator_user'] = $operator_user;
+            $_SESSION['operator_id'] = $operator_id;
+
+            $now = date("Y-m-d H:i:s");
+            $sqlFormat = "update %s set lastlogin='%s' where username='%s'";
+            $sql = sprintf($sqlFormat, $configValues['CONFIG_DB_TBL_DALOOPERATORS'], $now, $operator_user);
+            $res = $dbSocket->query($sql);
         }
     }
-    
-    // close connection to db before redirecting
-    include('../common/includes/db_close.php');
 
+    include('../common/includes/db_close.php');
 }
 
-// if everything went fine daloradius_logged_in session param has been set to true,
-// so we can check it for deciding where and how redirect user browser
 $header_location = "index.php";
 
 if ($_SESSION['daloradius_logged_in'] !== true) {
@@ -110,5 +101,4 @@ if ($_SESSION['daloradius_logged_in'] !== true) {
 }
 
 header("Location: $header_location");
-
 ?>

--- a/app/operators/include/menu/sidebar/config/operators.php
+++ b/app/operators/include/menu/sidebar/config/operators.php
@@ -40,6 +40,9 @@ $descriptors1 = array();
 $descriptors1[] = array( 'type' => 'link', 'label' => t('button','NewOperator'), 'href' =>'config-operators-new.php',
                          'icon' => 'person-fill-add', 'img' => array( 'src' => 'static/images/icons/userNew.gif', ), );
 
+$descriptors1[] = array( 'type' => 'link', 'label' => 'Two-factor authentication', 'href' =>'config-operator-2fa.php',
+                         'icon' => 'shield-lock', 'img' => array( 'src' => 'static/images/icons/userEdit.gif', ), );
+
 if (count($menu_datalist) > 0) {
     $descriptors1[] = array( 'type' => 'link', 'label' => t('button','ListOperators'), 'href' => 'config-operators-list.php',
                              'icon' => 'person-lines-fill', 'img' => array( 'src' => 'static/images/icons/userList.gif', ), );

--- a/app/operators/library/totp.php
+++ b/app/operators/library/totp.php
@@ -1,0 +1,92 @@
+<?php
+/*
+ *********************************************************************************************************
+ * daloRADIUS - RADIUS Web Platform
+ *
+ * Operator TOTP helpers. This file wraps the vendored remotemerge/totp-php
+ * library so the rest of daloRADIUS does not depend directly on that API.
+ *********************************************************************************************************
+ */
+
+if (strpos($_SERVER['PHP_SELF'], '/library/totp.php') !== false) {
+    header("Location: ../index.php");
+    exit;
+}
+
+require_once __DIR__ . '/../../common/library/totp-php/autoload.php';
+
+use RemoteMerge\Totp\TotpFactory;
+use RemoteMerge\Totp\TotpInterface;
+use RemoteMerge\Totp\TotpException;
+
+function dalo_totp_new(): TotpInterface {
+    return TotpFactory::create(array(
+        'algorithm' => 'sha1',
+        'digits' => 6,
+        'period' => 30,
+        'max_discrepancy' => 1,
+    ));
+}
+
+function dalo_totp_generate_secret(): string {
+    return dalo_totp_new()->generateSecret();
+}
+
+function dalo_totp_generate_uri(string $secret, string $operator_username): string {
+    return dalo_totp_new()->generateUri($secret, $operator_username, 'daloRADIUS');
+}
+
+function dalo_totp_verify(string $secret, string $code): bool {
+    try {
+        return dalo_totp_new()->verifyCode($secret, $code, 1);
+    } catch (TotpException $e) {
+        return false;
+    }
+}
+
+function dalo_totp_verify_once(string $secret, string $code, ?int $last_counter): ?int {
+    try {
+        return dalo_totp_new()->verifyCodeOnce($secret, $code, $last_counter ?? -1, 1);
+    } catch (TotpException $e) {
+        return null;
+    }
+}
+
+function dalo_totp_generate_recovery_codes(int $count = 8): array {
+    $codes = array();
+    for ($i = 0; $i < $count; $i++) {
+        $raw = strtoupper(bin2hex(random_bytes(5)));
+        $codes[] = substr($raw, 0, 5) . '-' . substr($raw, 5, 5);
+    }
+    return $codes;
+}
+
+function dalo_totp_hash_recovery_codes(array $codes): string {
+    $hashes = array();
+    foreach ($codes as $code) {
+        $hashes[] = password_hash(strtoupper(trim($code)), PASSWORD_DEFAULT);
+    }
+    return json_encode($hashes);
+}
+
+function dalo_totp_verify_recovery_code(?string $encoded_hashes, string $code): array {
+    if (empty($encoded_hashes)) {
+        return array(false, $encoded_hashes);
+    }
+
+    $hashes = json_decode($encoded_hashes, true);
+    if (!is_array($hashes)) {
+        return array(false, $encoded_hashes);
+    }
+
+    $code = strtoupper(trim($code));
+    foreach ($hashes as $idx => $hash) {
+        if (is_string($hash) && password_verify($code, $hash)) {
+            unset($hashes[$idx]);
+            return array(true, json_encode(array_values($hashes)));
+        }
+    }
+
+    return array(false, $encoded_hashes);
+}
+?>

--- a/app/operators/library/totp.php
+++ b/app/operators/library/totp.php
@@ -14,6 +14,7 @@ if (strpos($_SERVER['PHP_SELF'], '/library/totp.php') !== false) {
 }
 
 require_once __DIR__ . '/../../common/library/totp-php/autoload.php';
+require_once __DIR__ . '/../../common/library/php-svg-qrcode/svg-qrcode.php';
 
 use RemoteMerge\Totp\TotpFactory;
 use RemoteMerge\Totp\TotpInterface;
@@ -34,6 +35,13 @@ function dalo_totp_generate_secret(): string {
 
 function dalo_totp_generate_uri(string $secret, string $operator_username): string {
     return dalo_totp_new()->generateUri($secret, $operator_username, 'daloRADIUS');
+}
+
+function dalo_totp_generate_qr_svg_data_uri(string $otpauth_uri): string {
+    $qr = new SVGQRCode($otpauth_uri, array('s' => 'qrm'));
+    $svg = $qr->render_svg();
+
+    return 'data:image/svg+xml;base64,' . base64_encode($svg);
 }
 
 function dalo_totp_verify(string $secret, string $code): bool {

--- a/app/operators/login-otp.php
+++ b/app/operators/login-otp.php
@@ -1,0 +1,115 @@
+<?php
+include_once("library/sessions.php");
+include_once('../common/includes/config_read.php');
+include_once('library/totp.php');
+
+dalo_session_start();
+
+if (empty($_SESSION['operator_2fa_pending']) || empty($_SESSION['operator_2fa_id']) || empty($_SESSION['operator_2fa_user'])) {
+    header('Location: login.php');
+    exit;
+}
+
+include("lang/main.php");
+
+$failureMsg = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!array_key_exists('csrf_token', $_POST) || !dalo_check_csrf_token($_POST['csrf_token'])) {
+        $failureMsg = 'CSRF token error';
+    } else {
+        $otp_code = (array_key_exists('otp_code', $_POST) && isset($_POST['otp_code'])) ? trim($_POST['otp_code']) : '';
+        $_SESSION['operator_2fa_attempts'] = intval($_SESSION['operator_2fa_attempts'] ?? 0) + 1;
+
+        include('../common/includes/db_open.php');
+
+        $operator_id = intval($_SESSION['operator_2fa_id']);
+        $operator_user = $dbSocket->escapeSimple($_SESSION['operator_2fa_user']);
+        $sql = sprintf("SELECT id, username, totp_secret, totp_last_counter, totp_recovery_codes FROM %s WHERE id=%d AND username='%s' AND totp_enabled=1",
+                       $configValues['CONFIG_DB_TBL_DALOOPERATORS'], $operator_id, $operator_user);
+        $res = $dbSocket->query($sql);
+
+        $authenticated = false;
+        if ($res->numRows() === 1) {
+            $row = $res->fetchRow(DB_FETCHMODE_ASSOC);
+            $matched_counter = dalo_totp_verify_once($row['totp_secret'], $otp_code, isset($row['totp_last_counter']) ? intval($row['totp_last_counter']) : null);
+
+            if ($matched_counter !== null) {
+                $sql = sprintf("UPDATE %s SET lastlogin='%s', totp_last_counter=%d WHERE id=%d",
+                               $configValues['CONFIG_DB_TBL_DALOOPERATORS'], date('Y-m-d H:i:s'), $matched_counter, $operator_id);
+                $dbSocket->query($sql);
+                $authenticated = true;
+            } else {
+                list($recovery_ok, $new_recovery_codes) = dalo_totp_verify_recovery_code($row['totp_recovery_codes'], $otp_code);
+                if ($recovery_ok) {
+                    $sql = sprintf("UPDATE %s SET lastlogin='%s', totp_recovery_codes='%s' WHERE id=%d",
+                                   $configValues['CONFIG_DB_TBL_DALOOPERATORS'], date('Y-m-d H:i:s'),
+                                   $dbSocket->escapeSimple($new_recovery_codes), $operator_id);
+                    $dbSocket->query($sql);
+                    $authenticated = true;
+                }
+            }
+        }
+
+        include('../common/includes/db_close.php');
+
+        if ($authenticated) {
+            $_SESSION['daloradius_logged_in'] = true;
+            $_SESSION['operator_user'] = $_SESSION['operator_2fa_user'];
+            $_SESSION['operator_id'] = intval($_SESSION['operator_2fa_id']);
+            unset($_SESSION['operator_2fa_pending'], $_SESSION['operator_2fa_id'], $_SESSION['operator_2fa_user'], $_SESSION['operator_2fa_attempts']);
+            header('Location: index.php');
+            exit;
+        }
+
+        if (intval($_SESSION['operator_2fa_attempts']) >= 5) {
+            unset($_SESSION['operator_2fa_pending'], $_SESSION['operator_2fa_id'], $_SESSION['operator_2fa_user'], $_SESSION['operator_2fa_attempts']);
+            $_SESSION['operator_login_error'] = true;
+            header('Location: login.php');
+            exit;
+        }
+
+        $failureMsg = 'Invalid verification code';
+    }
+}
+
+$dir = (strtolower($langCode) === 'ar') ? "rtl" : "ltr";
+?>
+<!DOCTYPE html>
+<html lang="<?= $langCode ?>" dir="<?= $dir ?>">
+<head>
+    <title>daloRADIUS :: Two-factor authentication</title>
+    <meta charset="utf-8">
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex">
+    <link rel="stylesheet" href="static/css/bootstrap.min.css">
+    <style>
+html, body { height: 100%; }
+body { display: flex; align-items: center; padding-top: 40px; padding-bottom: 40px; background-color: #f5f5f5; }
+.form-login { max-width: 480px; padding: 15px; }
+    </style>
+</head>
+<body>
+    <main class="form-login w-100 m-auto">
+    <form action="login-otp.php" method="POST">
+    <img class="mb-4" src="static/images/daloradius_small.png" alt="daloRADIUS" width="135" height="41">
+    <h1 class="h3 mb-3 fw-normal">Two-factor authentication</h1>
+    <p class="text-muted">Enter the 6-digit code from your authenticator app, or a recovery code.</p>
+
+    <?php if (!empty($failureMsg)): ?>
+    <div class="alert alert-danger"><?= htmlspecialchars($failureMsg, ENT_QUOTES, 'UTF-8') ?></div>
+    <?php endif; ?>
+
+    <div class="form-floating mb-3">
+        <input type="text" class="form-control" id="otp_code" name="otp_code" inputmode="numeric" autocomplete="one-time-code" placeholder="Verification code" required autofocus>
+        <label for="otp_code">Verification code</label>
+    </div>
+
+    <button class="w-100 btn btn-lg btn-primary" type="submit">Verify</button>
+    <input name="csrf_token" type="hidden" value="<?= dalo_csrf_token() ?>">
+    </form>
+    </main>
+    <script src="static/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/contrib/db/mariadb-daloradius.sql
+++ b/contrib/db/mariadb-daloradius.sql
@@ -10280,6 +10280,11 @@ CREATE TABLE `operators` (
   `creationby` VARCHAR(128) DEFAULT NULL,
   `updatedate` DATETIME DEFAULT '0000-00-00 00:00:00',
   `updateby` VARCHAR(128) DEFAULT NULL,
+  `totp_enabled` TINYINT(1) NOT NULL DEFAULT 0,
+  `totp_secret` VARCHAR(64) DEFAULT NULL,
+  `totp_last_counter` BIGINT DEFAULT NULL,
+  `totp_confirmed_at` DATETIME DEFAULT NULL,
+  `totp_recovery_codes` TEXT DEFAULT NULL,
   PRIMARY KEY  (`id`),
   KEY `username` (`username`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;
@@ -10358,6 +10363,7 @@ INSERT INTO `operators_acl` (`id`, `operator_id`, `file`, `access`) VALUES
 (38, 1, 'config_operators_new', 1),
 (39, 1, 'config_operators_del', 1),
 (40, 1, 'config_operators_edit', 1),
+(1101, 1, 'config_operator_2fa', 1),
 (41, 1, 'gis_editmap', 1),
 (42, 1, 'gis_viewmap', 1),
 (43, 1, 'graphs_alltime_logins', 1),
@@ -10606,6 +10612,7 @@ INSERT INTO `operators_acl_files` (`file`, `category`, `section`) VALUES
 ('config_operators_list', 'Configuration', 'Operators'),
 ('config_operators_edit', 'Configuration', 'Operators'),
 ('config_operators_new', 'Configuration', 'Operators'),
+('config_operator_2fa', 'Configuration', 'Operators'),
 ('config_backup_createbackups', 'Configuration', 'Backup'),
 ('config_backup_managebackups', 'Configuration', 'Backup'),
 ('acct_plans_usage', 'Accounting', 'Plans'),

--- a/contrib/db/migrations/2026-06-operator-totp-mfa.sql
+++ b/contrib/db/migrations/2026-06-operator-totp-mfa.sql
@@ -1,0 +1,35 @@
+--
+-- daloRADIUS operator TOTP MFA migration
+--
+-- Apply this script when upgrading an existing daloRADIUS installation
+-- to a version that supports operator TOTP MFA.
+--
+-- Fresh installations already include these schema changes in
+-- contrib/db/mariadb-daloradius.sql.
+--
+
+ALTER TABLE operators
+  ADD COLUMN IF NOT EXISTS totp_enabled TINYINT(1) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS totp_secret VARCHAR(64) DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS totp_last_counter BIGINT DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS totp_confirmed_at DATETIME DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS totp_recovery_codes TEXT DEFAULT NULL;
+
+INSERT INTO operators_acl_files (file, category, section)
+SELECT 'config_operator_2fa', 'Configuration', 'Operators'
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM operators_acl_files
+    WHERE file = 'config_operator_2fa'
+);
+
+INSERT INTO operators_acl (operator_id, file, access)
+SELECT id, 'config_operator_2fa', 1
+FROM operators
+WHERE username = 'administrator'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM operators_acl
+      WHERE operators_acl.operator_id = operators.id
+        AND operators_acl.file = 'config_operator_2fa'
+  );

--- a/doc/setup/operator-mfa.md
+++ b/doc/setup/operator-mfa.md
@@ -27,6 +27,27 @@ $configValues['CONFIG_DB_TBL_DALOOPERATORS'] = 'operators';
 
 If your installation uses different values, replace the example database name and table name in the commands below.
 
+## Upgrading an existing installation
+
+Fresh installations already include the operator MFA schema in `contrib/db/mariadb-daloradius.sql`. Existing installations must apply the database migration before operators enable MFA or use the MFA recovery page.
+
+Back up the database first, then run the migration script from the daloRADIUS source tree.
+
+For a standard MariaDB/MySQL installation:
+
+```bash
+mariadb -u raduser -p raddb < contrib/db/migrations/2026-06-operator-totp-mfa.sql
+```
+
+For a Docker Compose installation, run this from the directory that contains `docker-compose.yml`:
+
+```bash
+docker compose exec -T radius-mysql sh -lc 'mariadb -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE"' \
+  < contrib/db/migrations/2026-06-operator-totp-mfa.sql
+```
+
+The migration is idempotent: it adds the missing MFA columns and registers the MFA page in the operators ACL metadata if they are not already present.
+
 ## Standard MariaDB/MySQL installation
 
 In the examples below, replace `administrator` with the operator username you want to unlock.

--- a/doc/setup/operator-mfa.md
+++ b/doc/setup/operator-mfa.md
@@ -1,0 +1,110 @@
+# Operator two-factor authentication recovery
+
+This guide explains how to reset two-factor authentication (2FA/MFA) for a daloRADIUS operator account from the server command line. Use it when an operator has lost access to their authenticator app or recovery codes and cannot complete login.
+
+Resetting MFA does **not** change the operator password and does **not** delete the operator account. It only clears the TOTP secret, last accepted counter, confirmation timestamp, and recovery codes. The operator can then log in with their existing password and enroll MFA again from the operators interface.
+
+## Before you start
+
+1. Log in to the server that hosts the daloRADIUS database.
+2. Identify the operator username to reset.
+3. Identify the daloRADIUS database name, user, and operators table name.
+
+For standard installations these values are configured in:
+
+```text
+app/common/includes/daloradius.conf.php
+```
+
+The relevant settings are:
+
+```php
+$configValues['CONFIG_DB_USER'] = 'raduser';
+$configValues['CONFIG_DB_PASS'] = 'radpass';
+$configValues['CONFIG_DB_NAME'] = 'raddb';
+$configValues['CONFIG_DB_TBL_DALOOPERATORS'] = 'operators';
+```
+
+If your installation uses different values, replace the example database name and table name in the commands below.
+
+## Standard MariaDB/MySQL installation
+
+In the examples below, replace `administrator` with the operator username you want to unlock.
+
+Check that the operator exists and confirm their current MFA state:
+
+```bash
+mariadb -u raduser -p raddb <<'SQL'
+SELECT id, username, totp_enabled, totp_confirmed_at
+FROM operators
+WHERE username = 'administrator';
+SQL
+```
+
+Reset MFA for that operator:
+
+```bash
+mariadb -u raduser -p raddb <<'SQL'
+UPDATE operators
+   SET totp_enabled = 0,
+       totp_secret = NULL,
+       totp_last_counter = NULL,
+       totp_confirmed_at = NULL,
+       totp_recovery_codes = NULL
+ WHERE username = 'administrator';
+SQL
+```
+
+Verify the reset:
+
+```bash
+mariadb -u raduser -p raddb <<'SQL'
+SELECT id, username, totp_enabled, totp_confirmed_at
+FROM operators
+WHERE username = 'administrator';
+SQL
+```
+
+The `totp_enabled` value should now be `0`.
+
+> **Note:** If the operator username contains a single quote (`'`), escape it for SQL by replacing it with two single quotes (`''`) before running the commands.
+
+## Docker Compose installation
+
+Run these commands from the directory that contains `docker-compose.yml`. Replace `administrator` with the operator username you want to unlock.
+
+Check that the operator exists:
+
+```bash
+docker compose exec -T radius-mysql sh -lc 'mariadb -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE"' <<'SQL'
+SELECT id, username, totp_enabled, totp_confirmed_at
+FROM operators
+WHERE username = 'administrator';
+SQL
+```
+
+Reset MFA for that operator:
+
+```bash
+docker compose exec -T radius-mysql sh -lc 'mariadb -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE"' <<'SQL'
+UPDATE operators
+   SET totp_enabled = 0,
+       totp_secret = NULL,
+       totp_last_counter = NULL,
+       totp_confirmed_at = NULL,
+       totp_recovery_codes = NULL
+ WHERE username = 'administrator';
+SQL
+```
+
+Verify the reset:
+
+```bash
+docker compose exec -T radius-mysql sh -lc 'mariadb -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE"' <<'SQL'
+SELECT id, username, totp_enabled, totp_confirmed_at
+FROM operators
+WHERE username = 'administrator';
+SQL
+```
+
+The operator can now log in with their existing password. Ask them to re-enable two-factor authentication and store their new recovery codes.

--- a/init.sh
+++ b/init.sh
@@ -152,6 +152,44 @@ EOSQL
     fi
 }
 
+function ensure_operator_totp_columns {
+    if ! table_exists "operators"; then
+        return
+    fi
+
+    local missing_columns
+    missing_columns=$(mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" --batch --skip-column-names "$MYSQL_DATABASE" <<'EOSQL'
+SELECT COUNT(*)
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND table_name = 'operators'
+  AND column_name IN ('totp_enabled', 'totp_secret', 'totp_last_counter', 'totp_confirmed_at', 'totp_recovery_codes');
+EOSQL
+)
+
+    if [ "$missing_columns" -lt 5 ]; then
+        echo "Adding operator TOTP columns."
+        mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" <<'EOSQL'
+ALTER TABLE operators
+  ADD COLUMN IF NOT EXISTS totp_enabled TINYINT(1) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS totp_secret VARCHAR(64) DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS totp_last_counter BIGINT DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS totp_confirmed_at DATETIME DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS totp_recovery_codes TEXT DEFAULT NULL;
+EOSQL
+    fi
+
+    mysql --defaults-extra-file="$MYSQL_DEFAULTS_FILE" "$MYSQL_DATABASE" <<'EOSQL'
+INSERT IGNORE INTO operators_acl_files (file, category, section)
+VALUES ('config_operator_2fa', 'Configuration', 'Operators');
+
+INSERT IGNORE INTO operators_acl (operator_id, file, access)
+SELECT id, 'config_operator_2fa', 1
+FROM operators
+WHERE username = 'administrator';
+EOSQL
+}
+
 function wait_for_mysql {
     echo -n "Waiting for mysql ($MYSQL_HOST)..."
     while ! mysqladmin --defaults-extra-file="$MYSQL_DEFAULTS_FILE" ping --silent; do
@@ -191,6 +229,7 @@ else
 fi
 
 ensure_operator_password_column
+ensure_operator_totp_columns
 
 # Start Apache2 in the foreground
 cleanup_mysql_defaults


### PR DESCRIPTION
# Description

This PR adds optional TOTP-based multi-factor authentication for operator accounts.

It introduces the operator MFA flow, including setup, verification during login, recovery codes, and a lightweight UI for managing two-factor authentication from the operator account area.

# Changes

* Add TOTP MFA support for operator logins.
* Add operator MFA setup and management page.
* Add recovery code handling for account recovery.
* Add database migration documentation for the new MFA-related fields.
* Add operator MFA recovery documentation.
* Add local QR code generation for authenticator app setup.
* Vendor and credit the lightweight PHP libraries used for TOTP and QR code generation.
* Improve the MFA setup UX with:

  * clearer enabled/disabled status;
  * step-by-step setup flow;
  * QR code display;
  * manual secret fallback;
  * advanced provisioning URI fallback;
  * improved OTP input guidance;
  * aligned setup action buttons.

# Validation

Tested locally in the Docker-based daloRADIUS development environment.

Validated:

* PHP syntax checks for the modified MFA files.
* TOTP secret and provisioning URI generation.
* QR code data URI generation.
* Operator MFA setup page rendering.
* QR code presence on the setup page.
* Manual secret and provisioning URI fallback display.
* Confirm/cancel button ordering and layout.
* Updated MFA setup UX elements.

# Notes

The QR code is generated locally and embedded as an SVG data URI. No external QR code service is used, so the TOTP provisioning URI and secret are not sent to a third party.

Closes : #568

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional TOTP-based MFA for operator accounts with setup, login verification, and recovery codes. Improves security with local QR generation and admin reset tools.

- **New Features**
  - TOTP MFA for operator logins (setup flow, verify on login).
  - Recovery codes and a self-serve 2FA management page.
  - Admin can reset an operator’s MFA from Edit Operator.
  - Local SVG QR codes (no external service); vendored `remotemerge/totp-php` and `php-svg-qrcode`.
  - Schema, docs, and Docker notes added; init script ensures required columns.

- **Migration**
  - Upgrades: apply `contrib/db/migrations/2026-06-operator-totp-mfa.sql` before enabling MFA.

<sup>Written for commit fcc5afdb98c29232ddbb148d807a4d34b0237311. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

