### PR TITLE
Fix/issue 542 lxc proc check

### DIFF
--- a/doc/install/INSTALL.debian.md
+++ b/doc/install/INSTALL.debian.md
@@ -27,6 +27,26 @@ Lastly, all the commands and procedures mentioned in this guide assume the use o
 
 **The authors of this guide disclaims any responsibility for any direct, indirect, incidental, consequential or other damages arising from the use of this guide.**
 
+
+# Proxmox LXC containers
+
+This installation can run inside Proxmox LXC containers, but the container must allow systemd services such as FreeRADIUS to use the required namespace protections.
+
+For Proxmox LXC, enable the `nesting` feature before running the installer or following this guide:
+
+```bash
+pct set <CTID> -features nesting=1
+```
+
+Without this feature, FreeRADIUS may fail to start with an error similar to:
+
+```text
+Failed to set up mount namespacing: /run/systemd/unit-root/proc: Permission denied
+Failed at step NAMESPACE
+```
+
+If you see this error, enable nesting for the container or use a full virtual machine instead of a restricted LXC container.
+
 # Installing MariaDB
 
 To install the MariaDB server, run the following command:

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -116,6 +116,30 @@ system_ensure_root() {
   fi
 }
 
+# Function to ensure systemd can run services that protect kernel tunables.
+# Some container environments, such as Proxmox LXC containers without the
+# nesting feature enabled, cannot set up the mount namespace required by the
+# Debian FreeRADIUS unit (ProtectKernelTunables=true). Detect this before the
+# installer mutates the system and leaves a partial installation behind.
+system_check_service_namespace_support() {
+    echo -n "[+] Checking systemd service namespace support... "
+
+    if ! command -v systemd-run >/dev/null 2>&1; then
+        print_red "KO"
+        echo "[!] systemd-run is required to validate service namespace support. Aborting." >&2
+        exit 1
+    fi
+
+    if ! systemd-run --wait --collect --quiet -p ProtectKernelTunables=yes /bin/true >/dev/null 2>&1; then
+        print_red "KO"
+        echo "[!] This system cannot run services with protected kernel tunables." >&2
+        echo "[!] In Proxmox LXC containers, enable the nesting feature or provide write access to /proc/sys before running this installer." >&2
+        exit 1
+    fi
+
+    print_green "OK"
+}
+
 # Function to install necessary system packages and perform system update
 system_update() {
     echo -n "[+] Updating system package lists... "
@@ -646,6 +670,7 @@ system_finalize() {
 # Main function calling other functions in the correct order
 main() {
     system_ensure_root
+    system_check_service_namespace_support
     system_update
 
     mariadb_install


### PR DESCRIPTION
# Summary

Adds an early installer preflight check for environments that cannot run systemd services with protected kernel tunables, such as Proxmox LXC containers without nesting enabled.

# Changes

- Add an early `systemd-run` check in `setup/install.sh` before the installer mutates the system.
- Abort with a clear error message when the environment cannot support the namespace protections required by the Debian FreeRADIUS service.
- Document Proxmox LXC requirements in `doc/install/INSTALL.debian.md`.
- Clarify that Proxmox LXC can be used when the nesting feature is enabled.

# Why

On restricted Proxmox LXC containers without nesting, the installer currently fails late when restarting FreeRADIUS:

```text
Failed to set up mount namespacing: /run/systemd/unit-root/proc: Permission denied
Failed at step NAMESPACE
```

By that point, `/var/www/daloradius` has already been created and the system is left in a partially installed state.

The new preflight check detects this unsupported environment before installation starts.

# Validation

- Reproduced the failure on a clean Debian 12 Proxmox LXC container with `nesting=0`.
- Verified the updated installer exits early on `nesting=0` before creating `/var/www/daloradius`.
- Verified the updated installer completes successfully on a clean Debian 12 Proxmox LXC container with `nesting=1`.
- Confirmed `freeradius`, `apache2`, and `mariadb` are active after installation with nesting enabled.
- Ran `git diff --check`.
- Ran `bash -n setup/install.sh`.

# Related Issue

Fixes: #542

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an early preflight check to block installs on environments that can’t run `systemd` services with protected kernel tunables (e.g., Proxmox LXC without nesting). Prevents partial installs by failing fast and documents LXC requirements.

- **Bug Fixes**
  - Add `systemd-run` probe in `setup/install.sh` to verify namespace protections before any changes.
  - Abort with a clear error when unsupported; advise enabling LXC `nesting` or using a VM.
  - Document Proxmox LXC requirements in `doc/install/INSTALL.debian.md`, including `pct set <CTID> -features nesting=1`.

<sup>Written for commit 70d35d6ab732bca0b4439dd5417ae77d64249924. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

