### PR TITLE
Improve nas management

### DIFF
--- a/app/operators/config-maint-disconnect-user.php
+++ b/app/operators/config-maint-disconnect-user.php
@@ -174,6 +174,7 @@
         $options = get_online_users();
         array_unshift($options, "");
 
+        // descriptors 0
         $input_descriptors0 = array();
         $input_descriptors0[] = array(
                                         "name" => "username",
@@ -240,11 +241,11 @@
         $input_descriptors2[] = array(
                                         "type" => "submit",
                                         "name" => "submit",
-                                        "value" => t('all','TestUser'),
+                                        "value" => t('button','DisconnectUser'),
                                      );
 
         // set navbar stuff
-        $navkeys = array( 'Settings', 'Advanced', );
+        $navkeys = array( t('title','Settings'), t('title','Advanced'), );
 
         // print navbar controls
         print_tab_header($navkeys);
@@ -260,7 +261,7 @@
 
         // open a fieldset
         $fieldset0_descriptor = array(
-                                        "title" => "Disconnect User",
+                                        "title" => t('button','DisconnectUser'),
                                      );
 
         open_fieldset($fieldset0_descriptor);

--- a/app/operators/config-maint-disconnect-user.php
+++ b/app/operators/config-maint-disconnect-user.php
@@ -21,45 +21,43 @@
  *********************************************************************************************************
  */
 
-    include("library/checklogin.php");
+    include_once implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', 'common', 'includes', 'config_read.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'checklogin.php' ]);
     $operator = $_SESSION['operator_user'];
 
-    include('../common/includes/config_read.php');
-    include('library/check_operator_perm.php');
-
-    include_once("lang/main.php");
-    include_once("../common/includes/validation.php");
-    include("../common/includes/layout.php");
-    include("include/management/functions.php");
-    include("library/extensions/maintenance_radclient.php");
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'check_operator_perm.php' ]);
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LANG'], 'main.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'validation.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'layout.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'functions.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY_EXTENSIONS'], 'maintenance_radclient.php' ]);
 
     // init logging variables
     $log = "visited page: ";
     $logAction = "";
     $logDebugSQL = "";
 
-
     $valid_packetTypes = array(
                                     "disconnect" => 'PoD - Packet of Disconnect',
                                     "coa" => 'CoA - Change of Authorization'
                               );
 
-    include('../common/includes/db_open.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
 
-    $sql = sprintf("SELECT DISTINCT(nasname), ports, shortname, CONCAT('nas-', id) FROM %s ORDER BY nasname ASC",
+    $sql = sprintf("SELECT DISTINCT(nasname), shortname, CONCAT('nas-', id) FROM %s ORDER BY nasname ASC",
                    $configValues['CONFIG_DB_TBL_RADNAS']);
     $res = $dbSocket->query($sql);
 
     $valid_nas_ids = array();
     while ($row = $res->fetchRow()) {
-        $value = $row[3];
-        $label = sprintf("%s (%s:%d)", $row[2], $row[0], intval($row[1]));
-        $valid_nas_ids[$value] = $label;
+        list($nasname, $shortname, $nas_id) = $row;
+        $shortname = trim($shortname);
+        $valid_nas_ids[$nas_id] = ($shortname !== "") ? sprintf("%s (%s)", $shortname, $nasname) : $nasname;
     }
 
-    include('../common/includes/db_close.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
 
-    $radclient_path = is_radclient_present();
+    $radclient_path = RadClient::is_radclient_present();
 
     if ($radclient_path !== false) {
 
@@ -85,11 +83,14 @@
                     $logAction .= "$failureMsg on page: ";
                 } else {
 
-                    $packetType = (isset($_POST['packetType']) && in_array(trim($_POST['packetType']), array_keys($valid_packetTypes)))
-                                ? trim($_POST['packetType']) : $valid_packetTypes[0];
+                    $packetType = (isset($_POST['packetType']) && array_key_exists(trim($_POST['packetType']), $valid_packetTypes))
+                                ? trim($_POST['packetType']) : array_key_first($valid_packetTypes);
                     $customAttributes = (array_key_exists('customAttributes', $_POST) && !empty(trim($_POST['customAttributes'])))
                                       ? trim($_POST['customAttributes']) : "";
 
+                    $port = (array_key_exists('port', $_POST) && !empty(trim($_POST['port'])) &&
+                             intval(trim($_POST['port'])) >= 1 && intval(trim($_POST['port'])) <= 65535)
+                          ? intval(trim($_POST['port'])) : RadClient::DEFAULT_COA_PORT;
                     $debug = (isset($_POST['debug']) && in_array($_POST['debug'], array("yes", "no"))) ? $_POST['debug'] : "no";
                     $timeout = (isset($_POST['timeout']) && intval($_POST['timeout']) > 0) ? intval($_POST['timeout']) : 3;
                     $retries = (isset($_POST['retries']) && intval($_POST['retries']) > 0) ? intval($_POST['retries']) : 3;
@@ -98,22 +99,27 @@
 
                     $simulate = (isset($_POST['simulate']) && $_POST['simulate'] === "on");
 
-                    // this will be passed to user_auth function
-                    $params =  array(
-                                        "nas_id" => intval(str_replace("nas-", "", $nas_id)),
-                                        "username" => $username,
-                                        "count" => $count,
-                                        "requests" => $requests,
-                                        "retries" => $retries,
-                                        "timeout" => $timeout,
-                                        "debug" => ($debug == "yes"),
-                                        "command" => $packetType,
-                                        "customAttributes" => $customAttributes,
-                                        "simulate" => $simulate,
-                                    );
+                    // this will be passed to RadClient::disconnect()
+                    $params = array(
+                        "nas_id"           => intval(str_replace("nas-", "", $nas_id)),
+                        "username"         => $username,
+                        "count"            => $count,
+                        "requests"         => $requests,
+                        "retries"          => $retries,
+                        "timeout"          => $timeout,
+                        "debug"            => ($debug == "yes"),
+                        "command"          => $packetType,
+                        "customAttributes" => $customAttributes,
+                        "simulate"         => $simulate,
+                        "port"             => $port,   // CoA/PoD port, default 3799
+                    );
 
                     // disconnect user
-                    $result = user_disconnect($params);
+                    try {
+                        $result = (new RadClient($params))->disconnect($params);
+                    } catch (RuntimeException $e) {
+                        $result = array("error" => true, "output" => $e->getMessage());
+                    }
 
                     $username_enc = htmlspecialchars($username, ENT_QUOTES, 'UTF-8');
 
@@ -160,11 +166,10 @@
 
     print_title_and_help($title, $help);
 
-    include_once('include/management/actionMessages.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'actionMessages.php' ]);
 
     if ($radclient_path !== false) {
-
-        include("include/management/populate_selectbox.php");
+        include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'populate_selectbox.php' ]);
 
         $options = get_online_users();
         array_unshift($options, "");
@@ -214,6 +219,10 @@
         // descriptors 1
         $input_descriptors1 = array();
         $input_descriptors1[] = array( "name" => "debug", "caption" => t('all','Debug'), "type" => "select", "options" => array("yes", "no"), );
+        $input_descriptors1[] = array( "name" => "port", "caption" => "CoA/PoD Port", "type" => "number", "min" => "1",
+                                       "max" => "65535", "value" => ((isset($port)) ? $port : RadClient::DEFAULT_COA_PORT),
+                                       "tooltipText" => "UDP port the NAS listens on for CoA/PoD packets. Default 3799 (some legacy NAS use 1700). (Optional)"
+                                     );
         $input_descriptors1[] = array( "name" => "timeout", "caption" => t('all','Timeout'), "type" => "number", "value" => "3", "min" => "1", );
         $input_descriptors1[] = array( "name" => "retries", "caption" => t('all','Retries'), "type" => "number", "value" => "3", "min" => "0", );
         $input_descriptors1[] = array( "name" => "count", "caption" => t('all','Count'), "type" => "number", "value" => "1", "min" => "1", );
@@ -293,7 +302,5 @@
 
     }
 
-    include('include/config/logging.php');
-
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_CONFIG'], 'logging.php' ]);
     print_footer_and_html_epilogue();
-?>

--- a/app/operators/config-maint-test-user.php
+++ b/app/operators/config-maint-test-user.php
@@ -23,7 +23,7 @@
  *********************************************************************************************************
  */
 
-    
+
     include implode(DIRECTORY_SEPARATOR, [ __DIR__, 'library', 'checklogin.php' ]);
     $operator = $_SESSION['operator_user'];
     include implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', 'common', 'includes', 'config_read.php' ]);
@@ -52,7 +52,7 @@
         $configValues['CONFIG_MAINT_TEST_USER_RADIUSSECRET'] = "testing123";
     }
 
-    $radclient_path = is_radclient_present();
+    $radclient_path = RadClient::is_radclient_present();
 
     if ($radclient_path !== false) {
 
@@ -99,11 +99,11 @@
                     // required
                     $failureMsg = "This user does not exist";
                 } else {
-                    $selected_dictionary = (isset($_POST['selected_dictionary']) && !empty(trim($_POST['selected_dictionary'])) &&
-                                       in_array(trim($_POST['selected_dictionary']), $valid_dictionaryPaths))
-                                    ? trim($_POST['selected_dictionary']) : "";
+                    $selected_dictionary = (isset($_POST['dictionary']) && !empty(trim($_POST['dictionary'])) &&
+                                            in_array(trim($_POST['dictionary']), $valid_dictionaries, true))
+                                        ? trim($_POST['dictionary']) : "";
 
-                    $dictionaryPath = (!empty($selected_dictionary)) ? "$dictionaryDir/dictionary.$selected_dictionary" : "";
+                    $dictionaryPath = ($selected_dictionary !== "") ? "$dictionaryDir/dictionary.$selected_dictionary" : "";
 
                     $debug = (isset($_POST['debug']) && in_array($_POST['debug'], array("yes", "no"))) ? $_POST['debug'] : "no";
                     $timeout = (isset($_POST['timeout']) && intval($_POST['timeout']) > 0) ? intval($_POST['timeout']) : 3;
@@ -116,7 +116,7 @@
                     $password1 = (isset($_POST['password1']) && !empty(trim($_POST['password1']))) ? trim($_POST['password1']) : "";
                     $password2 = (isset($_POST['password2']) && !empty(trim($_POST['password2']))) ? trim($_POST['password2']) : "";
 
-                    // this will be passed to user_auth function
+                    // this will be passed to RadClient::check_connectivity()
                     $params =  array(
                                         "command" => "auth",
                                         "server" => $radius_addr,
@@ -159,7 +159,11 @@
                         include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'config_write.php' ]);
 
                         // test user
-                        $result = user_auth($params);
+                        try {
+                            $result = (new RadClient($params))->check_connectivity($params);
+                        } catch (RuntimeException $e) {
+                            $result = array("error" => true, "output" => $e->getMessage());
+                        }
 
                         $username_enc = htmlspecialchars($username, ENT_QUOTES, 'UTF-8');
 
@@ -212,61 +216,78 @@
 
         $input_descriptors0 = array();
         $input_descriptors0[] = array(
-                                        "name" => "username",
-                                        "caption" => t('all','Username'),
-                                        "type" => "text",
-                                        "value" => ((isset($username)) ? $username : ""),
-                                     );
-
+            "name" => "username",
+            "caption" => t('all','Username'),
+            "type" => "text",
+            "value" => ((isset($username)) ? $username : ""),
+            "tooltipText" => "Username to authenticate against the RADIUS server. (Required)"
+        );
         $input_descriptors0[] = array(
-                                        "name" => "password1",
-                                        "caption" => t('all','Password'),
-                                        "type" => "password",
-                                        "value" => ((isset($password)) ? $password : ""),
-                                     );
-
+            "name" => "password1",
+            "caption" => t('all','Password'),
+            "type" => "password",
+            "value" => ((isset($password)) ? $password : ""),
+            "tooltipText" => "Password for the user being tested. (Required)"
+        );
         $input_descriptors0[] = array(
-                                        "name" => "password2",
-                                        "caption" => t('all','Password') . " (confirmation)",
-                                        "type" => "password",
-                                        "value" => ((isset($password)) ? $password : ""),
-                                     );
-
+            "name" => "password2",
+            "caption" => t('all','Password') . " (confirmation)",
+            "type" => "password",
+            "value" => ((isset($password)) ? $password : ""),
+            "tooltipText" => "Re-enter the password to confirm it matches. (Required)"
+        );
         $input_descriptors0[] = array(
-                                        "name" => "radius_addr",
-                                        "caption" => t('all','RadiusServer'),
-                                        "type" => "text",
-                                        "value" => ((isset($radius_addr)) ? $radius_addr : $configValues['CONFIG_MAINT_TEST_USER_RADIUSSERVER']),
-                                     );
-
+            "name" => "radius_addr",
+            "caption" => t('all','RadiusServer'),
+            "type" => "text",
+            "value" => ((isset($radius_addr)) ? $radius_addr : $configValues['CONFIG_MAINT_TEST_USER_RADIUSSERVER']),
+            "tooltipText" => "IP address of the RADIUS server to query. Defaults to the saved value. (Optional)"
+        );
         $input_descriptors0[] = array(
-                                        "name" => "radius_port",
-                                        "caption" => t('all','RadiusPort'),
-                                        "type" => "number",
-                                        "min" => 1,
-                                        "max" => 65535,
-                                        "value" => ((isset($radius_port)) ? $radius_port : $configValues['CONFIG_MAINT_TEST_USER_RADIUSPORT']),
-                                     );
-
-        $input_descriptors0[] = array( "name" => "secret",
-                                       "caption" => t('all','NasSecret'),
-                                       "type" => "text",
-                                       "value" => ((isset($secret)) ? $secret : $configValues['CONFIG_MAINT_TEST_USER_RADIUSSECRET']),
-                                     );
-
+            "name" => "radius_port",
+            "caption" => t('all','RadiusPort'),
+            "type" => "number",
+            "min" => 1,
+            "max" => 65535,
+            "value" => ((isset($radius_port)) ? $radius_port : $configValues['CONFIG_MAINT_TEST_USER_RADIUSPORT']),
+            "tooltipText" => "UDP authentication port of the RADIUS server. Default 1812. (Optional)"
+        );
         $input_descriptors0[] = array(
-                                        "name" => "simulate",
-                                        "caption" => "Simulate (only show command, don't execute)",
-                                        "type" => "checkbox",
-                                        "checked" => (isset($simulate) ? $simulate : false),
-                                     );
+            "name" => "secret",
+            "caption" => t('all','NasSecret'),
+            "type" => "text",
+            "value" => ((isset($secret)) ? $secret : $configValues['CONFIG_MAINT_TEST_USER_RADIUSSECRET']),
+            "tooltipText" => "Shared secret between this client and the RADIUS server. (Optional)"
+        );
+        $input_descriptors0[] = array(
+            "name" => "simulate",
+            "caption" => "Simulate (only show command, don't execute)",
+            "type" => "checkbox",
+            "checked" => (isset($simulate) ? $simulate : false),
+            "tooltipText" => "Show the radclient command that would run, without executing it. (Optional)"
+        );
 
         $input_descriptors1 = array();
