### PR TITLE
feat: show framed IP address on user list

### DIFF
--- a/app/operators/mng-list-all.php
+++ b/app/operators/mng-list-all.php
@@ -73,6 +73,7 @@
         $cols["auth"] = t('all','Password');
     }
 
+    $cols["framedipaddress"] = t('all','FramedIPAddress');
     $cols["lastlogin"] = t('all','LastLoginTime');
     $cols[] = t('title','Groups');
 
@@ -138,9 +139,11 @@
         // we execute and log the actual data query
         $sql = sprintf("SELECT ui.id AS id, rc.username AS username, rc.value AS auth, rc.attribute,
                                CONCAT(COALESCE(ui.firstname, ''), ' ', COALESCE(ui.lastname, '')) AS fullname,
+                               (SELECT MAX(value) FROM %s WHERE username = rc.username AND attribute = 'Framed-IP-Address') AS framedipaddress,
                                (SELECT MAX(acctstarttime) FROM %s WHERE username = rc.username) AS lastlogin
                           FROM %s %s
-                         GROUP BY rc.username", 
+                         GROUP BY rc.username",
+                         $configValues['CONFIG_DB_TBL_RADREPLY'],
                          $configValues['CONFIG_DB_TBL_RADACCT'],
                          $_SESSION['reportTable'], $_SESSION['reportQuery']);
 
@@ -180,6 +183,7 @@
                 'groups' => array(),
                 'type' => $type,
                 'id' => $row['id'],
+                'framedipaddress' => $row['framedipaddress'],
                 'lastlogin' => $row['lastlogin'],
             );
             // in the same pass we init the $usernamelist
@@ -305,6 +309,8 @@
             $auth = htmlspecialchars($data['auth'], ENT_QUOTES, 'UTF-8');
 
             $fullname = htmlspecialchars($data['fullname'], ENT_QUOTES, 'UTF-8');
+            $framedipaddress = (!empty($data['framedipaddress']))
+                            ? htmlspecialchars($data['framedipaddress'], ENT_QUOTES, 'UTF-8') : "(n/a)";
             $lastlogin = (!empty($data['lastlogin']))
                        ? htmlspecialchars($data['lastlogin'], ENT_QUOTES, 'UTF-8') : "(n/a)";
             $grouplist = implode("<br>", $data['groups']);
@@ -340,6 +346,7 @@
                 $table_row[] = ($type == 'USER') ? $auth : "(n/a)";
             }
 
+            $table_row[] = $framedipaddress;
             $table_row[] = $lastlogin;
             $table_row[] = $grouplist;
 


### PR DESCRIPTION
## Summary

Adds a **Framed-IP-Address** column to the main user list page (`mng-list-all.php`).

The value is read from the user's static `radreply` attribute:

```sql
attribute = 'Framed-IP-Address'
```

This helps operators see already assigned static user IP addresses directly from the user list and avoid accidental IP conflicts.

## Related Issues

Fixes #561.

## Validation

Tested in the Docker development environment:

- `php -l app/operators/mng-list-all.php`
- `git diff --check`
- Created a test user with `Framed-IP-Address = 10.56.1.23`
- Opened `mng-list-all.php?orderBy=framedipaddress&orderType=asc`
- Confirmed the new column appears and shows the assigned static IP
- Checked `radius-web` logs for PHP/database errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Framed-IP-Address column to the user list so operators can see assigned static IPs and avoid conflicts. Fixes #561.

- **New Features**
  - Shows `Framed-IP-Address` per user, sourced from `radreply`.
  - Falls back to "(n/a)" and escapes the value for safe display.

<sup>Written for commit 9c952758061cf3bacb1cb9e30c0085c6ee4d3249. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

