### PR TITLE
chore: update vendored PHPMailer library to 6.12.0

### DIFF
--- a/app/common/library/phpmailer/DSNConfigurator.php
+++ b/app/common/library/phpmailer/DSNConfigurator.php
@@ -13,7 +13,7 @@
  * @copyright 2012 - 2023 Marcus Bointon
  * @copyright 2010 - 2012 Jim Jagielski
  * @copyright 2004 - 2009 Andy Prevost
- * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ * @license   https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html GNU Lesser General Public License
  * @note      This program is distributed in the hope that it will be useful - WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.
@@ -80,9 +80,7 @@ class DSNConfigurator
         $config = $this->parseUrl($dsn);
 
         if (false === $config || !isset($config['scheme']) || !isset($config['host'])) {
-            throw new Exception(
-                sprintf('Malformed DSN: "%s".', $dsn)
-            );
+            throw new Exception('Malformed DSN');
         }
 
         if (isset($config['query'])) {

--- a/app/common/library/phpmailer/Exception.php
+++ b/app/common/library/phpmailer/Exception.php
@@ -13,7 +13,7 @@
  * @copyright 2012 - 2020 Marcus Bointon
  * @copyright 2010 - 2012 Jim Jagielski
  * @copyright 2004 - 2009 Andy Prevost
- * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ * @license   https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html GNU Lesser General Public License
  * @note      This program is distributed in the hope that it will be useful - WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.

--- a/app/common/library/phpmailer/OAuth.php
+++ b/app/common/library/phpmailer/OAuth.php
@@ -13,7 +13,7 @@
  * @copyright 2012 - 2020 Marcus Bointon
  * @copyright 2010 - 2012 Jim Jagielski
  * @copyright 2004 - 2009 Andy Prevost
- * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ * @license   https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html GNU Lesser General Public License
  * @note      This program is distributed in the hope that it will be useful - WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.
@@ -29,7 +29,7 @@ use League\OAuth2\Client\Token\AccessToken;
  * OAuth - OAuth2 authentication wrapper class.
  * Uses the oauth2-client package from the League of Extraordinary Packages.
  *
- * @see     http://oauth2-client.thephpleague.com
+ * @see     https://oauth2-client.thephpleague.com
  *
  * @author  Marcus Bointon (Synchro/coolbru) <phpmailer@synchromedia.co.uk>
  */

--- a/app/common/library/phpmailer/OAuthTokenProvider.php
+++ b/app/common/library/phpmailer/OAuthTokenProvider.php
@@ -13,7 +13,7 @@
  * @copyright 2012 - 2020 Marcus Bointon
  * @copyright 2010 - 2012 Jim Jagielski
  * @copyright 2004 - 2009 Andy Prevost
- * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ * @license   https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html GNU Lesser General Public License
  * @note      This program is distributed in the hope that it will be useful - WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.

--- a/app/common/library/phpmailer/POP3.php
+++ b/app/common/library/phpmailer/POP3.php
@@ -13,7 +13,7 @@
  * @copyright 2012 - 2020 Marcus Bointon
  * @copyright 2010 - 2012 Jim Jagielski
  * @copyright 2004 - 2009 Andy Prevost
- * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ * @license   https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html GNU Lesser General Public License
  * @note      This program is distributed in the hope that it will be useful - WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.
@@ -46,7 +46,7 @@ class POP3
      *
      * @var string
      */
-    const VERSION = '6.8.0';
+    const VERSION = '6.12.0';
 
     /**
      * Default POP3 port number.
@@ -250,7 +250,9 @@ class POP3
 
         //On Windows this will raise a PHP Warning error if the hostname doesn't exist.
         //Rather than suppress it with @fsockopen, capture it cleanly instead
-        set_error_handler([$this, 'catchWarning']);
+        set_error_handler(function () {
+            call_user_func_array([$this, 'catchWarning'], func_get_args());
+        });
 
         if (false === $port) {
             $port = static::DEFAULT_PORT;


### PR DESCRIPTION
updates vendored PHPMailer from 6.8.0 to 6.12.0; validated syntax and daloRADIUS mail API compatibility.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update vendored `PHPMailer` from 6.8.0 to 6.12.0. Adds SMTPUTF8 and Unicode address support, XCLIENT, and reliability fixes; confirmed compatible with the daloRADIUS mail API.

- **New Features**
  - SMTPUTF8 with auto-detection; blocks send if server lacks support.
  - EAI email validator; auto-switch when UTF‑8 local parts are used.
  - SMTP XCLIENT support via set/get SMTPXclientAttribute and SMTP::xclient.
  - New helpers: clearCustomHeader and replaceCustomHeader.

- **Bug Fixes**
  - Smarter TLS auto-negotiation (skips localhost); improved host validation.
  - Cleaner debug logs and tighter transaction ID regexes.
  - Wrapped set_error_handler in SMTP/POP3 to avoid warnings.
  - Safer DSN errors and better header/body encoding when using SMTPUTF8.

<sup>Written for commit 1bec8a8bee076710a9d245b21535140d730f2a70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