-        $input_descriptors1[] = array( "name" => "debug", "caption" => t('all','Debug'), "type" => "select", "options" => array("yes", "no"), );
-        $input_descriptors1[] = array( "name" => "timeout", "caption" => t('all','Timeout'), "type" => "number", "value" => "3", "min" => "1", );
-        $input_descriptors1[] = array( "name" => "retries", "caption" => t('all','Retries'), "type" => "number", "value" => "3", "min" => "0", );
-        $input_descriptors1[] = array( "name" => "count", "caption" => t('all','Count'), "type" => "number", "value" => "1", "min" => "1", );
-        $input_descriptors1[] = array( "name" => "requests", "caption" => t('all','Requests'), "type" => "number", "value" => "3", "min" => "1", );
+        $input_descriptors1[] = array(
+            "name" => "debug", "caption" => t('all','Debug'), "type" => "select", "options" => array("yes", "no"),
+            "tooltipText" => "Enable radclient verbose output (-x) for troubleshooting. (Optional)"
+        );
+        $input_descriptors1[] = array(
+            "name" => "timeout", "caption" => t('all','Timeout'), "type" => "number", "value" => "3", "min" => "1",
+            "tooltipText" => "Seconds to wait for a reply before retrying (-t). Default 3. (Optional)"
+        );
+        $input_descriptors1[] = array(
+            "name" => "retries", "caption" => t('all','Retries'), "type" => "number", "value" => "3", "min" => "0",
+            "tooltipText" => "Number of times to resend a packet on timeout (-r). (Optional)"
+        );
+        $input_descriptors1[] = array(
+            "name" => "count", "caption" => t('all','Count'), "type" => "number", "value" => "1", "min" => "1",
+            "tooltipText" => "Number of times to send each packet (-c). Default 1. (Optional)"
+        );
+        $input_descriptors1[] = array(
+            "name" => "requests", "caption" => t('all','Requests'), "type" => "number", "value" => "3", "min" => "1",
+            "tooltipText" => "Number of packets sent in parallel (-n). (Optional)"
+        );
 
         if (count($valid_dictionaries) > 0) {
 
@@ -274,10 +295,10 @@
             array_unshift($options, "");
 
             $input_descriptors1[] = array(
-                                            "name" => "dictionaryPath",
+                                            "name" => "dictionary",
                                             "caption" => t('all','RADIUSDictionaryPath'),
                                             "type" => "select",
-                                            "selected_value" => ((isset($dictionaryPath)) ? $dictionaryPath : ""),
+                                            "selected_value" => ((isset($selected_dictionary)) ? $selected_dictionary : ""),
                                             "options" => $options,
                                          );
         }

--- a/app/operators/config-maint-test-user.php
+++ b/app/operators/config-maint-test-user.php
@@ -317,7 +317,7 @@
                                      );
 
         // set navbar stuff
-        $navkeys = array( 'Settings', 'Advanced', );
+        $navkeys = array( t('title','Settings'), t('title','Advanced'), );
 
         // print navbar controls
         print_tab_header($navkeys);
@@ -333,7 +333,7 @@
 
         // open a fieldset
         $fieldset0_descriptor = array(
-                                        "title" => "Test User Connectivity",
+                                        "title" => t('button','TestUserConnectivity'),
                                      );
 
         open_fieldset($fieldset0_descriptor);

