### PR TITLE
fix: enable SQL session tracking for simultaneous use

### DIFF
--- a/doc/install/INSTALL.debian.md
+++ b/doc/install/INSTALL.debian.md
@@ -144,6 +144,26 @@ authorize {
 
 This lets FreeRADIUS compare the user's accumulated accounting time with daloRADIUS check attributes such as `Max-All-Session`.
 
+To enforce simultaneous session limits such as `Simultaneous-Use`, enable SQL-backed session tracking in the `session` section of `/etc/freeradius/3.0/sites-available/default`:
+
+```text
+session {
+    sql
+}
+```
+
+This lets FreeRADIUS check active sessions in the SQL accounting table (`radacct`). Make sure your NAS sends accounting packets (`Accounting-Start`, `Accounting-Stop`, and ideally interim updates), otherwise FreeRADIUS cannot reliably know which sessions are currently active.
+
+To reduce the race between `Access-Accept` and the NAS sending `Accounting-Start`, also enable `sql_session_start` in the `post-auth` section:
+
+```text
+post-auth {
+    ...
+    sql_session_start
+    ...
+}
+```
+
 To enforce daloRADIUS profile/group NAS restrictions configured as `radgroupcheck` rows, also add the following policy immediately after `noresetcounter` in the same `authorize` section:
 
 ```text

--- a/init-freeradius.sh
+++ b/init-freeradius.sh
@@ -147,9 +147,16 @@ function init_freeradius {
 }
 
 function enable_noresetcounter {
+	local freeradius_default_tmp
+	freeradius_default_tmp=$(mktemp) || {
+		echo "Failed to create temporary file."
+		exit 1
+	}
+
 	# Enforce Max-All-Session limits through FreeRADIUS sqlcounter.
 	# The sqlcounter module must run in authorize; enabling mods-enabled/sqlcounter alone is not enough.
 	if grep -q "^[[:space:]]*noresetcounter[[:space:]]*$" "$RADIUS_PATH/sites-available/default"; then
+		rm -f "$freeradius_default_tmp"
 		return
 	fi
 
@@ -165,14 +172,20 @@ function enable_noresetcounter {
 		/^authenticate[[:space:]]*[{]/ { in_authorize = 0 }
 		{ print }
 		END { exit added ? 0 : 1 }
-	' "$RADIUS_PATH/sites-available/default" > /tmp/freeradius-default; then
-		rm -f /tmp/freeradius-default
+	' "$RADIUS_PATH/sites-available/default" > "$freeradius_default_tmp"; then
+		rm -f "$freeradius_default_tmp"
 		echo "Failed to add noresetcounter to FreeRADIUS authorize section."
 		exit 1
 	fi
-	mv /tmp/freeradius-default "$RADIUS_PATH/sites-available/default"
+	mv "$freeradius_default_tmp" "$RADIUS_PATH/sites-available/default"
 }
 function enable_sql_session_tracking {
+	local freeradius_default_tmp
+	freeradius_default_tmp=$(mktemp) || {
+		echo "Failed to create temporary file."
+		exit 1
+	}
+
 	# Enforce Simultaneous-Use limits with SQL-backed session tracking.
 	# The SQL module must run in the session section; enabling mods-enabled/sql
 	# alone is not enough. sql_session_start creates an accounting row at
@@ -199,22 +212,29 @@ function enable_sql_session_tracking {
 
 		{ print }
 		END { exit (session_sql && sql_session_start) ? 0 : 1 }
-	' "$RADIUS_PATH/sites-available/default" > /tmp/freeradius-default; then
-		rm -f /tmp/freeradius-default
+	' "$RADIUS_PATH/sites-available/default" > "$freeradius_default_tmp"; then
+		rm -f "$freeradius_default_tmp"
 		echo "Failed to enable SQL session tracking in FreeRADIUS."
 		exit 1
 	fi
-	mv /tmp/freeradius-default "$RADIUS_PATH/sites-available/default"
+	mv "$freeradius_default_tmp" "$RADIUS_PATH/sites-available/default"
 }
 
 
 function enable_group_nas_restrictions {
+	local freeradius_default_tmp
+	freeradius_default_tmp=$(mktemp) || {
+		echo "Failed to create temporary file."
+		exit 1
+	}
+
 	# Enforce daloRADIUS group/profile NAS restrictions stored in radgroupcheck.
 	# FreeRADIUS uses radgroupcheck to decide whether group reply items apply; it
 	# does not automatically reject a user who already authenticated via radcheck.
 	# This policy rejects users when their SQL group has NAS-IP-Address == rows
 	# and the request NAS-IP-Address does not match any of those allowed values.
 	if grep -q "daloRADIUS group NAS restriction policy" "$RADIUS_PATH/sites-available/default"; then
+		rm -f "$freeradius_default_tmp"
 		return
 	fi
 
@@ -238,12 +258,12 @@ function enable_group_nas_restrictions {
 			}
 		}
 		END { exit added ? 0 : 1 }
-	' "$RADIUS_PATH/sites-available/default" > /tmp/freeradius-default; then
-		rm -f /tmp/freeradius-default
+	' "$RADIUS_PATH/sites-available/default" > "$freeradius_default_tmp"; then
+		rm -f "$freeradius_default_tmp"
 		echo "Failed to add daloRADIUS group NAS restriction policy to FreeRADIUS authorize section."
 		exit 1
 	fi
-	mv /tmp/freeradius-default "$RADIUS_PATH/sites-available/default"
+	mv "$freeradius_default_tmp" "$RADIUS_PATH/sites-available/default"
 }
 
 function ensure_daloradius_schema {

--- a/init-freeradius.sh
+++ b/init-freeradius.sh
@@ -172,6 +172,41 @@ function enable_noresetcounter {
 	fi
 	mv /tmp/freeradius-default "$RADIUS_PATH/sites-available/default"
 }
+function enable_sql_session_tracking {
+	# Enforce Simultaneous-Use limits with SQL-backed session tracking.
+	# The SQL module must run in the session section; enabling mods-enabled/sql
+	# alone is not enough. sql_session_start creates an accounting row at
+	# Access-Accept time to reduce the race before Accounting-Start arrives.
+	if ! awk '
+		BEGIN { in_session = 0; in_post_auth = 0; session_sql = 0; sql_session_start = 0 }
+		/^session[[:space:]]*[{]/ { in_session = 1 }
+		in_session && /^[[:space:]]*#[[:space:]]*sql[[:space:]]*$/ {
+			print "	sql"
+			session_sql = 1
+			next
+		}
+		in_session && /^[[:space:]]*sql[[:space:]]*$/ { session_sql = 1 }
+		in_session && /^}/ { in_session = 0 }
+
+		/^post-auth[[:space:]]*[{]/ { in_post_auth = 1 }
+		in_post_auth && /^[[:space:]]*#[[:space:]]*sql_session_start[[:space:]]*$/ {
+			print "	sql_session_start"
+			sql_session_start = 1
+			next
+		}
+		in_post_auth && /^[[:space:]]*sql_session_start[[:space:]]*$/ { sql_session_start = 1 }
+		in_post_auth && /^}/ { in_post_auth = 0 }
+
+		{ print }
+		END { exit (session_sql && sql_session_start) ? 0 : 1 }
+	' "$RADIUS_PATH/sites-available/default" > /tmp/freeradius-default; then
+		rm -f /tmp/freeradius-default
+		echo "Failed to enable SQL session tracking in FreeRADIUS."
+		exit 1
+	fi
+	mv /tmp/freeradius-default "$RADIUS_PATH/sites-available/default"
+}
+
 
 function enable_group_nas_restrictions {
 	# Enforce daloRADIUS group/profile NAS restrictions stored in radgroupcheck.
@@ -286,6 +321,7 @@ if test -L "$RADIUS_PATH/mods-enabled/sqlcounter"; then
 fi
 
 if test -L "$RADIUS_PATH/mods-enabled/sql"; then
+	enable_sql_session_tracking
 	enable_group_nas_restrictions
 fi
 

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -256,6 +256,13 @@ freeradius_setup_sql_mod() {
 freeradius_setup_sqlcounter_mod() {
     echo -n "[+] Setting up freeRADIUS SQL counter module... "
 
+    local freeradius_default_tmp
+    freeradius_default_tmp=$(mktemp) || {
+        print_red "KO"
+        echo "[!] Failed to create temporary file. Aborting." >&2
+        exit 1
+    }
+
     if ! sed -Ei 's/^[[:space:]#]*dialect[[:space:]]+=[[:space:]]+.*$/	dialect = "mysql"/g' "${FREERADIUS_SQLCOUNTER_MOD_PATH}" >/dev/null 2>&1; then
         print_red "KO"
         echo "[!] Failed to configure freeRADIUS SQL counter module. Aborting." >&2
@@ -283,13 +290,15 @@ freeradius_setup_sqlcounter_mod() {
             /^authenticate[[:space:]]*[{]/ { in_authorize = 0 }
             { print }
             END { exit added ? 0 : 1 }
-        ' "${FREERADIUS_DEFAULT_SITE_PATH}" > /tmp/freeradius-default; then
-            rm -f /tmp/freeradius-default
+        ' "${FREERADIUS_DEFAULT_SITE_PATH}" > "${freeradius_default_tmp}"; then
+            rm -f "${freeradius_default_tmp}"
             print_red "KO"
             echo "[!] Failed to add noresetcounter to freeRADIUS authorize section. Aborting." >&2
             exit 1
         fi
-        mv /tmp/freeradius-default "${FREERADIUS_DEFAULT_SITE_PATH}"
+        mv "${freeradius_default_tmp}" "${FREERADIUS_DEFAULT_SITE_PATH}"
+    else
+        rm -f "${freeradius_default_tmp}"
     fi
 
     print_green "OK"
@@ -299,6 +308,13 @@ freeradius_setup_sqlcounter_mod() {
 # Function to set up SQL-backed session tracking for Simultaneous-Use
 freeradius_setup_sql_session_tracking() {
     echo -n "[+] Setting up freeRADIUS SQL session tracking... "
+
+    local freeradius_default_tmp
+    freeradius_default_tmp=$(mktemp) || {
+        print_red "KO"
+        echo "[!] Failed to create temporary file. Aborting." >&2
+        exit 1
+    }
 
     if ! awk '
         BEGIN { in_session = 0; in_post_auth = 0; session_sql = 0; sql_session_start = 0 }
@@ -322,14 +338,14 @@ freeradius_setup_sql_session_tracking() {
 
         { print }
         END { exit (session_sql && sql_session_start) ? 0 : 1 }
-    ' "${FREERADIUS_DEFAULT_SITE_PATH}" > /tmp/freeradius-default; then
-        rm -f /tmp/freeradius-default
+    ' "${FREERADIUS_DEFAULT_SITE_PATH}" > "${freeradius_default_tmp}"; then
+        rm -f "${freeradius_default_tmp}"
         print_red "KO"
         echo "[!] Failed to enable SQL session tracking in freeRADIUS. Aborting." >&2
         exit 1
     fi
 
-    mv /tmp/freeradius-default "${FREERADIUS_DEFAULT_SITE_PATH}"
+    mv "${freeradius_default_tmp}" "${FREERADIUS_DEFAULT_SITE_PATH}"
     print_green "OK"
 }
 
@@ -338,7 +354,15 @@ freeradius_setup_sql_session_tracking() {
 freeradius_setup_group_nas_restrictions() {
     echo -n "[+] Setting up freeRADIUS group NAS restriction policy... "
 
+    local freeradius_default_tmp
+    freeradius_default_tmp=$(mktemp) || {
+        print_red "KO"
+        echo "[!] Failed to create temporary file. Aborting." >&2
+        exit 1
+    }
+
     if grep -q "daloRADIUS group NAS restriction policy" "${FREERADIUS_DEFAULT_SITE_PATH}"; then
+        rm -f "${freeradius_default_tmp}"
         print_green "OK"
         return
     fi
@@ -363,14 +387,14 @@ freeradius_setup_group_nas_restrictions() {
             }
         }
         END { exit added ? 0 : 1 }
-    ' "${FREERADIUS_DEFAULT_SITE_PATH}" > /tmp/freeradius-default; then
-        rm -f /tmp/freeradius-default
+    ' "${FREERADIUS_DEFAULT_SITE_PATH}" > "${freeradius_default_tmp}"; then
+        rm -f "${freeradius_default_tmp}"
         print_red "KO"
         echo "[!] Failed to add daloRADIUS group NAS restriction policy to freeRADIUS authorize section. Aborting." >&2
         exit 1
     fi
 
-    mv /tmp/freeradius-default "${FREERADIUS_DEFAULT_SITE_PATH}"
+    mv "${freeradius_default_tmp}" "${FREERADIUS_DEFAULT_SITE_PATH}"
     print_green "OK"
 }
 

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -296,6 +296,44 @@ freeradius_setup_sqlcounter_mod() {
 }
 
 
+# Function to set up SQL-backed session tracking for Simultaneous-Use
+freeradius_setup_sql_session_tracking() {
+    echo -n "[+] Setting up freeRADIUS SQL session tracking... "
+
+    if ! awk '
+        BEGIN { in_session = 0; in_post_auth = 0; session_sql = 0; sql_session_start = 0 }
+        /^session[[:space:]]*[{]/ { in_session = 1 }
+        in_session && /^[[:space:]]*#[[:space:]]*sql[[:space:]]*$/ {
+            print "	sql"
+            session_sql = 1
+            next
+        }
+        in_session && /^[[:space:]]*sql[[:space:]]*$/ { session_sql = 1 }
+        in_session && /^}/ { in_session = 0 }
+
+        /^post-auth[[:space:]]*[{]/ { in_post_auth = 1 }
+        in_post_auth && /^[[:space:]]*#[[:space:]]*sql_session_start[[:space:]]*$/ {
+            print "	sql_session_start"
+            sql_session_start = 1
+            next
+        }
+        in_post_auth && /^[[:space:]]*sql_session_start[[:space:]]*$/ { sql_session_start = 1 }
+        in_post_auth && /^}/ { in_post_auth = 0 }
+
+        { print }
+        END { exit (session_sql && sql_session_start) ? 0 : 1 }
+    ' "${FREERADIUS_DEFAULT_SITE_PATH}" > /tmp/freeradius-default; then
+        rm -f /tmp/freeradius-default
+        print_red "KO"
+        echo "[!] Failed to enable SQL session tracking in freeRADIUS. Aborting." >&2
+        exit 1
+    fi
+
+    mv /tmp/freeradius-default "${FREERADIUS_DEFAULT_SITE_PATH}"
+    print_green "OK"
+}
+
+
 # Function to enforce daloRADIUS group/profile NAS restrictions in freeRADIUS
 freeradius_setup_group_nas_restrictions() {
     echo -n "[+] Setting up freeRADIUS group NAS restriction policy... "
@@ -688,6 +726,7 @@ main() {
     freeradius_install
     freeradius_setup_sql_mod
     freeradius_setup_sqlcounter_mod
+    freeradius_setup_sql_session_tracking
     freeradius_setup_group_nas_restrictions
     freeradius_enable_restart
 


### PR DESCRIPTION
# Summary

Enables SQL-backed session tracking in FreeRADIUS so `Simultaneous-Use` check attributes configured from daloRADIUS are actually enforced.

# Changes

- Enable `sql` in the FreeRADIUS `session` section for Docker installs via `init-freeradius.sh`.
- Enable `sql` in the FreeRADIUS `session` section for classic Debian installs via `setup/install.sh`.
- Enable `sql_session_start` in `post-auth` to reduce the race window before the NAS sends `Accounting-Start`.
- Keep the change idempotent so repeated container starts or installer configuration passes do not duplicate entries.
- Document the required SQL session tracking setup in `doc/install/INSTALL.debian.md`.

# Why

`Simultaneous-Use := 1` is a valid FreeRADIUS check attribute, and daloRADIUS already allows configuring it. However, FreeRADIUS only enforces it when a session module is enabled.

Before this change, daloRADIUS enabled SQL for authorization/accounting and configured SQL counters such as `noresetcounter`, but the default FreeRADIUS `session` section still had SQL commented out:

```text
session {
#       sql
}
```

As a result, users with `Simultaneous-Use := 1` could still authenticate even when an active SQL accounting session already existed.

# Validation

- Reproduced the issue with a test user using `Simultaneous-Use := 1` and an active `radacct` row.
- Confirmed that authentication was accepted when SQL session tracking was disabled.
- Rebuilt and tested the Docker FreeRADIUS container using the updated `init-freeradius.sh`.
- Verified the generated Docker FreeRADIUS configuration contains exactly one active `sql` entry in `session`.
- Verified the generated Docker FreeRADIUS configuration contains exactly one active `sql_session_start` entry.
- Verified Docker FreeRADIUS configuration with:

  ```bash
  freeradius -C
  ```

- Verified authentication is rejected with:

  ```text
  Access-Reject
  Reply-Message = "You are already logged in - access denied"
  ```

- Tested the classic Debian installer in a clean Debian 12 LXC container.
- Verified `freeradius`, `apache2`, and `mariadb` start successfully after installation.
- Verified the Debian installation also rejects a second login when `Simultaneous-Use := 1` and an active `radacct` row exists.
- Ran `git diff --check`.
- Ran `bash -n setup/install.sh`.
- Ran `bash -n init-freeradius.sh`.

# Related Issue

Fixes: #552

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable SQL-backed session tracking in FreeRADIUS so `Simultaneous-Use` limits from daloRADIUS are enforced. Also enable `sql_session_start` to reduce the window before accounting starts.

- **Bug Fixes**
  - Update Docker init and Debian installer to enable these settings idempotently, using safe temp files for config edits.
  - Add Debian install docs on enabling `session { sql }` and `sql_session_start`.

<sup>Written for commit 1162dc9a7d320fc058af91ab74a239d66db09fca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

