### PR TITLE
chore(db): add migration for operators password column resize to VARCHAR(95)

### DIFF
--- a/contrib/db/migrations/2025-03-operator-password-hashing.sql
+++ b/contrib/db/migrations/2025-03-operator-password-hashing.sql
@@ -1,0 +1,20 @@
+--
+-- daloRADIUS operator password hashing migration
+--
+-- Apply this script when upgrading an existing daloRADIUS installation
+-- to a version that stores operator passwords as a password_hash()
+-- digest instead of a 32-char (MD5) value.
+--
+-- This widens operators.password from VARCHAR(32) to VARCHAR(95) so it
+-- can hold the hash produced by PHP's password_hash().
+--
+-- Fresh installations already include this schema change in
+-- contrib/db/mariadb-daloradius.sql.
+--
+-- NOTE: this migration only resizes the column. Existing stored
+-- passwords are not re-hashed by this script; that is handled by the
+-- application (e.g. transparently re-hashed on the operator's next login).
+--
+
+ALTER TABLE operators
+  MODIFY COLUMN IF EXISTS password VARCHAR(95) NOT NULL;


### PR DESCRIPTION
daloRADIUS operator password hashing migration

Apply this script when upgrading an existing daloRADIUS installation
to a version that stores operator passwords as a password_hash()
digest instead of a 32-char (MD5) value.

This widens operators.password from VARCHAR(32) to VARCHAR(95) so it
can hold the hash produced by PHP's password_hash().

Fresh installations already include this schema change in
contrib/db/mariadb-daloradius.sql.

NOTE: this migration only resizes the column. Existing stored
passwords are not re-hashed by this script; that is handled by the
application (e.g. transparently re-hashed on the operator's next login).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a DB migration that widens operators.password from VARCHAR(32) to VARCHAR(95) to support PHP password_hash() instead of 32-char MD5. This targets upgrades; fresh installs already include the schema.

- **Migration**
  - Run contrib/db/migrations/2025-03-operator-password-hashing.sql on existing installations.
  - Only resizes the column; no data changes.
  - Existing passwords are re-hashed by the app on next login.

<sup>Written for commit 594dfc8c133c45e815fc6650d6d4da0aaf3abe95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