--- a/app/operators/library/extensions/maintenance_radclient.php
+++ b/app/operators/library/extensions/maintenance_radclient.php
@@ -37,328 +37,258 @@ if (strpos($_SERVER['PHP_SELF'], $extension_file) !== false) {
 $extension_file_enc = htmlspecialchars($extension_file, ENT_QUOTES, 'UTF-8');
 
 /**
- * Check if the radclient binary is present in the system.
+ * Thin wrapper around the `radclient` utility.
  *
- * This function executes the shell command to check the availability of the radclient binary.
- * If found, it returns the absolute path of the radclient binary; otherwise, it returns false.
+ * Shared "advanced" options (count, requests, retries, timeout, dictionary,
+ * simulate) are normalised once in the constructor; the two public methods only
+ * receive action-specific parameters:
  *
- * @return string|false The absolute path of the radclient binary if found, otherwise false.
+ *   - disconnect()         -> sends a CoA / Packet-of-Disconnect to a NAS
+ *   - check_connectivity() -> sends an auth / status request to a RADIUS server
+ *
+ * Both return: array("error" => bool, "output" => string)
+ *
+ * NOTE: the destination UDP port for CoA/PoD is a dedicated parameter
+ * (default 3799), NOT the `ports` column of the `nas` table, which is a purely
+ * informational field and must never be used as a network port.
  */
-function is_radclient_present() {
-    exec("(which radclient || command -v radclient) 2> /dev/null", $output, $result_code);
-    return ($result_code === 0) ? $output[0] : false;
-}
+class RadClient {
 
+    const DEFAULT_COA_PORT  = 3799;   // RFC 5176 (some legacy NAS use 1700)
+    const DEFAULT_AUTH_PORT = 1812;
 
-/**
- * Ensure that optional radclient parameters are correctly set up.
- *
- * This function checks if optional parameters for radclient are provided and sets default values if not.
- * It also converts the parameters to the appropriate data types.
- *
- * @param array $params An associative array containing radclient parameters.
- *                     Possible parameters include 'count', 'requests', 'retries', 'timeout', 'debug', and 'simulate'.
- * @return array An associative array containing radclient parameters with correct values and data types.
- */
-function radclient_common_options($params) {
-    // Set default values for optional parameters if not provided
-    $count = (array_key_exists('count', $params) && $params['count'] > 0) ? $params['count'] : 1;
-    $requests = (array_key_exists('requests', $params) && $params['requests'] > 0) ? $params['requests'] : 1;
-    $retries = (array_key_exists('retries', $params) && $params['retries'] > 0) ? $params['retries'] : 10;
-    $timeout = (array_key_exists('timeout', $params) && $params['timeout'] > 0) ? $params['timeout'] : 3;
-    $debug = (array_key_exists('debug', $params) && $params['debug'] == true) ? "-x" : "";
-    $simulate = (array_key_exists('simulate', $params) && $params['simulate'] == true);
+    private $path;
+    private $options;
+    private $simulate;
 
-    // Convert parameters to appropriate data types
-    $params["count"] = intval($count);
-    $params["requests"] = intval($requests);
-    $params["retries"] = intval($retries);
-    $params["timeout"] = intval($timeout);
-    $params["debug"] = boolval($debug);
-    $params["simulate"] = boolval($simulate);
-
-    return $params;
-}
-
-
-/**
- * Disconnects a user from the network.
- *
- * This function disconnects a user from the network by sending a COA (Change of Authorization)
- * or disconnect command to the RADIUS server using the radclient utility.
- * It requires certain parameters to be provided, including 'nas_id', 'command', and 'username'.
- * If any of the required parameters are missing or if the command is invalid, an error message is returned.
- * The function also retrieves necessary information from the database, such as NAS details.
- * Additionally, it prepares radclient arguments, custom attributes, and other radclient options
- * based on the provided parameters. It then executes the radclient command to disconnect the user.
- *
- * @param array $params An associative array containing the parameters required for disconnecting the user.
- *                      Required parameters: 'nas_id', 'command', 'username'.
- *                      Optional parameters: 'count', 'requests', 'retries', 'timeout', 'debug', 'customAttributes', 'dictionary', 'simulate'.
- * @return array An associative array containing the result of the operation.
- *               If successful, 'error' will be set to false and 'output' will contain the command executed and the result.
- *               If unsuccessful, 'error' will be set to true and 'output' will contain an error message.
- */
-function user_disconnect($params) {
-    global $configValues;
-
-    // Check if radclient binary is present
-    $radclient_path = is_radclient_present();
-
-    // Return error if radclient binary is not found
-    if ($radclient_path === false) {
-        return array(
-            "error" => true,
-            "output" => "radclient binary not found on the system",
-        );
-    }
-
-    // Required parameters for disconnecting the user
-    $required_params = array("nas_id", "command", "username");
-
-    // Check for missing required parameters
-    $missing_params = array();
-    foreach ($required_params as $required_param) {
-        if (!array_key_exists($required_param, $params)) {
-            $missing_params[] = $required_param;
+    /**
+     * @param array $params Shared options: count, requests, retries, timeout,
+     *                       dictionary, simulate.
+     * @throws RuntimeException if the radclient binary is not available.
+     */
+    public function __construct(array $params = array()) {
+        $this->path = self::is_radclient_present();
+        if ($this->path === false) {
+            throw new RuntimeException("radclient binary not found on the system");
         }
-    }
 
-    // Return error if any required parameter is missing
-    if (!empty($missing_params)) {
-        return array(
-            "error" => true,
-            "output" => "Missing required parameter(s): " . implode(', ', $missing_params),
+        // normalise the shared advanced options a single time
+        $params = $this->radclient_common_options($params);
+
+        $this->options = array(
+            'count'      => $params['count'],
+            'requests'   => $params['requests'],
+            'retries'    => $params['retries'],
+            'timeout'    => $params['timeout'],
+            'dictionary' => isset($params['dictionary']) ? trim($params['dictionary']) : '',
         );
+
+        $this->simulate = !empty($params['simulate']);
     }
 
-    // Valid commands for radclient
-    $valid_commands = array("coa", "disconnect");
+    /**
+     * Disconnect a user via CoA / Packet-of-Disconnect.
+     *
+     * Required: nas_id, command ("coa"|"disconnect"), username
+     * Optional: port (1-65535, default 3799), customAttributes
+     */
+    public function disconnect(array $params) {
+        $missing = $this->missing_params($params, array("nas_id", "command", "username"));
+        if (!empty($missing)) {
+            return $this->fail("Missing required parameter(s): " . implode(", ", $missing));
+        }
 
-    // Return error if command is invalid
-    if (!in_array($params['command'], $valid_commands)) {
-        return array(
-            "error" => true,
-            "output" => sprintf("'%s': invalid command", $params['command']),
-        );
+        if (!in_array($params['command'], array("coa", "disconnect"), true)) {
+            return $this->fail(sprintf("'%s': invalid command", $params['command']));
+        }
+
+        // dedicated CoA/PoD port, decoupled from the DB `ports` column
+        $port = $this->valid_port($params, self::DEFAULT_COA_PORT);
+
+        $nas = $this->get_nas($params['nas_id']);
+        if ($nas === null) {
+            return $this->fail("NAS not found");
+        }
+        list($addr, $secret) = $nas;
+
+        $query  = sprintf("User-Name=%s", escapeshellarg($params['username']));
+        $query .= $this->build_custom_attributes($params);
+
+        return $this->run(sprintf("%s:%d", $addr, $port), $params['command'], $secret, $query);
     }
 
-    // Get NAS details from the database
-    include implode(DIRECTORY_SEPARATOR, [$configValues['COMMON_INCLUDES'], 'db_open.php']);
+    /**
+     * Test connectivity / credentials via auth or status request.
+     *
+     * Required: command ("auth"|"status"), username, password, password_type,
+     *           server (IP), port, secret
+     */
+    public function check_connectivity(array $params) {
+        include_once implode(DIRECTORY_SEPARATOR, [$GLOBALS['configValues']['COMMON_INCLUDES'], 'validation.php']);
+        global $valid_passwordTypes;
 
-    $sql = sprintf("SELECT DISTINCT(`nasname`), `ports`, `secret`
-                      FROM `%s` WHERE `id`=?", $configValues['CONFIG_DB_TBL_RADNAS']);
-    $prepared = $dbSocket->prepare($sql);
-    $res = $dbSocket->execute($prepared, $params['nas_id']);
+        $required = array("command", "username", "password", "password_type", "server", "port", "secret");
+        $missing  = $this->missing_params($params, $required);
+        if (!empty($missing)) {
+            return $this->fail("Missing required parameter(s): " . implode(", ", $missing));
+        }
 
-    list($addr, $port, $secret) = $res->fetchrow();
+        if (!in_array($params['command'], array("auth", "status"), true)) {
+            return $this->fail(sprintf("'%s': invalid command", $params['command']));
+        }
 
-    include implode(DIRECTORY_SEPARATOR, [$configValues['COMMON_INCLUDES'], 'db_close.php']);
+        if (!in_array($params['password_type'], $valid_passwordTypes, true)) {
+            return $this->fail(sprintf("'%s': invalid password type", $params['password_type']));
+        }
 
-    // Set radclient options
-    $params = radclient_common_options($params);
+        if (filter_var(trim($params['server']), FILTER_VALIDATE_IP) === false) {
+            return $this->fail("Invalid RADIUS server IP address");
+        }
 
-    // Prepare radclient arguments
-    $count = $params['count'];
-    $requests = $params['requests'];
-    $retries = $params['retries'];
-    $timeout = $params['timeout'];
-    $debug = $params['debug'];
-    $command = in_array($params['command'], $valid_commands) ? $params['command'] : "auth";
+        $port   = $this->valid_port($params, self::DEFAULT_AUTH_PORT);
+        $secret = (trim($params['secret']) !== "") ? trim($params['secret']) : "testing123";
 
-    // Prepare radclient query
-    $server_port = sprintf("%s:%d", $addr, $port);
-    $positional_args = sprintf("%s %s %s", escapeshellarg($server_port), escapeshellarg($command), escapeshellarg($secret));
+        // password_type is whitelist-validated above, so it is safe unescaped
+        $query = sprintf("User-Name=%s,%s=%s",
+            escapeshellarg($params['username']), $params['password_type'], escapeshellarg($params['password']));
 
-    // Include custom attributes in the query
-    $query = sprintf("User-Name=%s", escapeshellarg($params['username']));
-    if (isset($params['customAttributes']) && !empty($params['customAttributes'])) {
-        $attr_values = explode(",", $params['customAttributes']);
-        foreach ($attr_values as $attr_value) {
-            list($attr, $value) = explode("=", $attr_value);
-            $attr = trim($attr);
+        $server = sprintf("%s:%d", trim($params['server']), $port);
+        return $this->run($server, $params['command'], $secret, $query);
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    /**
+     * Check if the radclient binary is present in the system.
+     *
+     * @return string|false The absolute path of the radclient binary if found, otherwise false.
+     */
+    public static function is_radclient_present() {
+        exec("(which radclient || command -v radclient) 2> /dev/null", $output, $result_code);
+        return ($result_code === 0) ? $output[0] : false;
+    }
+
+    /**
+     * Ensure that optional radclient parameters are correctly set up.
+     *
+     * @param array $params Shared radclient parameters.
+     * @return array Normalized parameters.
+     */
+    private function radclient_common_options($params) {
+        $count = (array_key_exists('count', $params) && $params['count'] > 0) ? $params['count'] : 1;
+        $requests = (array_key_exists('requests', $params) && $params['requests'] > 0) ? $params['requests'] : 1;
+        $retries = (array_key_exists('retries', $params) && $params['retries'] > 0) ? $params['retries'] : 10;
+        $timeout = (array_key_exists('timeout', $params) && $params['timeout'] > 0) ? $params['timeout'] : 3;
+        $debug = (array_key_exists('debug', $params) && $params['debug'] == true) ? "-x" : "";
+        $simulate = (array_key_exists('simulate', $params) && $params['simulate'] == true);
+
+        $params["count"] = intval($count);
+        $params["requests"] = intval($requests);
+        $params["retries"] = intval($retries);
+        $params["timeout"] = intval($timeout);
+        $params["debug"] = boolval($debug);
+        $params["simulate"] = boolval($simulate);
+
+        return $params;
+    }
+
+    /** Build and (optionally) execute the radclient command. */
+    private function run($server_port, $command, $secret, $query) {
+        $positional = sprintf("%s %s %s",
+            escapeshellarg($server_port), escapeshellarg($command), escapeshellarg($secret));
+
+        $cmd = sprintf('echo "%s" | %s %s %s 2>&1',
+            escapeshellcmd($query), $this->path, $this->build_options(), $positional);
+
+        if ($this->simulate) {
+            return array("error" => false, "output" => "$cmd (not executed)");
+        }
+
+        $result = shell_exec($cmd);
+        if (empty($result)) {
+            return array("error" => true, "output" => "Command did not return any output");
+        }
+
+        return array("error" => false, "output" => "$cmd\n$result");
+    }
+
+    /** Common radclient flags (-c -n -r -t -x [-d]). */
+    private function build_options() {
+        $opts = sprintf(" -c %s -n %s -r %s -t %s -x",
+            escapeshellarg($this->options['count']),
+            escapeshellarg($this->options['requests']),
+            escapeshellarg($this->options['retries']),
+            escapeshellarg($this->options['timeout']));
+
+        if ($this->options['dictionary'] !== '') {
+            $opts .= sprintf(" -d %s", escapeshellarg($this->options['dictionary']));
+        }
+
+        return $opts;
+    }
+
+    /** Fetch nasname + secret for a given NAS id (ports column intentionally ignored). */
+    private function get_nas($nas_id) {
+        global $configValues;
+
+        include implode(DIRECTORY_SEPARATOR, [$configValues['COMMON_INCLUDES'], 'db_open.php']);
+
+        $sql      = sprintf("SELECT DISTINCT(`nasname`), `secret` FROM `%s` WHERE `id`=?",
+                            $configValues['CONFIG_DB_TBL_RADNAS']);
+        $prepared = $dbSocket->prepare($sql);
+        $res      = $dbSocket->execute($prepared, $nas_id);
+        $row      = $res->fetchRow();
+
+        include implode(DIRECTORY_SEPARATOR, [$configValues['COMMON_INCLUDES'], 'db_close.php']);
+
+        return $row ? array($row[0], $row[1]) : null;
+    }
+
+    /** Parse, validate and shell-escape optional custom attributes. */
+    private function build_custom_attributes($params) {
+        global $configValues;
+
+        if (empty($params['customAttributes'])) {
+            return "";
+        }
+
+        include_once implode(DIRECTORY_SEPARATOR, [$configValues['COMMON_INCLUDES'], 'validation.php']);
+
+        $out = "";
+        foreach (explode(",", $params['customAttributes']) as $pair) {
+            if (strpos($pair, "=") === false) {
+                continue; // skip malformed entries instead of triggering a notice
+            }
+
+            list($attr, $value) = explode("=", $pair, 2);
+            $attr  = trim($attr);
             $value = trim($value);
 
-            include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'validation.php' ]);
-            if (!empty($attr) && !empty($value) && $attr !== 'User-Name' && preg_match(ALLOWED_ATTRIBUTE_CHARS_REGEX, $attr) === 1) {
-                $query .= sprintf(", %s=%s", $attr, escapeshellarg($value));
+            if ($attr !== "" && $value !== "" && $attr !== 'User-Name'
+                && preg_match(ALLOWED_ATTRIBUTE_CHARS_REGEX, $attr) === 1) {
+                $out .= sprintf(", %s=%s", $attr, escapeshellarg($value));
             }
         }
+
+        return $out;
     }
 
-    // Set radclient options
-    $radclient_options = sprintf(" -c %s -n %s -r %s -t %s -x", escapeshellarg($count), escapeshellarg($requests),
-        escapeshellarg($retries), escapeshellarg($timeout));
-
-    // Add dictionary option if provided
-    if (isset($params['dictionary']) && !empty(trim($params['dictionary']))) {
-        $radclient_options .= sprintf(" -d %s", escapeshellarg(trim($params['dictionary'])));
+    private function valid_port($params, $default) {
+        return (isset($params['port']) && intval($params['port']) >= 1 && intval($params['port']) <= 65535)
+             ? intval($params['port']) : $default;
     }
 
-    // Construct radclient command
-    $cmd = sprintf('echo "%s" | %s %s %s 2>&1', escapeshellcmd($query), $radclient_path, $radclient_options, $positional_args);
-
-    // Simulate mode
-    if ($params['simulate']) {
-        return array(
-            "error" => false,
-            "output" => "$cmd (not executed)",
-        );
-    }
-
-    // Execute radclient command
-    $result = shell_exec($cmd);
-
-    // Return error if command did not return any output
-    if (empty($result)) {
-        return array(
-            "error" => true,
-            "output" => "Command did not return any output",
-        );
-    }
-
-    return array(
-        "error" => false,
-        "output" => "$cmd\n$result"
-    );
-}
-
-
-/**
- * Authenticate a user against the RADIUS server.
- *
- * This function authenticates a user against the RADIUS server by sending an authentication
- * request using the radclient utility. It requires several parameters to be provided,
- * including 'command', 'username', 'password', 'password_type', 'server', 'port', and 'secret'.
- * If any of the required parameters are missing or if the command, password type, or server IP address is invalid,
- * an error message is returned. The function also validates other parameters such as port and secret.
- * Additionally, it prepares radclient arguments, custom attributes, and other radclient options
- * based on the provided parameters. It then executes the radclient command to authenticate the user.
- *
- * @param array $params An associative array containing the parameters required for authenticating the user.
- *                      Required parameters: 'command', 'username', 'password', 'password_type', 'server', 'port', 'secret'.
- *                      Optional parameters: 'count', 'requests', 'retries', 'timeout', 'debug', 'dictionary', 'simulate'.
- * @return array An associative array containing the result of the authentication operation.
- *               If successful, 'error' will be set to false and 'output' will contain the command executed and the result.
- *               If unsuccessful, 'error' will be set to true and 'output' will contain an error message.
- */
-function user_auth($params) {
-    global $configValues;
-
-    // Check if radclient binary is present
-    $radclient_path = is_radclient_present();
-
-    // Return error if radclient binary is not found
-    if ($radclient_path === false) {
-        return array(
-            "error" => true,
-            "output" => "radclient binary not found on the system",
-        );
-    }
-
-    // Include validation functions
-    include_once implode(DIRECTORY_SEPARATOR, [$configValues['COMMON_INCLUDES'], 'validation.php']);
-    global $valid_passwordTypes;
-
-    // Required parameters for user authentication
-    $required_params = array("command", "username", "password", "password_type", "server", "port", "secret");
-
-    // Check for missing required parameters
-    $missing_params = array();
-    foreach ($required_params as $required_param) {
-        if (!array_key_exists($required_param, $params)) {
-            $missing_params[] = $required_param;
+    private function missing_params($params, $required) {
+        $missing = array();
+        foreach ($required as $name) {
+            if (!array_key_exists($name, $params)) {
+                $missing[] = $name;
+            }
         }
+        return $missing;
     }
 
-    // Return error if any required parameter is missing
-    if (!empty($missing_params)) {
-        return array(
-            "error" => true,
-            "output" => "Missing required parameter(s): " . implode(", ", $missing_params),
-        );
+    private function fail($message) {
+        return array("error" => true, "output" => $message);
     }
-
-    // Valid commands for radclient
-    $valid_commands = array("auth", "status");
-
-    // Return error if command is invalid
-    if (!in_array($params['command'], $valid_commands)) {
-        return array(
-            "error" => true,
-            "output" => sprintf("'%s': invalid command", $params['command']),
-        );
-    }
-
-    // Return error if password type is invalid
-    if (!in_array($params['password_type'], $valid_passwordTypes)) {
-        return array(
-            "error" => true,
-            "output" => sprintf("'%s': invalid password type", $params['password_type']),
-        );
-    }
-
-    // Return error if server IP address is invalid
-    if (filter_var(trim($params['server']), FILTER_VALIDATE_IP) === false) {
-        return array(
-            "error" => true,
-            "output" => "Invalid RADIUS server IP address",
-        );
-    }
-
-    // Validate other parameters
-    $command = in_array($params['command'], $valid_commands) ? $params['command'] : "auth";
-    $port = ($params['port'] >= 1 && $params['port'] <= 65535) ? $params['port'] : 1812;
-    $secret = !empty(trim($params['secret'])) ? escapeshellarg(trim($params['secret'])) : "testing123";
-
-    // Set radclient options
-    $params = radclient_common_options($params);
-    $count = $params['count'];
-    $requests = $params['requests'];
-    $retries = $params['retries'];
-    $timeout = $params['timeout'];
-    $debug = $params['debug'];
-
-    // Prepare radclient arguments
-    $server_port = sprintf("%s:%d", $params['server'], $params['port']);
-    $positional_args = sprintf("%s %s %s", escapeshellarg($server_port), escapeshellarg($command), $secret);
-
-    // Prepare radclient query
-    $query = sprintf("User-Name=%s,%s=%s", escapeshellarg($params['username']), $params['password_type'], escapeshellarg($params['password']));
-
-    // Other radclient options
-    $radclient_options = sprintf(" -c %s -n %s -r %s -t %s -x", escapeshellarg($count), escapeshellarg($requests),
-        escapeshellarg($retries), escapeshellarg($timeout));
-
-    // Add dictionary option if provided
-    if (isset($params['dictionary']) && !empty(trim($params['dictionary']))) {
-        $radclient_options .= sprintf(" -d %s", escapeshellarg(trim($params['dictionary'])));
-    }
-
-    // Construct radclient command
-    $cmd = sprintf('echo "%s" | %s %s %s 2>&1', escapeshellcmd($query), $radclient_path, $radclient_options, $positional_args);
-
-    // Simulate mode
-    if ($params['simulate']) {
-        return array(
-            "error" => false,
-            "output" => "$cmd (not executed)",
-        );
-    }
-
-    // Execute radclient command
-    $result = shell_exec($cmd);
-
-    // Return error if command did not return any output
-    if (empty($result)) {
-        return array(
-            "error" => true,
-            "output" => "Command did not return any output",
-        );
-    }
-
-    return array(
-        "error" => false,
-        "output" => "$cmd\n$result"
-    );
 }

--- a/app/operators/mng-rad-nas-del.php
+++ b/app/operators/mng-rad-nas-del.php
@@ -21,40 +21,43 @@
  *********************************************************************************************************
  */
 
-    include("library/checklogin.php");
+    include_once implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', 'common', 'includes', 'config_read.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'checklogin.php' ]);
     $operator = $_SESSION['operator_user'];
 
-    include('library/check_operator_perm.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'check_operator_perm.php' ]);
 
     // init logging variables
     $logAction = "";
     $logDebugSQL = "";
     $log = "visited page: ";
 
-    include('../common/includes/db_open.php');
-    
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
+
     // init field_name and values (all, valid and to delete)
     $field_name = 'nashost';
     $db_field_name = 'nasname';
-    
+
     $valid_values = array();
-    
+
     $sql = sprintf("SELECT DISTINCT(%s) FROM %s", $db_field_name, $configValues['CONFIG_DB_TBL_RADNAS']);
     $res = $dbSocket->query($sql);
     $logDebugSQL .= "$sql;\n";
-    
-    while ($row = $res->fetchRow()) {
-        $valid_values[] = $row[0];
+
+    if (!DB::isError($res)) {
+        while ($row = $res->fetchRow()) {
+            $valid_values[] = $row[0];
+        }
     }
-    
+
     if (array_key_exists('csrf_token', $_POST) && isset($_POST['csrf_token']) && dalo_check_csrf_token($_POST['csrf_token'])) {
-    
+
         $values = array();
         $deleted_values = array();
-        
+
         // validate values
         if (array_key_exists($field_name, $_POST) && isset($_POST[$field_name])) {
-            
+
             $tmp = (!is_array($_POST[$field_name])) ? array($_POST[$field_name]) : $_POST[$field_name];
             foreach ($tmp as $value) {
                 if (in_array($value, $valid_values)) {
@@ -62,7 +65,7 @@
                 }
             }
         }
-        
+
         // use valid values for updating db,
         // update deleted_values as a valid value has been removed
         if (count($values) > 0) {
@@ -71,13 +74,13 @@
                                                                $db_field_name, $dbSocket->escapeSimple($value));
                 $result = $dbSocket->query($sql);
                 $logDebugSQL .= "$sql;\n";
-                
+
                 if ($result > 0) {
                     $deleted_values[] = $value;
                 }
             }
         }
-        
+
         $success = $_SERVER['REQUEST_METHOD'] == 'POST' && count($values) > 0 && count($deleted_values) > 0;
 
         // present results
@@ -86,9 +89,9 @@
             foreach ($deleted_values as $deleted_value) {
                 $tmp[] = htmlspecialchars($deleted_value, ENT_QUOTES, 'UTF-8');
             }
-            
-            $label = (count($tmp) > 1 || count($tmp) == 0) ? "NASs" : "NAS";
-            
+
+            $label = (count($tmp) > 1 || count($tmp) == 0) ? "NASes" : "NAS";
+
             $successMsg = sprintf("Deleted %s: <strong>%s</strong>.", $label, implode(", ", $tmp));
             $successMsg .= '<br><strong>Restart FreeRADIUS for NAS changes to take effect.</strong>';
             $logAction .= sprintf("Successfully deleted %s [%s] on page: ", $label, implode(", ", $deleted_values));
@@ -96,8 +99,8 @@
             $failureMsg = "Empty or invalid NAS hostname/IP(s).";
             $logAction .= sprintf("Failed deleting NAS(s) [%s] on page: ", implode(", ", $valid_values));
         }
-        
-        include('../common/includes/db_close.php');
+
+        include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
 
     } else {
         $success = false;
@@ -105,78 +108,71 @@
         $logAction .= "$failureMsg on page: ";
     }
 
-    include_once('../common/includes/config_read.php');
-    include_once("lang/main.php");
-    include("../common/includes/layout.php");
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LANG'], 'main.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'layout.php' ]);
 
     // print HTML prologue
-    
     $title = t('Intro','mngradnasdel.php');
     $help = t('helpPage','mngradnasdel');
-    
+
     print_html_prologue($title, $langCode);
-
-    
-    
-
     print_title_and_help($title, $help);
-    
+
     if ($_SERVER['REQUEST_METHOD'] != 'GET') {
-        include_once('include/management/actionMessages.php');
+        include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'actionMessages.php' ]);
     }
-    
+
     if (!$success) {
         $options = $valid_values;
-        
+
         $input_descriptors1 = array();
-        
+
         $input_descriptors1[0] = array(
                                         'name' => $field_name . "[]",
                                         'id' => $field_name,
                                         'type' => 'text',
                                         'caption' => t('all','NasIPHost'),
                                       );
-        
-        
+
+
         if (count($options) > 0) {
             $input_descriptors1[0]['datalist'] = $options;
         } else {
             $input_descriptors1[0]['disabled'] = true;
         }
-        
+
         $input_descriptors1[] = array(
                                         "type" => "submit",
                                         "name" => "submit",
                                         "value" => t('buttons','apply')
                                       );
-                                  
+
         $input_descriptors1[] = array(
                                         "name" => "csrf_token",
                                         "type" => "hidden",
                                         "value" => dalo_csrf_token(),
                                      );
-                                     
+
         $fieldset1_descriptor = array(
                                         "title" => t('title','NASInfo'),
                                         "disabled" => (count($options) == 0)
                                      );
 
         open_form();
-        
+
         open_fieldset($fieldset1_descriptor);
 
         foreach ($input_descriptors1 as $input_descriptor) {
             print_form_component($input_descriptor);
         }
-        
+
         close_fieldset();
-        
+
         close_form();
-    
+
     }
 
     print_back_to_previous_page();
 
-    include('include/config/logging.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_CONFIG'], 'logging.php' ]);
     print_footer_and_html_epilogue();
-?>

--- a/app/operators/mng-rad-nas-del.php
+++ b/app/operators/mng-rad-nas-del.php
@@ -34,44 +34,44 @@
 
     include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
 
-    // init field_name and values (all, valid and to delete)
-    $field_name = 'nashost';
-    $db_field_name = 'nasname';
-
+    // build a whitelist of existing NAS names; only these can be deleted
     $valid_values = array();
-
-    $sql = sprintf("SELECT DISTINCT(%s) FROM %s", $db_field_name, $configValues['CONFIG_DB_TBL_RADNAS']);
+    $sql = sprintf("SELECT DISTINCT(nasname) FROM %s", $configValues['CONFIG_DB_TBL_RADNAS']);
     $res = $dbSocket->query($sql);
     $logDebugSQL .= "$sql;\n";
-
     if (!DB::isError($res)) {
         while ($row = $res->fetchRow()) {
             $valid_values[] = $row[0];
         }
     }
 
-    if (array_key_exists('csrf_token', $_POST) && isset($_POST['csrf_token']) && dalo_check_csrf_token($_POST['csrf_token'])) {
+    $nasnames = array();
+    if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+        if (array_key_exists('nasname', $_POST) && isset($_POST['nasname'])) {
+            $nasnames = (!is_array($_POST['nasname'])) ? array($_POST['nasname']) : $_POST['nasname'];
+        }
+    } else {
+        if (array_key_exists('nasname', $_REQUEST) && isset($_REQUEST['nasname'])) {
+            $nasnames = (!is_array($_REQUEST['nasname'])) ? array($_REQUEST['nasname']) : $_REQUEST['nasname'];
+        }
+    }
 
-        $values = array();
+    $selected_values = array();
+    foreach ($nasnames as $value) {
+        $value = trim($value);
+        if (in_array($value, $valid_values)) {
+            $selected_values[] = $value;
+        }
+    }
+
+    if ($_SERVER['REQUEST_METHOD'] === 'POST' &&
+        array_key_exists('csrf_token', $_POST) && isset($_POST['csrf_token']) && dalo_check_csrf_token($_POST['csrf_token'])) {
         $deleted_values = array();
 
-        // validate values
-        if (array_key_exists($field_name, $_POST) && isset($_POST[$field_name])) {
-
-            $tmp = (!is_array($_POST[$field_name])) ? array($_POST[$field_name]) : $_POST[$field_name];
-            foreach ($tmp as $value) {
-                if (in_array($value, $valid_values)) {
-                    $values[] = $value;
-                }
-            }
-        }
-
-        // use valid values for updating db,
-        // update deleted_values as a valid value has been removed
-        if (count($values) > 0) {
-            foreach ($values as $value) {
-                $sql = sprintf("DELETE FROM %s WHERE %s='%s'", $configValues['CONFIG_DB_TBL_RADNAS'],
-                                                               $db_field_name, $dbSocket->escapeSimple($value));
+        if (count($selected_values) > 0) {
+            foreach ($selected_values as $value) {
+                $sql = sprintf("DELETE FROM %s WHERE nasname='%s'", $configValues['CONFIG_DB_TBL_RADNAS'],
+                                                                    $dbSocket->escapeSimple($value));
                 $result = $dbSocket->query($sql);
                 $logDebugSQL .= "$sql;\n";
 
@@ -81,7 +81,7 @@
             }
         }
 
-        $success = $_SERVER['REQUEST_METHOD'] == 'POST' && count($values) > 0 && count($deleted_values) > 0;
+        $success = $_SERVER['REQUEST_METHOD'] == 'POST' && count($selected_values) > 0 && count($deleted_values) > 0;
 
         // present results
         if ($success) {
@@ -89,24 +89,24 @@
             foreach ($deleted_values as $deleted_value) {
                 $tmp[] = htmlspecialchars($deleted_value, ENT_QUOTES, 'UTF-8');
             }
-
-            $label = (count($tmp) > 1 || count($tmp) == 0) ? "NASes" : "NAS";
-
-            $successMsg = sprintf("Deleted %s: <strong>%s</strong>.", $label, implode(", ", $tmp));
-            $successMsg .= '<br><strong>Restart FreeRADIUS for NAS changes to take effect.</strong>';
+            $label = (count($tmp) == 1) ? "NAS device" : "NAS devices";
+            $successMsg = sprintf("Successfully deleted %d %s: <strong>%s</strong>.", count($tmp), $label, implode(", ", $tmp));
+            $successMsg .= '<br><strong>Restart FreeRADIUS for the changes to take effect.</strong>';
             $logAction .= sprintf("Successfully deleted %s [%s] on page: ", $label, implode(", ", $deleted_values));
         } else {
-            $failureMsg = "Empty or invalid NAS hostname/IP(s).";
+            $failureMsg = "No valid NAS hostname/IP provided; nothing was deleted.";
             $logAction .= sprintf("Failed deleting NAS(s) [%s] on page: ", implode(", ", $valid_values));
         }
 
-        include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
-
     } else {
         $success = false;
-        $failureMsg = "CSRF token error";
-        $logAction .= "$failureMsg on page: ";
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $failureMsg = "CSRF token error";
+            $logAction .= "$failureMsg on page: ";
+        }
     }
+
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
 
     include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LANG'], 'main.php' ]);
     include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'layout.php' ]);
@@ -123,21 +123,24 @@
     }
 
     if (!$success) {
-        $options = $valid_values;
+        $options = array();
+        foreach ($valid_values as $valid_value) {
+            $options[$valid_value] = $valid_value;
+        }
 
         $input_descriptors1 = array();
 
         $input_descriptors1[0] = array(
-                                        'name' => $field_name . "[]",
-                                        'id' => $field_name,
-                                        'type' => 'text',
+                                        'name' => 'nasname[]',
+                                        'id' => 'nasname',
+                                        'type' => 'select',
                                         'caption' => t('all','NasIPHost'),
+                                        'options' => $options,
+                                        'multiple' => true,
+                                        'size' => 5,
+                                        'selected_value' => $selected_values,
                                       );
-
-
-        if (count($options) > 0) {
-            $input_descriptors1[0]['datalist'] = $options;
-        } else {
+        if (count($options) == 0) {
             $input_descriptors1[0]['disabled'] = true;
         }
 

--- a/app/operators/mng-rad-nas-edit.php
+++ b/app/operators/mng-rad-nas-edit.php
@@ -21,23 +21,22 @@
  *********************************************************************************************************
  */
 
-    include("library/checklogin.php");
+    include_once implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', 'common', 'includes', 'config_read.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'checklogin.php' ]);
     $operator = $_SESSION['operator_user'];
 
-    include('../common/includes/config_read.php');
-    include('library/check_operator_perm.php');
-
-    include_once("lang/main.php");
-    include("../common/includes/validation.php");
-    include("../common/includes/layout.php");
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'check_operator_perm.php' ]);
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LANG'], 'main.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'validation.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'layout.php' ]);
 
     // init logging variables
     $log = "visited page: ";
     $logAction = "";
     $logDebugSQL = "";
 
