### PR TITLE
feat: add SHA2 password support

### DIFF
--- a/app/common/includes/validation.php
+++ b/app/common/includes/validation.php
@@ -77,6 +77,7 @@ $valid_passwordTypes = array(
                                 "NT-Password",
                                 "MD5-Password",
                                 "SHA1-Password",
+                                "SHA2-Password",
                                 "User-Password",
                                 "Crypt-Password",
                                 //~ "CHAP-Password"

--- a/app/operators/include/management/populate_selectbox.php
+++ b/app/operators/include/management/populate_selectbox.php
@@ -686,6 +686,7 @@ function populate_password_types($elementName = "", $cssClass = "form", $mode = 
             <option value='Crypt-Password'>Crypt-Password</option>
             <option value='MD5-Password'>MD5-Password</option>
             <option value='SHA1-Password'>SHA1-Password</option>
+            <option value='SHA2-Password'>SHA2-Password</option>
             <option value='CHAP-Password'>CHAP-Password</option>
             </select>";
 }

--- a/app/operators/lang/de.php
+++ b/app/operators/lang/de.php
@@ -586,7 +586,7 @@ $l['FormField']['mngradnasnew.php']['ToolTip']['NasShortname'] = "(beschreibende
 $l['FormField']['mngradusergroupdel.php']['ToolTip']['Groupname'] = "Wenn Sie eine Gruppe angeben, wird nur der einzelne Datensatz entfernt, der sowohl zum Benutzernamen als auch zur angegebenen Gruppe passt. Wenn Sie die Gruppe weglassen, werden alle Datensätze für diesen Benutzernamen entfernt!";
 
 $l['Tooltip']['usernameTooltip'] = "Beispiel: max_mustermann. Der genaue Benutzername, den der Benutzer zur Anmeldung im System verwendet.";
-$l['Tooltip']['passwordTypeTooltip'] = "Beispiel: Cleartext-Password, MD5-Password, SHA1-Password. Der Passworttyp, der zur Authentifizierung des Benutzers im RADIUS verwendet wird.";
+$l['Tooltip']['passwordTypeTooltip'] = "Beispiel: Cleartext-Password, MD5-Password, SHA1-Password, SHA2-Password. Der Passworttyp, der zur Authentifizierung des Benutzers im RADIUS verwendet wird.";
 $l['Tooltip']['passwordTooltip'] = "Beispiel: P@ssw0rt!. Das Passwort des Benutzers. Beachten Sie, dass manche Systeme zwischen Groß- und Kleinschreibung unterscheiden. Bitte achten Sie auf die genaue Eingabe.";
 $l['Tooltip']['groupTooltip'] = "Beispiel: Premium_Benutzer. Die Gruppe, der der Benutzer hinzugefügt wird. Durch das Hinzufügen zu einer bestimmten Gruppe erbt der Benutzer die Attribute dieser Gruppe.";
 $l['Tooltip']['macaddressTooltip'] = "Beispiel: 00:AA:BB:CC:DD:EE. Das MAC-Adressformat sollte dem Format entsprechen, das vom NAS gesendet wird. In der Regel ist das ohne Trennzeichen.";

--- a/app/operators/lang/en.php
+++ b/app/operators/lang/en.php
@@ -586,7 +586,7 @@ $l['FormField']['mngradnasnew.php']['ToolTip']['NasShortname'] = "(descriptive n
 $l['FormField']['mngradusergroupdel.php']['ToolTip']['Groupname'] = "If you specify group then only the single record that matches both the username and the group which you have specified will be removed. If you omit the group then all records for that particular user will be removed!";
 
 $l['Tooltip']['usernameTooltip'] = "Example: john_doe. The exact username the user will use to connect to the system.";
-$l['Tooltip']['passwordTypeTooltip'] = "Example: Cleartext-Password, MD5-Password, SHA1-Password. The password type used to authenticate the user in RADIUS.";
+$l['Tooltip']['passwordTypeTooltip'] = "Example: Cleartext-Password, MD5-Password, SHA1-Password, SHA2-Password. The password type used to authenticate the user in RADIUS.";
 $l['Tooltip']['passwordTooltip'] = "Example: P@ssw0rd!. The user's password. Note that some systems use case-sensitive passwords, so please take extra care.";
 $l['Tooltip']['groupTooltip'] = "Example: Premium_Users. The group to which the user will be added. By adding a user to a specific group, they become subject to that group's attributes.";
 $l['Tooltip']['macaddressTooltip'] = "Example: 00:AA:BB:CC:DD:EE. The MAC Address format should be the same as sent by the NAS. Usually, this is without any separating characters.";

--- a/app/operators/library/attributes.php
+++ b/app/operators/library/attributes.php
@@ -59,6 +59,9 @@ function hashPasswordAttribute($attribute, $value) {
         case "SHA1-Password":
             return sha1($value);
 
+        case "SHA2-Password":
+            return hash('sha256', $value);
+
         case "NT-Password":
             return strtoupper(bin2hex(mhash(MHASH_MD4, iconv('UTF-8', 'UTF-16LE', $value))));
 

--- a/app/users/pref-auth-password-edit.php
+++ b/app/users/pref-auth-password-edit.php
@@ -54,6 +54,9 @@
             
             case "SHA1-Password":
                 return sha1($value);
+
+            case "SHA2-Password":
+                return hash('sha256', $value);
             
             case "NT-Password":
                 return strtoupper(bin2hex(mhash(MHASH_MD4, iconv('UTF-8', 'UTF-16LE', $value))));


### PR DESCRIPTION
# Summary

Adds **SHA2-Password** as an optional password type in daloRADIUS.

# Changes

- Add `SHA2-Password` to the central `$valid_passwordTypes` list.
- Add SHA-256 hashing support in the operators-side `hashPasswordAttribute()` helper.
- Add SHA-256 hashing support in the users portal password-change helper.
- Add `SHA2-Password` to the legacy password type select helper.
- Update password type tooltip text to mention `SHA2-Password`.

# Notes

This is intentionally added as an optional password type only. Existing users are not migrated or changed automatically.

`SHA2-Password` was validated with FreeRADIUS 3.2.x for PAP authentication. Other authentication methods such as MS-CHAP, CHAP, or EAP may require different password material, such as `NT-Password` or cleartext-equivalent values.

# Validation

- Ran `git diff --check`
- Ran PHP lint on all modified PHP files
- Verified `hashPasswordAttribute("SHA2-Password", "secret")` returns the expected SHA-256 hex digest
- Verified FreeRADIUS PAP authentication succeeds with a `radcheck` row using:
  ```text
  SHA2-Password := <sha256 hex>
  ```
- Verified `SHA2-Password` appears in the password type selector on `mng-new.php`

# Related Issue

Fixes: #614

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `SHA2-Password` as an optional password type with SHA-256 hashing to support PAP on FreeRADIUS 3.2.x. Implements #614; no auto-migration.

- **New Features**
  - Added `SHA2-Password` to valid types and the password type selector.
  - Implemented SHA-256 hashing in `hashPasswordAttribute()` for operators and the user portal.
  - Updated tooltip text to include `SHA2-Password`.

<sup>Written for commit ee5e1cdd40cfd850adc641656a40374041be836a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

