### PR TITLE
fix(ui): accordion-button show/hidden bug in userReport.php and duplicate 'Apply' button in operatorinfo.php. (pull request #720 again for removing old commits)

### DIFF
--- a/app/operators/include/management/operatorinfo.php
+++ b/app/operators/include/management/operatorinfo.php
@@ -85,13 +85,6 @@ $input_descriptors1[] = array( 'name' => 'updateby', 'caption' => t('all','Updat
                                'type' => 'text', 'value' => ((isset($operator_updateby)) ? $operator_updateby : ""),
                              );
 
-
-$submit_descriptor = array(
-                                "type" => "submit",
-                                "name" => "submit",
-                                "value" => t('buttons','apply')
-                          );                                
-                            
 echo "<fieldset>"
    . "<h302>Operator Details</h302>"
    . "<ul>";
@@ -103,5 +96,4 @@ foreach ($input_descriptors1 as $input_descriptor) {
 echo "</ul>"
    . "</fieldset>";
 
-print_form_component($submit_descriptor);
 ?>

--- a/app/operators/include/management/userReports.php
+++ b/app/operators/include/management/userReports.php
@@ -37,12 +37,13 @@ function open_accordion_item($descriptor) {
     $parent_id = $descriptor['parent_id'];
     $key = (isset($descriptor['key'])) ? $descriptor['key'] : "key-" . rand();
     $show = (isset($descriptor['open']) && $descriptor['open']) ? " show" : "";
+    $collapsed = (isset($descriptor['open']) && $descriptor['open']) ? "" : " collapsed";
     $expanded = (isset($descriptor['open']) && $descriptor['open']) ? "true" : "false";
 
     echo <<<EOF
 <div class="accordion-item">
     <h2 class="accordion-header" id="{$key}-head">
-        <button class="accordion-button" type="button" data-bs-toggle="collapse"
+        <button class="accordion-button{$collapsed}" type="button" data-bs-toggle="collapse"
             data-bs-target="#{$key}-content" aria-expanded="{$expanded}" aria-controls="{$key}-content">
             {$label}
         </button>


### PR DESCRIPTION
1.  In userReport.php, when edit or new a user, the last page 'Other Info', three Bootstrap `accordion-button` showing wrong state, Collapsed buttons class need add 'collapsed' value. 
Before:
<img width="1889" height="854" alt="Screenshot 2026-06-24 094503" src="https://github.com/user-attachments/assets/e911f9f4-8114-44a3-af40-6c802eefc858" />
After:
<img width="1901" height="841" alt="Screenshot 2026-06-24 094608" src="https://github.com/user-attachments/assets/85e8d567-ebba-4e1d-a400-c95b0d58401f" />

2. In the operator management, when edit or new an operator, the page 'Contact Info' show duplicate 'Apply' button. The duplicate code is in the operatorinfo.php, it has a duplicate `$submit_descriptor`, and I search whole project codes, the opeartorinfo.php only included in config-operators-new.php and config-operators-edit.php.
Before:
<img width="1900" height="812" alt="Screenshot 2026-06-24 095227" src="https://github.com/user-attachments/assets/a9767906-1b06-49aa-8fbf-7c8e42f4d87d" />
<img width="1902" height="818" alt="Screenshot 2026-06-24 095245" src="https://github.com/user-attachments/assets/4a09899a-2324-4e09-ae0d-f4a78cc3803a" />
After:
<img width="1909" height="793" alt="Screenshot 2026-06-24 101000" src="https://github.com/user-attachments/assets/9d1866b7-5bf5-4ee1-9589-af88b7eb97b8" />
<img width="1897" height="808" alt="Screenshot 2026-06-24 101011" src="https://github.com/user-attachments/assets/4d5cc935-60a3-40cf-b285-335a93f455a4" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the accordion toggle state in User > Other Info and removes the duplicate Apply button in Operator > Contact Info. UI now shows correct collapsed headers and only one Apply button.

- Bug Fixes
  - userReports.php: Add the "collapsed" class to closed accordion headers so the button state matches aria-expanded/show.
  - operatorinfo.php: Remove the duplicated `$submit_descriptor` and its render call to eliminate the extra Apply button when included by `config-operators-new.php` and `config-operators-edit.php`.

<sup>Written for commit a831da4268712413d25ad4e909eaa9ae892beabd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