-    include('../common/includes/db_open.php');
-    
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
+
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $nasname = (array_key_exists('nasname', $_POST) && !empty(str_replace("%", "", trim($_POST['nasname']))))
                  ? str_replace("%", "", trim($_POST['nasname'])) : "";
@@ -45,30 +44,29 @@
         $nasname = (array_key_exists('nasname', $_REQUEST) && !empty(str_replace("%", "", trim($_REQUEST['nasname']))))
                  ? str_replace("%", "", trim($_REQUEST['nasname'])) : "";
     }
-    
+
     // check if this nas exists
     $sql = sprintf("SELECT COUNT(id) FROM %s WHERE nasname='%s'", $configValues['CONFIG_DB_TBL_RADNAS'],
                                                                   $dbSocket->escapeSimple($nasname));
     $res = $dbSocket->query($sql);
     $logDebugSQL .= "$sql;\n";
-    
+
     $exists = $res->fetchrow()[0] == 1;
-    
+
     if (!$exists) {
         // we reset the nasname if it does not exist
         $nasname = "";
     }
-    
-    
+
     // from now on, we can assume that nasname is valid
     $nasname_enc = (!empty($nasname)) ? htmlspecialchars($nasname, ENT_QUOTES, 'UTF-8') : "";
-    
-    
+
+
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if (array_key_exists('csrf_token', $_POST) && isset($_POST['csrf_token']) && dalo_check_csrf_token($_POST['csrf_token'])) {
             $secret = (array_key_exists('secret', $_POST) && !empty(str_replace("%", "", trim($_POST['secret']))))
                     ? str_replace("%", "", trim($_POST['secret'])) : "";
-    
+
             // allow the current DB type to pass validation even if it is a
             // legacy/custom value not present in $valid_nastypes, so that
             // re-submitting the edit form does not silently overwrite it
@@ -88,26 +86,26 @@
 
             $type = (array_key_exists('type', $_POST) && isset($_POST['type']) &&
                      in_array($_POST['type'], $allowed_types)) ? $_POST['type'] : "other";
-            
+
             $shortname = (array_key_exists('shortname', $_POST) && !empty(str_replace("%", "", trim($_POST['shortname']))))
                        ? str_replace("%", "", trim($_POST['shortname'])) : "";
             $ports = (array_key_exists('ports', $_POST) && !empty(trim($_POST['ports'])) &&
                       intval(trim($_POST['ports'])) >= 1 && intval(trim($_POST['ports'])) <= 65535)
                    ? intval(trim($_POST['ports'])) : "";
-            
+
             $description = (array_key_exists('description', $_POST) && !empty(str_replace("%", "", trim($_POST['description']))))
                          ? str_replace("%", "", trim($_POST['description'])) : "";
             $community = (array_key_exists('community', $_POST) && !empty(str_replace("%", "", trim($_POST['community']))))
                        ? str_replace("%", "", trim($_POST['community'])) : "";
             $server = (array_key_exists('server', $_POST) && !empty(str_replace("%", "", trim($_POST['server']))))
                            ? str_replace("%", "", trim($_POST['server'])) : "";
-    
+
             if (empty($nasname) || empty($secret)) {
                 // required
                 $failureMsg = sprintf("%s and/or %s are empty or invalid", t('all','NasIPHost'), t('all','NasSecret'));
                 $logAction .= sprintf("Failed editing NAS (%s) on page: ", $failureMsg);
             } else {
-                
+
                 $sql = sprintf("UPDATE %s SET shortname='%s', type='%s', ports=%d, secret='%s',
                                                   server='%s', community='%s', description='%s'
                                  WHERE nasname='%s'", $configValues['CONFIG_DB_TBL_RADNAS'],
@@ -128,62 +126,60 @@
                     $failureMsg = sprintf($f, $nasname_enc);
                     $logAction .= sprintf($f, $nasname);
                 }
-                
+
             }
-    
+
         } else {
             // csrf
             $failureMsg = "CSRF token error";
             $logAction .= "$failureMsg on page: ";
         }
     }
