### PR TITLE
fix(ui): accordion-button show/hidden bug in userReport.php and duplicate 'Apply' button in operatorinfo.php.

### DIFF
--- a/app/operators/config-operators-new.php
+++ b/app/operators/config-operators-new.php
@@ -23,6 +23,7 @@
  
     include("library/checklogin.php");
     $operator = $_SESSION['operator_user'];
+    $operator_id = $_SESSION['operator_id'];
 
     include('library/check_operator_perm.php');
     include_once('../common/includes/config_read.php');
@@ -255,7 +256,7 @@
         open_tab($navkeys, 2);
 
         include_once('include/management/operator_acls.php');
-        drawOperatorACLs();
+        drawOperatorACLs($operator_id);
 
         close_tab($navkeys, 2);
 

--- a/app/operators/include/management/operatorinfo.php
+++ b/app/operators/include/management/operatorinfo.php
@@ -85,13 +85,6 @@ $input_descriptors1[] = array( 'name' => 'updateby', 'caption' => t('all','Updat
                                'type' => 'text', 'value' => ((isset($operator_updateby)) ? $operator_updateby : ""),
                              );
 
-
-$submit_descriptor = array(
-                                "type" => "submit",
-                                "name" => "submit",
-                                "value" => t('buttons','apply')
-                          );                                
-                            
 echo "<fieldset>"
    . "<h302>Operator Details</h302>"
    . "<ul>";
@@ -103,5 +96,4 @@ foreach ($input_descriptors1 as $input_descriptor) {
 echo "</ul>"
    . "</fieldset>";
 
-print_form_component($submit_descriptor);
 ?>

--- a/app/operators/include/management/userReports.php
+++ b/app/operators/include/management/userReports.php
@@ -37,12 +37,13 @@ function open_accordion_item($descriptor) {
     $parent_id = $descriptor['parent_id'];
     $key = (isset($descriptor['key'])) ? $descriptor['key'] : "key-" . rand();
     $show = (isset($descriptor['open']) && $descriptor['open']) ? " show" : "";
+    $collapsed = (isset($descriptor['open']) && $descriptor['open']) ? "" : " collapsed";
     $expanded = (isset($descriptor['open']) && $descriptor['open']) ? "true" : "false";
 
     echo <<<EOF
 <div class="accordion-item">
     <h2 class="accordion-header" id="{$key}-head">
-        <button class="accordion-button" type="button" data-bs-toggle="collapse"
+        <button class="accordion-button{$collapsed}" type="button" data-bs-toggle="collapse"
             data-bs-target="#{$key}-content" aria-expanded="{$expanded}" aria-controls="{$key}-content">
             {$label}
         </button>


### PR DESCRIPTION
1.  In userReport.php, when edit or new a user, the last page 'Other Info', three Bootstrap `accordion-button` showing wrong state, I found then the button class need a 'collapsed' for the button state.
Before:
<img width="1889" height="854" alt="Screenshot 2026-06-24 094503" src="https://github.com/user-attachments/assets/185c9569-0231-4332-a3c2-37a9cfbb5dc4" />
After:
<img width="1901" height="841" alt="Screenshot 2026-06-24 094608" src="https://github.com/user-attachments/assets/f0b7b061-3a67-4e5a-806f-add379c72446" />

2. In the operator management, when edit or new a operator, the page 'Contact Info', it show duplicate 'Apply' button. I found the duplicate code is in the operatorinfo.php, it has a duplicate `$submit_descriptor`, and I search hole project code, the opeartorinfo.php only included in config-operators-new.php and config-operators-edit.php.
Before:
<img width="1902" height="818" alt="Screenshot 2026-06-24 095245" src="https://github.com/user-attachments/assets/f86e51a2-f763-482e-8204-e657f148a5c1" />
<img width="1900" height="812" alt="Screenshot 2026-06-24 095227" src="https://github.com/user-attachments/assets/ac7b3dd1-473f-47c4-ad36-0f90dc833dc1" />
After:
<img width="1909" height="793" alt="Screenshot 2026-06-24 101000" src="https://github.com/user-attachments/assets/3c58cb7c-8124-41ff-91eb-5d062372e0f5" />
<img width="1897" height="808" alt="Screenshot 2026-06-24 101011" src="https://github.com/user-attachments/assets/39d60670-671f-473b-90d5-0a3ddee28b8d" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the accordion show/hide state in Users > Other Info and removes a duplicate Apply button in Operators > Contact Info. This cleans up the UI and avoids confusion in create/edit flows.

- **Bug Fixes**
  - userReports.php: add "collapsed" class to Bootstrap accordion buttons so headers reflect the correct open/closed state.
  - operatorinfo.php: remove duplicate `$submit_descriptor` to stop rendering a second "Apply" button on new/edit operator pages.

<sup>Written for commit b73744a13a926b215cb59ebe6166b239c0ac813b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

