### PR TITLE
Fix the operator username input box doesn't show the operator list.

### DIFF
--- a/app/operators/config-operators-del.php
+++ b/app/operators/config-operators-del.php
@@ -150,9 +150,9 @@
                                       );
         
         if (count($options) > 0) {
-            $input_descriptor[0]['datalist'] = $options;
+            $input_descriptors1[0]['datalist'] = $options;
         } else {
-            $input_descriptor[0]['disabled'] = true;
+            $input_descriptors1[0]['disabled'] = true;
         }
 
         $input_descriptors1[] = array(


### PR DESCRIPTION
The operator username of config-operators-del.php doesn't show operator list for select. 
$input_descriptor[0]['datalist'] is typo. It should be input_descriptors1[0]['datalist'].

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the operator username input in `config-operators-del.php` so the operator list appears. The datalist now populates correctly and the field disables when no operators are available.

- **Bug Fixes**
  - Use `$input_descriptors1[0]` for `datalist` and `disabled` instead of `$input_descriptor[0]`.

<sup>Written for commit b07750f317f9dd703412f6cc94bd84020fe2a9c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