-    
-    
+
+
     if (!empty($nasname)) {
         $sql = sprintf("SELECT nasname, shortname, type, ports, secret, server, community, description
                           FROM %s WHERE nasname='%s' LIMIT 1", $configValues['CONFIG_DB_TBL_RADNAS'],
                                                                $dbSocket->escapeSimple($nasname));
         $res = $dbSocket->query($sql);
         $logDebugSQL .= "$sql;\n";
-        
+
         $row = $res->fetchrow();
-        
+
         list($nasname, $shortname, $type, $ports, $secret, $server, $community, $description) = $row;
-        
+
     } else {
         $failureMsg = sprintf("%s is invalid", t('all','NasIPHost'));
         $logAction .= sprintf("Requested editing invalid NAS (%s) on page: ", $failureMsg);
     }
-    
-    include('../common/includes/db_close.php');
-    
+
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
+
     // print HTML prologue
     $title = t('Intro','mngradnasedit.php');
     $help = t('helpPage','mngradnasedit');
-    
+
     print_html_prologue($title, $langCode);
 
     if (isset($nasname_enc)) {
         $title .= " :: $nasname_enc";
-    } 
+    }
 
     print_title_and_help($title, $help);
-    
-    
-    include_once('include/management/actionMessages.php');
-    
-    
+
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'actionMessages.php' ]);
+
     if (!empty($nasname)) {
-        
+
         // set form component descriptors
         $input_descriptors0 = array();
-                
+
         $input_descriptors0[] = array(
                                         "name" => "nasname",
                                         "type" => "hidden",
                                         "value" => ((isset($nasname)) ? $nasname : "")
                                      );
-                                     
+
         $input_descriptors0[] = array(
                                         "name" => "nasname_presentation",
                                         "caption" => t('all','NasIPHost'),
@@ -192,7 +188,7 @@
                                         "disabled" => true,
                                         "tooltipText" => "Enter the IP address or hostname of the NAS device."
                                      );
-                                     
+
         $input_descriptors0[] = array(
                                         "name" => "secret",
                                         "caption" => t('all','NasSecret'),
@@ -200,7 +196,7 @@
                                         "value" => ((isset($secret)) ? $secret : ""),
                                         "tooltipText" => "Enter the shared secret used for RADIUS communication."
                                      );
-                                     
+
         // preserve legacy/custom NAS type values loaded from DB
         $nastype_options = $valid_nastypes;
         $nastype_selected = (isset($type) && $type !== "") ? $type : "other";
@@ -226,7 +222,7 @@
                                         "selected_value" => $nastype_selected,
                                         "tooltipText" => $nastype_tooltip
                                      );
