### PR TITLE
Fix operator_acls.php with duplicate files item when having other operator with different access value and create a new operator .

### DIFF
--- a/app/operators/config-operators-new.php
+++ b/app/operators/config-operators-new.php
@@ -23,6 +23,7 @@
  
     include("library/checklogin.php");
     $operator = $_SESSION['operator_user'];
+    $operator_id = $_SESSION['operator_id'];
 
     include('library/check_operator_perm.php');
     include_once('../common/includes/config_read.php');
@@ -255,7 +256,7 @@
         open_tab($navkeys, 2);
 
         include_once('include/management/operator_acls.php');
-        drawOperatorACLs();
+        drawOperatorACLs($operator_id);
 
         close_tab($navkeys, 2);
 


### PR DESCRIPTION
If in operators_acl table, a operator having a file with Granted access, and another operator with Denied access. When creating a new operator (call config-operator-new.php), $operator_id is empty at that time, no 'WHERE' SQL to filter operator_id, operator_acls.php will show the file with two items, one is Granted access, and another is Denied access. 

For my solution, I use a extra 'SELECT' SQL to choose the max operator_acl.operator_id (the latest operator) as the new operator reference, and final with 'COALESCE(opa.access, 1) AS access' to prevent event all operators were deleted, it can also use 1 for the access value.

<img width="1376" height="685" alt="Screenshot 2026-06-14 041233" src="https://github.com/user-attachments/assets/1f24f273-2b2c-45d3-922d-62a0e1e4e52c" />
<img width="1315" height="808" alt="Screenshot 2026-06-14 041254" src="https://github.com/user-attachments/assets/0047ba0b-63c3-4fd6-8850-0e5e93878a8a" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate ACL file entries when creating a new operator by scoping ACL queries to a single operator and passing the session `operator_id` to `drawOperatorACLs()`.

- **Bug Fixes**
  - Pass `$_SESSION['operator_id']` to `drawOperatorACLs($operator_id)` from `config-operators-new.php` to scope results during creation.
  - In `operator_acls.php`, scope to the provided `operator_id`, else use `MAX(operator_id)` from ACLs; use `COALESCE(opa.access, 1)` to default to Granted when no ACL exists.

<sup>Written for commit 5ca30608e8f7d4eed97ff302e14053de18a202e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

