### PR TITLE
docs: explain expiration reply messages

### DIFF
--- a/doc/setup/expiration-reply-message.md
+++ b/doc/setup/expiration-reply-message.md
@@ -1,0 +1,101 @@
+# Expiration reply messages
+
+When a user account expires, FreeRADIUS returns an `Access-Reject`. Some NAS or
+hotspot devices show only a generic message such as `invalid username or
+password` unless the RADIUS response includes a `Reply-Message` attribute.
+
+daloRADIUS can store that message in the user's reply attributes. FreeRADIUS then
+includes it in the reject packet, and the NAS can display it when it supports
+reject reply messages.
+
+## Use case
+
+This is useful when an expired user should see a clearer message, for example:
+
+```text
+The account is expired
+```
+
+instead of a generic authentication failure.
+
+## Configure a per-user expiration message
+
+1. Open the operators interface.
+2. Edit the user account.
+3. Add or verify the check attribute that expires the account:
+
+   | Attribute | Operator | Example value |
+   |-----------|----------|---------------|
+   | `Expiration` | `:=` | `01 Jan 2020 00:00:00` |
+
+4. Add a reply attribute for the message:
+
+   | Attribute | Operator | Example value |
+   |-----------|----------|---------------|
+   | `Reply-Message` | `:=` | `The account is expired` |
+
+5. Save the user.
+
+The `Expiration` check attribute decides whether the request is rejected. The
+`Reply-Message` reply attribute supplies the text that FreeRADIUS includes in the
+RADIUS response.
+
+## SQL example
+
+The same configuration can be applied directly in SQL:
+
+```sql
+INSERT INTO radcheck (username, attribute, op, value)
+VALUES
+  ('alice', 'Cleartext-Password', ':=', 'secret'),
+  ('alice', 'Expiration', ':=', '01 Jan 2020 00:00:00');
+
+INSERT INTO radreply (username, attribute, op, value)
+VALUES
+  ('alice', 'Reply-Message', ':=', 'The account is expired');
+```
+
+## Test with radtest
+
+After configuring the expired user and reply message, test the RADIUS response
+from a host that has `radtest` available and is allowed as a RADIUS client:
+
+```bash
+radtest alice secret 127.0.0.1 0 testing123
+```
+
+Replace `alice`, `secret`, `127.0.0.1`, and `testing123` with the username,
+password, RADIUS server address, and shared secret for your environment.
+
+The expected response is an `Access-Reject` that contains the configured
+`Reply-Message`:
+
+```text
+Received Access-Reject ...
+    Reply-Message = "The account is expired"
+```
+
+## NAS and captive portal behavior
+
+FreeRADIUS can send the `Reply-Message`, but the final user-facing text depends
+on the NAS, access point, hotspot, or captive portal. Some devices display the
+message as-is. Others ignore reject reply messages and continue to show a generic
+login error.
+
+For MikroTik and similar NAS devices, verify the exact behavior with the device's
+hotspot or PPP authentication flow after confirming with `radtest` that
+FreeRADIUS sends the expected `Reply-Message`.
+
+## Troubleshooting
+
+| Symptom | Possible cause | Resolution |
+|---------|----------------|------------|
+| `Access-Reject` has no `Reply-Message` | No `radreply` row exists for the user | Add `Reply-Message := <message>` to the user's reply attributes. |
+| `radtest` shows the message but the NAS does not | The NAS or captive portal ignores reject reply messages | Check the NAS documentation and test the NAS-specific login flow. |
+| The user is accepted instead of rejected | The `Expiration` value is in the future, has an invalid format, or is not evaluated | Use a past date in FreeRADIUS' expected format and verify the user has an `Expiration` check attribute. |
+| The message appears for successful logins too | `Reply-Message` is also sent on `Access-Accept` when the user is not rejected | Use wording that is safe for the intended state, or apply the reply message only to users that are expected to be expired. |
+
+## References
+
+- [GitHub Issue #562 — Expiration Reply from radius](https://github.com/lirantal/daloradius/issues/562)
+- [FreeRADIUS users file documentation for `Reply-Message`](https://wiki.freeradius.org/config/Users)


### PR DESCRIPTION
## Summary

Documents how to return a clearer RADIUS reject message for expired users by using the `Reply-Message` reply attribute together with the `Expiration` check attribute.

## Why

When a user account is expired, FreeRADIUS correctly returns an `Access-Reject`, but some NAS or hotspot devices may display only a generic message such as *invalid username or password*.

This documentation explains how administrators can configure daloRADIUS / FreeRADIUS to include a clearer message, for example:

```text
The account is expired
```

## Changes

- Add `doc/setup/expiration-reply-message.md`
- Explain how to configure:
  - `Expiration` as a check attribute
  - `Reply-Message` as a reply attribute
- Add a simple `radtest` validation example
- Document the limitation that the final user-facing message depends on NAS / captive portal support

## Validation

The behavior was validated with `radtest` by configuring an expired test user with a `Reply-Message`.

Expected result:

```text
Received Access-Reject ...
    Reply-Message = "The account is expired"
```


## Related Issues

Fixes #562.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a docs page showing how to return a clear RADIUS reject message for expired users by setting `Expiration` (check) and `Reply-Message` (reply) in daloRADIUS/FreeRADIUS. Includes a quick `radtest` example and notes on NAS/captive portal behavior; fixes #562.

<sup>Written for commit 7670500a9c3d94c5e9792b875ec15934fb2dbc0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