-                                     
+
         $input_descriptors0[] = array(
                                         "name" => "shortname",
                                         "caption" => t('all','NasShortname'),
@@ -235,9 +231,9 @@
                                         "tooltipText" => "A friendly short name to identify this NAS."
                                      );
 
-        
+
         $input_descriptors1 = array();
-        
+
         $input_descriptors1[] = array(
                                         "name" => "ports",
                                         "caption" => t('all','NasPorts'),
@@ -247,7 +243,7 @@
                                         "value" => ((isset($ports)) ? $ports : ""),
                                         "tooltipText" => "e.g. 1700, 3799, etc.",
                                      );
-                                     
+
         $input_descriptors1[] = array(
                                         "name" => "community",
                                         "caption" => t('all','NasCommunity'),
@@ -255,7 +251,7 @@
                                         "value" => ((isset($community)) ? $community : ""),
                                         "tooltipText" => "SNMP community string for querying the NAS (optional)."
                                      );
-                                     
+
         $input_descriptors1[] = array(
                                         "name" => "server",
                                         "caption" => t('all','NasVirtualServer'),
@@ -263,7 +259,7 @@
                                         "value" => ((isset($server)) ? $server : ""),
                                         "tooltipText" => "FreeRADIUS virtual server to process requests from this NAS (optional)."
                                      );
-                                     
+
         $input_descriptors1[] = array(
                                         "name" => "description",
                                         "caption" => t('all','NasDescription'),
@@ -289,7 +285,7 @@
         $fieldset0_descriptor = array(
                                         "title" => t('title','NASInfo'),
                                      );
-                                     
+
         $fieldset1_descriptor = array(
                                         "title" => t('title','NASAdvanced'),
                                      );
@@ -300,52 +296,50 @@
 
         // print navbar controls
         print_tab_header($navkeys);
-        
+
         open_form();
-        
+
         // open tab wrapper
         open_tab_wrapper();
-        
+
         // open 0-th tab (shown)
         open_tab($navkeys, 0, true);
-        
+
         // open 0-th fieldset
         open_fieldset($fieldset0_descriptor);
 
         foreach ($input_descriptors0 as $input_descriptor) {
             print_form_component($input_descriptor);
         }
-        
+
         close_fieldset();
-        
+
         close_tab($navkeys, 0);
-        
+
         // open 1-st tab
         open_tab($navkeys, 1);
-        
+
         // open 1-th fieldset
         open_fieldset($fieldset1_descriptor);
-        
+
         foreach ($input_descriptors1 as $input_descriptor) {
             print_form_component($input_descriptor);
         }
-        
+
         close_fieldset();
-        
+
         close_tab($navkeys, 1);
-        
+
         // close tab wrapper
         close_tab_wrapper();
-        
+
         foreach ($input_descriptors2 as $input_descriptor) {
             print_form_component($input_descriptor);
         }
-        
+
         close_form();
-        
+
     }
 
-    include('include/config/logging.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_CONFIG'], 'logging.php' ]);
     print_footer_and_html_epilogue();
-    
-?>

--- a/app/operators/mng-rad-nas-edit.php
+++ b/app/operators/mng-rad-nas-edit.php
@@ -89,14 +89,17 @@
 
             $shortname = (array_key_exists('shortname', $_POST) && !empty(str_replace("%", "", trim($_POST['shortname']))))
                        ? str_replace("%", "", trim($_POST['shortname'])) : "";
+
             $ports = (array_key_exists('ports', $_POST) && !empty(trim($_POST['ports'])) &&
-                      intval(trim($_POST['ports'])) >= 1 && intval(trim($_POST['ports'])) <= 65535)
-                   ? intval(trim($_POST['ports'])) : "";
+                         intval(trim($_POST['ports'])) >= 0 && intval(trim($_POST['ports'])) <= 99999)
+                      ? intval(trim($_POST['ports'])) : 0;
 
             $description = (array_key_exists('description', $_POST) && !empty(str_replace("%", "", trim($_POST['description']))))
                          ? str_replace("%", "", trim($_POST['description'])) : "";
+
             $community = (array_key_exists('community', $_POST) && !empty(str_replace("%", "", trim($_POST['community']))))
                        ? str_replace("%", "", trim($_POST['community'])) : "";
+
             $server = (array_key_exists('server', $_POST) && !empty(str_replace("%", "", trim($_POST['server']))))
                            ? str_replace("%", "", trim($_POST['server'])) : "";
 
@@ -186,7 +189,7 @@
                                         "type" => "text",
                                         "value" => ((isset($nasname)) ? $nasname : ""),
                                         "disabled" => true,
-                                        "tooltipText" => "Enter the IP address or hostname of the NAS device."
+                                        "tooltipText" => "IP address or hostname of the NAS device. (Required)"
                                      );
 
         $input_descriptors0[] = array(
@@ -194,7 +197,7 @@
                                         "caption" => t('all','NasSecret'),
                                         "type" => "text",
                                         "value" => ((isset($secret)) ? $secret : ""),
-                                        "tooltipText" => "Enter the shared secret used for RADIUS communication."
+                                        "tooltipText" => "Shared secret used to authenticate RADIUS traffic with the NAS. (Required)"
                                      );
 
         // preserve legacy/custom NAS type values loaded from DB
@@ -228,9 +231,8 @@
                                         "caption" => t('all','NasShortname'),
                                         "type" => "text",
                                         "value" => ((isset($shortname)) ? $shortname : ""),
-                                        "tooltipText" => "A friendly short name to identify this NAS."
+                                        "tooltipText" => "Friendly short name to identify this NAS. (Optional)"
                                      );
-
 
         $input_descriptors1 = array();
 
@@ -238,10 +240,10 @@
                                         "name" => "ports",
                                         "caption" => t('all','NasPorts'),
                                         "type" => "number",
-                                        "min" => "1",
-                                        "max" => "65535",
+                                        "min" => "0",
+                                        "max" => "99999",
                                         "value" => ((isset($ports)) ? $ports : ""),
-                                        "tooltipText" => "e.g. 1700, 3799, etc.",
+                                        "tooltipText" => "Number of ports on the NAS; informational only, not used by the server. (Optional)"
                                      );
 
         $input_descriptors1[] = array(
@@ -249,7 +251,7 @@
                                         "caption" => t('all','NasCommunity'),
                                         "type" => "text",
                                         "value" => ((isset($community)) ? $community : ""),
-                                        "tooltipText" => "SNMP community string for querying the NAS (optional)."
+                                        "tooltipText" => "SNMP community string for querying the NAS. (Optional)"
                                      );
 
         $input_descriptors1[] = array(
@@ -257,7 +259,7 @@
                                         "caption" => t('all','NasVirtualServer'),
                                         "type" => "text",
                                         "value" => ((isset($server)) ? $server : ""),
-                                        "tooltipText" => "FreeRADIUS virtual server to process requests from this NAS (optional)."
+                                        "tooltipText" => "FreeRADIUS virtual server that processes requests from this NAS. (Optional)"
                                      );
 
         $input_descriptors1[] = array(
@@ -265,7 +267,7 @@
                                         "caption" => t('all','NasDescription'),
                                         "type" => "textarea",
                                         "content" => ((isset($description)) ? $description : ""),
-                                        "tooltipText" => "Additional details or notes about this NAS device."
+                                        "tooltipText" => "Notes or additional details about this NAS. (Optional)"
                                      );
 
         $input_descriptors2 = array();

--- a/app/operators/mng-rad-nas-list.php
+++ b/app/operators/mng-rad-nas-list.php
@@ -34,6 +34,9 @@
     $logQuery = "performed query on page: ";
     $logDebugSQL = "";
 
+    // init other useful variables
+    $hide_secrets = (strtolower($configValues['CONFIG_IFACE_PASSWORD_HIDDEN']) == "yes");
+
     // set session's page variable
     $_SESSION['PREV_LIST_PAGE'] = $_SERVER['REQUEST_URI'];
 
@@ -56,6 +59,7 @@
                     'community' => t('all','NasCommunity'),
                     'description' => t('all','NasDescription'),
                  );
+
     $colspan = count($cols);
     $half_colspan = intval($colspan / 2);
 
@@ -159,6 +163,11 @@
             }
 
             list($id, $nasname, $shortname, $type, $ports, $secret, $server, $community, $description) = $row;
+
+            if ($hide_secrets) {
+                $secret = "[secret is hidden]";
+            }
+
             $nasname_enc = urlencode($nasname);
 
             $tooltip = array(

--- a/app/operators/mng-rad-nas-list.php
+++ b/app/operators/mng-rad-nas-list.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /*
  *********************************************************************************************************
  * daloRADIUS - RADIUS Web Platform
@@ -21,13 +21,13 @@
  *********************************************************************************************************
  */
 
-    include("library/checklogin.php");
+    include_once implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', 'common', 'includes', 'config_read.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'checklogin.php' ]);
     $operator = $_SESSION['operator_user'];
 
