### PR TITLE
Autofill disconnect user

### DIFF
--- a/app/operators/config-maint-disconnect-user.php
+++ b/app/operators/config-maint-disconnect-user.php
@@ -144,6 +144,11 @@
                 $failureMsg = "CSRF token error";
                 $logAction .= "$failureMsg on page: ";
             }
+        } elseif ($_SERVER['REQUEST_METHOD'] === 'GET') {
+            $username = (isset($_GET['username']) && !empty(trim($_GET['username']))) ? trim($_GET['username']) : "";
+            $packetType = (isset($_GET['username']) && !empty(trim($_GET['username']))) ? "disconnect" : "";
+            $nas_id = (isset($_GET['nasaddr']) && !empty(trim($_GET['nasaddr']))) ? trim($_GET['nasaddr']) : "";
+
         }
 
     } else {

--- a/app/operators/config-maint-disconnect-user.php
+++ b/app/operators/config-maint-disconnect-user.php
@@ -144,7 +144,7 @@
                 $failureMsg = "CSRF token error";
                 $logAction .= "$failureMsg on page: ";
             }
-        } elseif ($_SERVER['REQUEST_METHOD'] === 'GET') {
+        } elseif ($_SERVER['REQUEST_METHOD'] === 'GET') { //input from online user page
             $username = (isset($_GET['username']) && !empty(trim($_GET['username']))) ? trim($_GET['username']) : "";
             $packetType = (isset($_GET['username']) && !empty(trim($_GET['username']))) ? "disconnect" : "";
             $nas_id = (isset($_GET['nasaddr']) && !empty(trim($_GET['nasaddr']))) ? trim($_GET['nasaddr']) : "";

--- a/app/operators/rep-online.php
+++ b/app/operators/rep-online.php
@@ -141,6 +141,7 @@
                    ra.acctoutputoctets AS download,
                    hs.name AS hotspot,
                    rn.shortname AS nasshortname,
+                   rn.id AS nasid,
                    ui.firstname AS firstname,
                    ui.lastname AS lastname
               FROM %s AS ra LEFT JOIN %s AS hs ON hs.mac=ra.calledstationid
@@ -231,7 +232,7 @@
             list(
                     $this_username, $this_framedipaddress, $this_callingstationid, $this_starttime, $this_sessiontime,
                     $this_nasipaddress, $this_calledstationid, $this_sessionid, $this_upload, $this_download,
-                    $this_hotspot, $this_nasshortname, $this_firstname, $this_lastname
+                    $this_hotspot, $this_nasshortname, $this_nasid, $this_firstname, $this_lastname
                 ) = $row;
 
             $this_sessiontime = time2str($this_sessiontime);
@@ -260,7 +261,7 @@
             // tooltip and ajax stuff
             $custom_attributes = sprintf("Acct-Session-Id=%s,Framed-IP-Address=%s", $this_sessionid, $this_framedipaddress);
             $tooltip_disconnect_href = sprintf("config-maint-disconnect-user.php?username=%s&nasaddr=%s&customattributes=%s",
-                                               urlencode($this_username), urlencode($this_nasipaddress), urlencode($custom_attributes));
+                                               urlencode($this_username), urlencode("nas-" . $this_nasid), urlencode($custom_attributes));
 
             $ajax_id = "divContainerUserInfo_" . $count;
             $param = sprintf('username=%s', urlencode($this_username));


### PR DESCRIPTION
if user click disconnect user it redirect to disconnect user, but no user and nas where selected
make some change, can autofill it

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clicking “Disconnect” from Online Users now opens the Disconnect User page with the username and NAS prefilled, and sets the action to disconnect. This fixes the empty form redirect and streamlines the flow.

- **Bug Fixes**
  - Read `username` and `nasaddr` from GET in `config-maint-disconnect-user.php`; set `packetType` to `disconnect` when `username` is present.
  - Added `rn.id AS nasid` to the Online Users query and updated the disconnect link to pass `nasaddr=nas-<id>` with custom attributes.
  - Prevents loading the page without a selected user or NAS.

<sup>Written for commit a76b3a67403db6441fd53d881bb9f789f841fe8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