-    include('library/check_operator_perm.php');
-    include_once('../common/includes/config_read.php');
-    include_once("lang/main.php");
-    include("../common/includes/layout.php");
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'check_operator_perm.php' ]);
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LANG'], 'main.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'layout.php' ]);
 
     // init logging variables
     $log = "visited page: ";
@@ -37,6 +37,14 @@
     // set session's page variable
     $_SESSION['PREV_LIST_PAGE'] = $_SERVER['REQUEST_URI'];
 
+    // the array $cols has multiple purposes:
+    // - its keys (when non-numerical) can be used
+    //   - for validating user input
+    //   - for table ordering purpose
+    // - its value can be used for table headings presentation
+    //
+    // the variables cols, colspan, and half_colspan
+    // can be used for validation and presentation purpose
     $cols = array(
                     'id' => t('all','NasID'),
                     'nasname' => t('all','NasIPHost'),
@@ -50,10 +58,10 @@
                  );
     $colspan = count($cols);
     $half_colspan = intval($colspan / 2);
-                 
+
     $param_cols = array();
     foreach ($cols as $k => $v) { if (!is_int($k)) { $param_cols[$k] = $v; } }
-    
+
     // whenever possible we use a whitelist approach
     $orderBy = (array_key_exists('orderBy', $_GET) && isset($_GET['orderBy']) &&
                 in_array($_GET['orderBy'], array_keys($param_cols)))
@@ -67,46 +75,47 @@
     // print HTML prologue
     $title = t('Intro','mngradnaslist.php');
     $help = t('helpPage','mngradnaslist');
-    
+
     print_html_prologue($title, $langCode);
-    
+
     // start printing content
     print_title_and_help($title, $help);
 
-    include('../common/includes/db_open.php');
-    include('include/management/pages_common.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'pages_common.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
 
-    // we use this simplified query just to initialize $numrows
+    // compute total number of rows matching the query for pagination
     $sql = sprintf("SELECT COUNT(id) FROM %s", $configValues['CONFIG_DB_TBL_RADNAS']);
     $res = $dbSocket->query($sql);
-    $numrows = $res->fetchrow()[0];
+    $numrows = (!DB::isError($res)) ? $res->fetchrow()[0] : 0;
 
     if ($numrows > 0) {
         /* START - Related to pages_numbering.php */
-        
+
         // when $numrows is set, $maxPage is calculated inside this include file
-        include('include/management/pages_numbering.php');    // must be included after opendb because it needs to read
-                                                              // the CONFIG_IFACE_TABLES_LISTING variable from the config file
-        
+        // must be included after opendb because it needs to read
+        // the CONFIG_IFACE_TABLES_LISTING variable from the config file
+        include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'pages_numbering.php' ]);
+
         // here we decide if page numbers should be shown
         $drawNumberLinks = strtolower($configValues['CONFIG_IFACE_TABLES_LISTING_NUM']) == "yes" && $maxPage > 1;
-        
+
         /* END */
-                     
+
         // we execute and log the actual query
         $sql = sprintf("SELECT id, nasname, shortname, type, ports, secret, server, community, description
                           FROM %s ORDER BY %s %s LIMIT %s, %s", $configValues['CONFIG_DB_TBL_RADNAS'],
                                                                 $orderBy, $orderType, $offset, $rowsPerPage);
         $res = $dbSocket->query($sql);
         $logDebugSQL = "$sql;\n";
-        
+
         $per_page_numrows = $res->numRows();
-        
-        // this can be passed as form attribute and 
+
+        // this can be passed as form attribute and
         // printTableFormControls function parameter
         $action = "mng-rad-nas-del.php";
         $form_name = "form_" . rand();
-        
+
         // we prepare the "controls bar" (aka the table prologue bar)
         $additional_controls = array();
         $additional_controls[] = array(
@@ -122,14 +131,14 @@
                             'order_by' => $orderBy,
                             'order_type' => $orderType,
                         );
-        
+
         $descriptors = array();
         $descriptors['start'] = array( 'common_controls' => 'nashost[]', 'additional_controls' => $additional_controls );
         $descriptors['center'] = array( 'draw' => $drawNumberLinks, 'params' => $params );
         print_table_prologue($descriptors);
-        
+
         $form_descriptor = array( 'form' => array( 'action' => $action, 'method' => 'POST', 'name' => $form_name ), );
-        
+
         // print table top
         print_table_top($form_descriptor);
 
@@ -138,29 +147,30 @@
 
         // closes table header, opens table body
         print_table_middle();
-   
+
         // table content
         $count = 0;
         while ($row = $res->fetchRow()) {
             $rowlen = count($row);
-        
+
             // escape row elements
             for ($i = 0; $i < $rowlen; $i++) {
                 $row[$i] = htmlspecialchars($row[$i], ENT_QUOTES, 'UTF-8');
             }
-            
+
             list($id, $nasname, $shortname, $type, $ports, $secret, $server, $community, $description) = $row;
-            
+            $nasname_enc = urlencode($nasname);
+
             $tooltip = array(
                                 'subject' => $nasname,
                                 'actions' => array(),
                             );
-            $tooltip['actions'][] = array( 'href' => sprintf('mng-rad-nas-edit.php?nasname=%s', urlencode($nasname), ), 'label' => t('button','EditNAS'), );
-            $tooltip['actions'][] = array( 'href' => sprintf('mng-rad-nas-del.php?nashost=%s', urlencode($nasname), ), 'label' => t('button','RemoveNAS'), );
-            
+            $tooltip['actions'][] = array( 'href' => sprintf('mng-rad-nas-edit.php?nasname=%s', $nasname_enc, ), 'label' => t('button','EditNAS'), );
+            $tooltip['actions'][] = array( 'href' => sprintf('mng-rad-nas-del.php?nashost=%s', $nasname_enc, ), 'label' => t('button','RemoveNAS'), );
+
             // create tooltip
             $tooltip = get_tooltip_list_str($tooltip);
-            
+
             // create checkbox
             $d = array( 'name' => 'nashost[]', 'value' => $nasname, 'label' => $id );
             $checkbox = get_checkbox_str($d);
@@ -193,12 +203,9 @@
 
     } else {
         $failureMsg = "Nothing to display";
-        include_once("include/management/actionMessages.php");
+        include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'actionMessages.php' ]);
     }
-    
-    include('../common/includes/db_close.php');
 
-    include('include/config/logging.php');
-    
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_CONFIG'], 'logging.php' ]);
     print_footer_and_html_epilogue();
-?>

--- a/app/operators/mng-rad-nas-list.php
+++ b/app/operators/mng-rad-nas-list.php
@@ -137,11 +137,11 @@
                         );
 
         $descriptors = array();
-        $descriptors['start'] = array( 'common_controls' => 'nashost[]', 'additional_controls' => $additional_controls );
+        $descriptors['start'] = array( 'common_controls' => 'nasname[]', 'additional_controls' => $additional_controls );
         $descriptors['center'] = array( 'draw' => $drawNumberLinks, 'params' => $params );
         print_table_prologue($descriptors);
 
-        $form_descriptor = array( 'form' => array( 'action' => $action, 'method' => 'POST', 'name' => $form_name ), );
+        $form_descriptor = array( 'form' => array( 'action' => $action, 'method' => 'GET', 'name' => $form_name ), );
 
         // print table top
         print_table_top($form_descriptor);
@@ -175,13 +175,13 @@
                                 'actions' => array(),
                             );
             $tooltip['actions'][] = array( 'href' => sprintf('mng-rad-nas-edit.php?nasname=%s', $nasname_enc, ), 'label' => t('button','EditNAS'), );
-            $tooltip['actions'][] = array( 'href' => sprintf('mng-rad-nas-del.php?nashost=%s', $nasname_enc, ), 'label' => t('button','RemoveNAS'), );
+            $tooltip['actions'][] = array( 'href' => sprintf('mng-rad-nas-del.php?nasname[]=%s', $nasname_enc, ), 'label' => t('button','RemoveNAS'), );
 
             // create tooltip
             $tooltip = get_tooltip_list_str($tooltip);
 
             // create checkbox
-            $d = array( 'name' => 'nashost[]', 'value' => $nasname, 'label' => $id );
+            $d = array( 'name' => 'nasname[]', 'value' => $nasname, 'label' => $id );
             $checkbox = get_checkbox_str($d);
 
             // build table row

--- a/app/operators/mng-rad-nas-new.php
+++ b/app/operators/mng-rad-nas-new.php
@@ -21,75 +21,76 @@
  *********************************************************************************************************
  */
 
-    include("library/checklogin.php");
+    include_once implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', 'common', 'includes', 'config_read.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'checklogin.php' ]);
     $operator = $_SESSION['operator_user'];
 
-    include('../common/includes/config_read.php');
-    include('library/check_operator_perm.php');
-    
-    include_once("lang/main.php");
-    include("../common/includes/validation.php");
-    include("../common/includes/layout.php");
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'check_operator_perm.php' ]);
+
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LANG'], 'main.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'validation.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'layout.php' ]);
 
     // init logging variables
     $log = "visited page: ";
     $logAction = "";
     $logDebugSQL = "";
-    
+
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if (array_key_exists('csrf_token', $_POST) && isset($_POST['csrf_token']) && dalo_check_csrf_token($_POST['csrf_token'])) {
-        
+
             $nasname = (array_key_exists('nasname', $_POST) && !empty(str_replace("%", "", trim($_POST['nasname']))))
                      ? str_replace("%", "", trim($_POST['nasname'])) : "";
-            $nassecret = (array_key_exists('nassecret', $_POST) && !empty(str_replace("%", "", trim($_POST['nassecret']))))
-                       ? str_replace("%", "", trim($_POST['nassecret'])) : "";
-            
+            $secret = (array_key_exists('secret', $_POST) && !empty(str_replace("%", "", trim($_POST['secret']))))
+                       ? str_replace("%", "", trim($_POST['secret'])) : "";
+
             $nasname_enc = (!empty($nasname)) ? htmlspecialchars($nasname, ENT_QUOTES, 'UTF-8') : "";
-            
+
             $nastype = (array_key_exists('nastype', $_POST) && isset($_POST['nastype']) &&
                         in_array($_POST['nastype'], $valid_nastypes)) ? $_POST['nastype'] : "other";
-            
+
             $shortname = (array_key_exists('shortname', $_POST) && !empty(str_replace("%", "", trim($_POST['shortname']))))
                        ? str_replace("%", "", trim($_POST['shortname'])) : "";
-            $nasports = (array_key_exists('nasports', $_POST) && !empty(trim($_POST['nasports'])) &&
-                         intval(trim($_POST['nasports'])) >= 1 && intval(trim($_POST['nasports'])) <= 65535)
-                      ? intval(trim($_POST['nasports'])) : "";
-            
-            $nasdescription = (array_key_exists('nasdescription', $_POST) && !empty(str_replace("%", "", trim($_POST['nasdescription']))))
-                            ? str_replace("%", "", trim($_POST['nasdescription'])) : "";
-            $nascommunity = (array_key_exists('nascommunity', $_POST) && !empty(str_replace("%", "", trim($_POST['nascommunity']))))
-                          ? str_replace("%", "", trim($_POST['nascommunity'])) : "";
-            $nasvirtualserver = (array_key_exists('nasvirtualserver', $_POST) && !empty(str_replace("%", "", trim($_POST['nasvirtualserver']))))
-                              ? str_replace("%", "", trim($_POST['nasvirtualserver'])) : "";
-            
-            if (empty($nasname) || empty($nassecret)) {
+
+            $ports = (array_key_exists('ports', $_POST) && !empty(trim($_POST['ports'])) &&
+                         intval(trim($_POST['ports'])) >= 0 && intval(trim($_POST['ports'])) <= 99999)
+                      ? intval(trim($_POST['ports'])) : 0;
+
+            $description = (array_key_exists('description', $_POST) && !empty(str_replace("%", "", trim($_POST['description']))))
+                            ? str_replace("%", "", trim($_POST['description'])) : "";
+            $community = (array_key_exists('community', $_POST) && !empty(str_replace("%", "", trim($_POST['community']))))
+                          ? str_replace("%", "", trim($_POST['community'])) : "";
+            $server = (array_key_exists('server', $_POST) && !empty(str_replace("%", "", trim($_POST['server']))))
+                              ? str_replace("%", "", trim($_POST['server'])) : "";
+
+            if (empty($nasname) || empty($secret)) {
                 // required
                 $failureMsg = sprintf("%s and/or %s are empty or invalid", t('all','NasIPHost'), t('all','NasSecret'));
                 $logAction .= "Failed adding (possible empty user/pass) new operator on page: ";
             } else {
-                include('../common/includes/db_open.php');
-                
+                include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
+
                 $sql = sprintf("SELECT COUNT(id) FROM %s WHERE nasname='%s'", $configValues['CONFIG_DB_TBL_RADNAS'],
                                                                               $dbSocket->escapeSimple($nasname));
                 $res = $dbSocket->query($sql);
                 $logDebugSQL .= "$sql;\n";
-                
+
                 $exists = $res->fetchrow()[0] > 0;
-                
+
                 if ($exists) {
                     // name already taken
                     $failureMsg = sprintf("This %s already exists: <b>%s</b>", t('all','NasIPHost'), $nasname_enc);
                     $logAction .= "Failed adding a new NAS [$nasname already exists] on page: ";
                 } else {
-                    
-                    $sql = sprintf("INSERT INTO %s (id, nasname, shortname, type, ports, secret, server, community, description)
-                                            VALUES (0, '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s')", $configValues['CONFIG_DB_TBL_RADNAS'],
+
+                    $sql = sprintf("INSERT INTO %s (nasname, shortname, type, ports, secret, server, community, description)
+                                            VALUES ('%s', '%s', '%s', %d, '%s', '%s', '%s', '%s')", $configValues['CONFIG_DB_TBL_RADNAS'],
                                    $dbSocket->escapeSimple($nasname), $dbSocket->escapeSimple($shortname), $dbSocket->escapeSimple($nastype),
-                                   $dbSocket->escapeSimple($nasports), $dbSocket->escapeSimple($nassecret), $dbSocket->escapeSimple($nasvirtualserver),
-                                   $dbSocket->escapeSimple($nascommunity), $dbSocket->escapeSimple($nasdescription));
+                                   $dbSocket->escapeSimple($ports), $dbSocket->escapeSimple($secret), $dbSocket->escapeSimple($server),
+                                   $dbSocket->escapeSimple($community), $dbSocket->escapeSimple($description));
                     $res = $dbSocket->query($sql);
                     $logDebugSQL .= "$sql;\n";
-                    
+
                     if (!DB::isError($res)) {
                         $successMsg = sprintf('Successfully added a new NAS (<strong>%s</strong>) '
                                             . '<a href="mng-rad-nas-edit.php?nasname=%s" title="Edit">Edit</a>',
@@ -103,8 +104,8 @@
                         $logAction .= sprintf($f, $nasname);
                     }
                 }
-                
-                include('../common/includes/db_close.php');
+
+                include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
             }
         } else {
             // csrf
@@ -117,43 +118,43 @@
     // print HTML prologue
     $title = t('Intro','mngradnasnew.php');
     $help = t('helpPage','mngradnasnew');
-    
+
     print_html_prologue($title, $langCode);
 
     print_title_and_help($title, $help);
-    
-    include_once('include/management/actionMessages.php');
+
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'actionMessages.php' ]);
 
     if (!isset($successMsg)) {
 
         // set form component descriptors
         $input_descriptors0 = array();
-        
+
         $input_descriptors0[] = array(
                                         "name" => "nasname",
                                         "caption" => t('all','NasIPHost'),
                                         "type" => "text",
                                         "value" => ((isset($nasname)) ? $nasname : ""),
-                                        "tooltipText" => "Enter the IP address or hostname of the NAS device."
+                                        "tooltipText" => "IP address or hostname of the NAS device. (Required)"
                                      );
-                                     
+
         $input_descriptors0[] = array(
-                                        "name" => "nassecret",
+                                        "name" => "secret",
                                         "caption" => t('all','NasSecret'),
                                         "type" => "text",
-                                        "value" => ((isset($nassecret)) ? $nassecret : ""),
-                                        "tooltipText" => "Enter the shared secret used for RADIUS communication."
+                                        "value" => ((isset($secret)) ? $secret : ""),
+                                        "tooltipText" => "Shared secret used to authenticate RADIUS traffic with the NAS. (Required)"
                                      );
-                                     
+
         $input_descriptors0[] = array(
                                         "name" => "nastype",
                                         "caption" => t('all','NasType'),
                                         "type" => "select",
                                         "options" => $valid_nastypes,
                                         "selected_value" => ((isset($nastype)) ? $nastype : "other"),
-                                        "tooltipText" => "Select the NAS vendor type from the predefined list."
+                                        "tooltipText" => "NAS vendor type; used by checkrad for simultaneous-use checks. (Optional)"
                                      );
-                                     
+
         $input_descriptors0[] = array(
                                         "name" => "shortname",
                                         "caption" => t('all','NasShortname'),
@@ -162,41 +163,41 @@
                                         "tooltipText" => "A friendly short name to identify this NAS."
                                      );
 
-        
+
         $input_descriptors1 = array();
-        
+
         $input_descriptors1[] = array(
-                                        "name" => "nasports",
+                                        "name" => "ports",
                                         "caption" => t('all','NasPorts'),
                                         "type" => "number",
-                                        "min" => "1",
-                                        "max" => "65535",
-                                        "value" => ((isset($nasports)) ? $nasports : ""),
-                                        "tooltipText" => "e.g. 1700, 3799, etc.",
+                                        "min" => "0",
+                                        "max" => "99999",
+                                        "value" => ((isset($ports)) ? $ports : ""),
+                                        "tooltipText" => "Number of ports on the NAS; informational only, not used by the server. (Optional)"
                                      );
-                                     
+
         $input_descriptors1[] = array(
-                                        "name" => "nascommunity",
+                                        "name" => "community",
                                         "caption" => t('all','NasCommunity'),
                                         "type" => "text",
-                                        "value" => ((isset($nascommunity)) ? $nascommunity : ""),
-                                        "tooltipText" => "SNMP community string for querying the NAS (optional)."
+                                        "value" => ((isset($community)) ? $community : ""),
+                                        "tooltipText" => "SNMP community string for querying the NAS. (Optional)"
                                      );
-                                     
+
         $input_descriptors1[] = array(
-                                        "name" => "nasvirtualserver",
+                                        "name" => "server",
                                         "caption" => t('all','NasVirtualServer'),
                                         "type" => "text",
-                                        "value" => ((isset($nasvirtualserver)) ? $nasvirtualserver : ""),
-                                        "tooltipText" => "FreeRADIUS virtual server to process requests from this NAS (optional)."
+                                        "value" => ((isset($server)) ? $server : ""),
+                                        "tooltipText" => "FreeRADIUS virtual server that processes requests from this NAS. (Optional)"
                                      );
-                                     
+
         $input_descriptors1[] = array(
-                                        "name" => "nasdescription",
+                                        "name" => "description",
                                         "caption" => t('all','NasDescription'),
                                         "type" => "textarea",
-                                        "content" => ((isset($nasdescription)) ? $nasdescription : ""),
-                                        "tooltipText" => "Additional details or notes about this NAS device."
+                                        "content" => ((isset($description)) ? $description : ""),
+                                        "tooltipText" => "Notes or additional details about this NAS. (Optional)"
                                      );
 
         $input_descriptors2 = array();
@@ -216,7 +217,7 @@
         $fieldset0_descriptor = array(
                                         "title" => t('title','NASInfo'),
                                      );
-                                     
+
         $fieldset1_descriptor = array(
                                         "title" => t('title','NASAdvanced'),
                                      );
@@ -227,53 +228,52 @@
 
         // print navbar controls
         print_tab_header($navkeys);
-        
+
         open_form();
-        
+
         // open tab wrapper
         open_tab_wrapper();
-        
+
         // open 0-th tab (shown)
         open_tab($navkeys, 0, true);
-        
+
         // open 0-th fieldset
         open_fieldset($fieldset0_descriptor);
 
         foreach ($input_descriptors0 as $input_descriptor) {
             print_form_component($input_descriptor);
         }
-        
+
         close_fieldset();
-        
+
         close_tab($navkeys, 0);
-        
+
         // open 1-st tab
         open_tab($navkeys, 1);
-        
+
         // open 1-th fieldset
         open_fieldset($fieldset1_descriptor);
-        
+
         foreach ($input_descriptors1 as $input_descriptor) {
             print_form_component($input_descriptor);
         }
-        
+
         close_fieldset();
-        
+
         close_tab($navkeys, 1);
-        
+
         // close tab wrapper
         close_tab_wrapper();
-        
+
         foreach ($input_descriptors2 as $input_descriptor) {
             print_form_component($input_descriptor);
         }
-        
+
         close_form();
 
     }
 
     print_back_to_previous_page();
 
-    include('include/config/logging.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_CONFIG'], 'logging.php' ]);
     print_footer_and_html_epilogue();
-?>


### PR DESCRIPTION
## Summary

This PR refactors the maintenance `radclient` flow, aligns several UI labels, and improves the NAS management section.

## What changed

### Maintenance / RadClient
- Introduced a dedicated `RadClient` class in `maintenance_radclient.php`
- Moved the radclient availability check to a static class method
- Converted maintenance includes to `implode()` for cleaner and safer path handling
- Fixed `disconnect user` so it uses the NAS `port` field correctly
- Kept `test user` and `disconnect user` aligned with the new class-based flow

### NAS section
- Improved the NAS list view by hiding sensitive secrets
- Added support for multi-select deletion from the NAS list
- Updated the delete flow so:
  - `GET` requests preselect the NAS entries to remove
  - `POST` requests validate and execute the deletion
- Applied the same `implode()` include pattern to the NAS pages
- Refined the NAS edit/new flows to better match the current form behavior

### Translations
- Aligned several translation labels for consistency across the UI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored radclient handling into a new `RadClient` class, fixed CoA/PoD port usage, and streamlined NAS management with hidden secrets, multi-delete, and clearer forms. This improves safety, UX, and maintainability.

- **Refactors**
  - Introduced `RadClient` with `disconnect()` and `check_connectivity()`; shared options normalized once; `is_radclient_present()` made static.
  - Fixed CoA/PoD port handling: use a dedicated port (default 3799), not the `nas.ports` column.
  - Adopted config-driven includes via `implode(DIRECTORY_SEPARATOR, ...)`.
  - Aligned labels/translations and added concise tooltips.
  - Guarded NAS list count query against DB errors.

- **New Features**
  - Hidden NAS secrets in list views.
  - Multi-select NAS deletion from the list; GET preselects, POST validates and deletes.
  - Added optional CoA/PoD port field to Disconnect User.
  - Clarified NAS “ports” field semantics (informational, 0–99999) and updated new/edit forms accordingly.

<sup>Written for commit a24227118e353b79ec1244b703fa3d1f31fd75d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

