### PR TITLE
fix: enforce FreeRADIUS file ownership

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -23,12 +23,16 @@ DB_HOST=localhost
 DB_PORT=3306
 DALORADIUS_USERS_PORT=80
 DALORADIUS_OPERATORS_PORT=8000
-DALORADIUS_ROOT_DIRECTORY=/var/www/daloradius
-DALORADIUS_CONF_FILE="${DALORADIUS_ROOT_DIRECTORY}/app/common/includes/daloradius.conf.php"
+DALORADIUS_ROOT_DIR=/var/www/daloradius
+DALORADIUS_CONF_FILE="${DALORADIUS_ROOT_DIR}/app/common/includes/daloradius.conf.php"
 DALORADIUS_SERVER_ADMIN=admin@daloradius.example.org
-FREERADIUS_SQL_MOD_PATH="/etc/freeradius/3.0/mods-available/sql"
-FREERADIUS_SQLCOUNTER_MOD_PATH="/etc/freeradius/3.0/mods-available/sqlcounter"
-FREERADIUS_DEFAULT_SITE_PATH="/etc/freeradius/3.0/sites-available/default"
+
+FREERADIUS_ROOT_DIR="/etc/freeradius/3.0"
+FREERADIUS_MODS_AVAIL_PATH="${FREERADIUS_ROOT_DIR}/mods-available"
+FREERADIUS_MODS_ENABL_PATH="${FREERADIUS_ROOT_DIR}/mods-enabled"
+FREERADIUS_SITES_ENABL_PATH="${FREERADIUS_ROOT_DIR}/sites-enabled"
+FREERADIUS_SITES_AVAIL_PATH="${FREERADIUS_ROOT_DIR}/sites-available"
+
 
 # Function to print an OK message in green
 print_green() {
@@ -233,21 +237,30 @@ freeradius_install() {
 # Function to set up freeRADIUS SQL module
 freeradius_setup_sql_mod() {
     echo -n "[+] Setting up freeRADIUS SQL module... "
-    if ! sed -Ei '/^[\t\s#]*tls\s+\{/, /[\t\s#]*\}/ s/^/#/' "${FREERADIUS_SQL_MOD_PATH}" >/dev/null 2>&1 || \
-       ! sed -Ei 's/^[\t\s#]*dialect\s+=\s+.*$/\tdialect = "mysql"/g' "${FREERADIUS_SQL_MOD_PATH}" >/dev/null 2>&1 || \
-       ! sed -Ei 's/^[\t\s#]*driver\s+=\s+"rlm_sql_null"/\tdriver = "rlm_sql_\${dialect}"/g' "${FREERADIUS_SQL_MOD_PATH}" >/dev/null 2>&1 || \
-       ! sed -Ei "s/^[\t\s#]*server\s+=\s+\"localhost\"/\tserver = \"${DB_HOST}\"/g" "${FREERADIUS_SQL_MOD_PATH}" >/dev/null 2>&1 || \
-       ! sed -Ei "s/^[\t\s#]*port\s+=\s+[0-9]+/\tport = ${DB_PORT}/g" "${FREERADIUS_SQL_MOD_PATH}" >/dev/null 2>&1 || \
-       ! sed -Ei "s/^[\t\s#]*login\s+=\s+\"radius\"/\tlogin = \"${DB_USER}\"/g" "${FREERADIUS_SQL_MOD_PATH}" >/dev/null 2>&1 || \
-       ! sed -Ei "s/^[\t\s#]*password\s+=\s+\"radpass\"/\tpassword = \"${DB_PASS}\"/g" "${FREERADIUS_SQL_MOD_PATH}" >/dev/null 2>&1 || \
-       ! sed -Ei "s/^[\t\s#]*radius_db\s+=\s+\"radius\"/\tradius_db = \"${DB_SCHEMA}\"/g" "${FREERADIUS_SQL_MOD_PATH}" >/dev/null 2>&1 || \
-       ! sed -Ei 's/^[\t\s#]*read_clients\s+=\s+.*$/\tread_clients = yes/g' "${FREERADIUS_SQL_MOD_PATH}" >/dev/null 2>&1 || \
-       ! sed -Ei 's/^[\t\s#]*client_table\s+=\s+.*$/\tclient_table = "nas"/g' "${FREERADIUS_SQL_MOD_PATH}" >/dev/null 2>&1 || \
-       ! ln -s "${FREERADIUS_SQL_MOD_PATH}" /etc/freeradius/3.0/mods-enabled/ >/dev/null 2>&1; then
+    if ! sed -Ei '/^[\t\s#]*tls\s+\{/, /[\t\s#]*\}/ s/^/#/' "${FREERADIUS_MODS_AVAIL_PATH}/sql" >/dev/null 2>&1 || \
+       ! sed -Ei 's/^[\t\s#]*dialect\s+=\s+.*$/\tdialect = "mysql"/g' "${FREERADIUS_MODS_AVAIL_PATH}/sql" >/dev/null 2>&1 || \
+       ! sed -Ei 's/^[\t\s#]*driver\s+=\s+"rlm_sql_null"/\tdriver = "rlm_sql_\${dialect}"/g' "${FREERADIUS_MODS_AVAIL_PATH}/sql" >/dev/null 2>&1 || \
+       ! sed -Ei "s/^[\t\s#]*server\s+=\s+\"localhost\"/\tserver = \"${DB_HOST}\"/g" "${FREERADIUS_MODS_AVAIL_PATH}/sql" >/dev/null 2>&1 || \
+       ! sed -Ei "s/^[\t\s#]*port\s+=\s+[0-9]+/\tport = ${DB_PORT}/g" "${FREERADIUS_MODS_AVAIL_PATH}/sql" >/dev/null 2>&1 || \
+       ! sed -Ei "s/^[\t\s#]*login\s+=\s+\"radius\"/\tlogin = \"${DB_USER}\"/g" "${FREERADIUS_MODS_AVAIL_PATH}/sql" >/dev/null 2>&1 || \
+       ! sed -Ei "s/^[\t\s#]*password\s+=\s+\"radpass\"/\tpassword = \"${DB_PASS}\"/g" "${FREERADIUS_MODS_AVAIL_PATH}/sql" >/dev/null 2>&1 || \
+       ! sed -Ei "s/^[\t\s#]*radius_db\s+=\s+\"radius\"/\tradius_db = \"${DB_SCHEMA}\"/g" "${FREERADIUS_MODS_AVAIL_PATH}/sql" >/dev/null 2>&1 || \
+       ! sed -Ei 's/^[\t\s#]*read_clients\s+=\s+.*$/\tread_clients = yes/g' "${FREERADIUS_MODS_AVAIL_PATH}/sql" >/dev/null 2>&1 || \
+       ! sed -Ei 's/^[\t\s#]*client_table\s+=\s+.*$/\tclient_table = "nas"/g' "${FREERADIUS_MODS_AVAIL_PATH}/sql" >/dev/null 2>&1 || \
+       ! ln -s "${FREERADIUS_MODS_AVAIL_PATH}/sql" "${FREERADIUS_MODS_ENABL_PATH}/sql" >/dev/null 2>&1; then
         print_red "KO"
         echo "[!] Failed to set up freeRADIUS SQL module. Aborting." >&2
         exit 1
     fi
+
+    # ensure freerad ownership
+    if ! chown freerad:freerad "${FREERADIUS_MODS_AVAIL_PATH}/sql" >/dev/null 2>&1 || \
+       ! chown -h freerad:freerad "${FREERADIUS_MODS_ENABL_PATH}/sql" >/dev/null 2>&1; then
+        print_red "KO"
+        echo "[!] Failed to set ownership of freeRADIUS SQL module. Aborting." >&2
+        exit 1
+    fi
+
     print_green "OK"
 }
 
@@ -263,21 +276,29 @@ freeradius_setup_sqlcounter_mod() {
         exit 1
     }
 
-    if ! sed -Ei 's/^[[:space:]#]*dialect[[:space:]]+=[[:space:]]+.*$/	dialect = "mysql"/g' "${FREERADIUS_SQLCOUNTER_MOD_PATH}" >/dev/null 2>&1; then
+    if ! sed -Ei 's/^[[:space:]#]*dialect[[:space:]]+=[[:space:]]+.*$/	dialect = "mysql"/g' "${FREERADIUS_MODS_AVAIL_PATH}/sqlcounter" >/dev/null 2>&1; then
         print_red "KO"
         echo "[!] Failed to configure freeRADIUS SQL counter module. Aborting." >&2
         exit 1
     fi
 
-    if [ ! -e /etc/freeradius/3.0/mods-enabled/sqlcounter ]; then
-        if ! ln -s "${FREERADIUS_SQLCOUNTER_MOD_PATH}" /etc/freeradius/3.0/mods-enabled/ >/dev/null 2>&1; then
+    if [ ! -e "${FREERADIUS_MODS_ENABL_PATH}/sqlcounter" ]; then
+        if ! ln -s "${FREERADIUS_MODS_AVAIL_PATH}/sqlcounter" "${FREERADIUS_MODS_ENABL_PATH}/sqlcounter" >/dev/null 2>&1; then
             print_red "KO"
             echo "[!] Failed to enable freeRADIUS SQL counter module. Aborting." >&2
             exit 1
         fi
+
+        # ensure freerad ownership
+        if ! chown freerad:freerad "${FREERADIUS_MODS_AVAIL_PATH}/sqlcounter" >/dev/null 2>&1 || \
+           ! chown -h freerad:freerad "${FREERADIUS_MODS_ENABL_PATH}/sqlcounter" >/dev/null 2>&1; then
+            print_red "KO"
+            echo "[!] Failed to set ownership of freeRADIUS SQL counter module. Aborting." >&2
+            exit 1
+        fi
     fi
 
-    if ! grep -q "^[[:space:]]*noresetcounter[[:space:]]*$" "${FREERADIUS_DEFAULT_SITE_PATH}"; then
+    if ! grep -q "^[[:space:]]*noresetcounter[[:space:]]*$" "${FREERADIUS_SITES_AVAIL_PATH}/default"; then
         if ! awk '
             BEGIN { in_authorize = 0; added = 0 }
             /^authorize[[:space:]]*[{]/ { in_authorize = 1 }
@@ -290,13 +311,13 @@ freeradius_setup_sqlcounter_mod() {
             /^authenticate[[:space:]]*[{]/ { in_authorize = 0 }
             { print }
             END { exit added ? 0 : 1 }
-        ' "${FREERADIUS_DEFAULT_SITE_PATH}" > "${freeradius_default_tmp}"; then
+        ' "${FREERADIUS_SITES_AVAIL_PATH}/default" > "${freeradius_default_tmp}"; then
             rm -f "${freeradius_default_tmp}"
             print_red "KO"
             echo "[!] Failed to add noresetcounter to freeRADIUS authorize section. Aborting." >&2
             exit 1
         fi
-        mv "${freeradius_default_tmp}" "${FREERADIUS_DEFAULT_SITE_PATH}"
+        mv "${freeradius_default_tmp}" "${FREERADIUS_SITES_AVAIL_PATH}/default"
     else
         rm -f "${freeradius_default_tmp}"
     fi
@@ -338,14 +359,15 @@ freeradius_setup_sql_session_tracking() {
 
         { print }
         END { exit (session_sql && sql_session_start) ? 0 : 1 }
-    ' "${FREERADIUS_DEFAULT_SITE_PATH}" > "${freeradius_default_tmp}"; then
+    ' "${FREERADIUS_SITES_AVAIL_PATH}/default" > "${freeradius_default_tmp}"; then
         rm -f "${freeradius_default_tmp}"
         print_red "KO"
         echo "[!] Failed to enable SQL session tracking in freeRADIUS. Aborting." >&2
         exit 1
     fi
 
-    mv "${freeradius_default_tmp}" "${FREERADIUS_DEFAULT_SITE_PATH}"
+    mv "${freeradius_default_tmp}" "${FREERADIUS_SITES_AVAIL_PATH}/default"
+
     print_green "OK"
 }
 
@@ -361,7 +383,7 @@ freeradius_setup_group_nas_restrictions() {
         exit 1
     }
 
-    if grep -q "daloRADIUS group NAS restriction policy" "${FREERADIUS_DEFAULT_SITE_PATH}"; then
+    if grep -q "daloRADIUS group NAS restriction policy" "${FREERADIUS_SITES_AVAIL_PATH}/default"; then
         rm -f "${freeradius_default_tmp}"
         print_green "OK"
         return
@@ -387,14 +409,57 @@ freeradius_setup_group_nas_restrictions() {
             }
         }
         END { exit added ? 0 : 1 }
-    ' "${FREERADIUS_DEFAULT_SITE_PATH}" > "${freeradius_default_tmp}"; then
+    ' "${FREERADIUS_SITES_AVAIL_PATH}/default" > "${freeradius_default_tmp}"; then
         rm -f "${freeradius_default_tmp}"
         print_red "KO"
         echo "[!] Failed to add daloRADIUS group NAS restriction policy to freeRADIUS authorize section. Aborting." >&2
         exit 1
     fi
 
-    mv "${freeradius_default_tmp}" "${FREERADIUS_DEFAULT_SITE_PATH}"
+    mv "${freeradius_default_tmp}" "${FREERADIUS_SITES_AVAIL_PATH}/default"
+    print_green "OK"
+}
+
+# Function to ensure ownership and enable the default freeRADIUS site
+freeradius_ensure_default_site() {
+    echo -n "[+] Ensuring freeRADIUS default site ownership and symlink... "
+
+    local default_site="${FREERADIUS_SITES_AVAIL_PATH}/default"
+    local default_link="${FREERADIUS_SITES_ENABL_PATH}/default"
+
+    if [ ! -f "${default_site}" ]; then
+        print_red "KO"
+        echo "[!] freeRADIUS default site file not found at ${default_site}. Aborting." >&2
+        exit 1
+    fi
+
+    if [ -e "${default_link}" ] && [ ! -L "${default_link}" ]; then
+        print_red "KO"
+        echo "[!] ${default_link} exists but is not a symbolic link. Aborting." >&2
+        exit 1
+    fi
+
+    if [ ! -L "${default_link}" ]; then
+        if ! ln -s "${default_site}" "${default_link}" >/dev/null 2>&1; then
+            print_red "KO"
+            echo "[!] Failed to enable the freeRADIUS default site. Aborting." >&2
+            exit 1
+        fi
+    fi
+
+    if [ "$(readlink -f "${default_link}")" != "$(readlink -f "${default_site}")" ]; then
+        print_red "KO"
+        echo "[!] ${default_link} does not point to ${default_site}. Aborting." >&2
+        exit 1
+    fi
+
+    if ! chown freerad:freerad "${default_site}" || \
+       ! chown -h freerad:freerad "${default_link}"; then
+        print_red "KO"
+        echo "[!] Failed to set ownership on the freeRADIUS default site. Aborting." >&2
+        exit 1
+    fi
+
     print_green "OK"
 }
 
@@ -429,7 +494,7 @@ daloradius_installation() {
     SCRIPT_PATH=$(realpath $0)
     SCRIPT_DIR=$(dirname ${SCRIPT_PATH})
 
-    if [ "${SCRIPT_DIR}" = "${DALORADIUS_ROOT_DIRECTORY}/setup" ]; then
+    if [ "${SCRIPT_DIR}" = "${DALORADIUS_ROOT_DIR}/setup" ]; then
         # local installation
         echo -n "[+] Setting up daloRADIUS... "
 
@@ -442,13 +507,13 @@ daloradius_installation() {
     else
         # remote installation
         echo -n "[+] Downloading and setting up daloRADIUS... "
-        if [ -d "${DALORADIUS_ROOT_DIRECTORY}" ]; then
+        if [ -d "${DALORADIUS_ROOT_DIR}" ]; then
             print_red "KO"
-            print_red "[!] Directory ${DALORADIUS_ROOT_DIRECTORY} already exists. Aborting." >&2
+            print_red "[!] Directory ${DALORADIUS_ROOT_DIR} already exists. Aborting." >&2
             exit 1
         fi
 
-        git clone https://github.com/lirantal/daloradius.git "${DALORADIUS_ROOT_DIRECTORY}" >/dev/null 2>&1 &
+        git clone https://github.com/lirantal/daloradius.git "${DALORADIUS_ROOT_DIR}" >/dev/null 2>&1 &
         print_spinner $!
         wait $!
         if [ $? -ne 0 ]; then
@@ -472,19 +537,19 @@ daloradius_setup_required_dirs() {
         exit 1
     fi
 
-    if ! mkdir -p ${DALORADIUS_ROOT_DIRECTORY}/var/{log,backup} >/dev/null 2>&1; then
+    if ! mkdir -p ${DALORADIUS_ROOT_DIR}/var/{log,backup} >/dev/null 2>&1; then
         print_red "KO"
         print_red "[!] Failed to create log and backup directories. Aborting." >&2
         exit 1
     fi
 
-    if ! chown -R www-data:www-data ${DALORADIUS_ROOT_DIRECTORY}/var >/dev/null 2>&1; then
+    if ! chown -R www-data:www-data ${DALORADIUS_ROOT_DIR}/var >/dev/null 2>&1; then
         print_red "KO"
         print_red "[!] Failed to change ownership of var directory. Aborting." >&2
         exit 1
     fi
 
-    if ! chmod -R 775 ${DALORADIUS_ROOT_DIRECTORY}/var >/dev/null 2>&1; then
+    if ! chmod -R 775 ${DALORADIUS_ROOT_DIR}/var >/dev/null 2>&1; then
         print_red "KO"
         print_red "[!] Failed to change permissions of var directory. Aborting." >&2
         exit 1
@@ -496,7 +561,7 @@ daloradius_setup_required_dirs() {
 # Function to set up daloRADIUS
 daloradius_setup_required_files() {
     echo -n "[+] Setting up daloRADIUS... "
-    DALORADIUS_CONF_FILE="${DALORADIUS_ROOT_DIRECTORY}/app/common/includes/daloradius.conf.php"
+    DALORADIUS_CONF_FILE="${DALORADIUS_ROOT_DIR}/app/common/includes/daloradius.conf.php"
 
     if ! cp "${DALORADIUS_CONF_FILE}.sample" "${DALORADIUS_CONF_FILE}" >/dev/null 2>&1; then
         print_red "KO"
@@ -529,7 +594,7 @@ daloradius_setup_required_files() {
         exit 1
     fi
 
-    if ! chown www-data:www-data ${DALORADIUS_ROOT_DIRECTORY}/contrib/scripts/dalo-crontab >/dev/null 2>&1; then
+    if ! chown www-data:www-data ${DALORADIUS_ROOT_DIR}/contrib/scripts/dalo-crontab >/dev/null 2>&1; then
         print_red "KO"
         print_red "[!] Failed to change ownership of dalo-crontab script. Aborting." >&2
         exit 1
@@ -563,7 +628,7 @@ export DALORADIUS_USERS_PORT=${DALORADIUS_USERS_PORT}
 export DALORADIUS_OPERATORS_PORT=${DALORADIUS_OPERATORS_PORT}
 
 # daloRADIUS package root directory
-export DALORADIUS_ROOT_DIRECTORY=${DALORADIUS_ROOT_DIRECTORY}
+export DALORADIUS_ROOT_DIRECTORY=${DALORADIUS_ROOT_DIR}
 
 # daloRADIUS administrator's email
 export DALORADIUS_SERVER_ADMIN=${DALORADIUS_SERVER_ADMIN}
@@ -681,7 +746,7 @@ apache_enable_restart() {
 
 # Function to load daloRADIUS SQL schema into MariaDB
 daloradius_load_sql_schema() {
-    DB_DIR="${DALORADIUS_ROOT_DIRECTORY}/contrib/db"
+    DB_DIR="${DALORADIUS_ROOT_DIR}/contrib/db"
     echo -n "[+] Loading daloRADIUS SQL schemas into MariaDB... "
 
     if ! mariadb --defaults-extra-file="${MARIADB_CLIENT_FILENAME}" < "${DB_DIR}/fr3-mariadb-freeradius.sql" >/dev/null 2>&1; then
@@ -768,6 +833,7 @@ main() {
     freeradius_setup_sqlcounter_mod
     freeradius_setup_sql_session_tracking
     freeradius_setup_group_nas_restrictions
+    freeradius_ensure_default_site
     freeradius_enable_restart
 
     apache_disable_all_sites

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -288,14 +288,14 @@ freeradius_setup_sqlcounter_mod() {
             echo "[!] Failed to enable freeRADIUS SQL counter module. Aborting." >&2
             exit 1
         fi
+    fi
 
-        # ensure freerad ownership
-        if ! chown freerad:freerad "${FREERADIUS_MODS_AVAIL_PATH}/sqlcounter" >/dev/null 2>&1 || \
-           ! chown -h freerad:freerad "${FREERADIUS_MODS_ENABL_PATH}/sqlcounter" >/dev/null 2>&1; then
-            print_red "KO"
-            echo "[!] Failed to set ownership of freeRADIUS SQL counter module. Aborting." >&2
-            exit 1
-        fi
+    # ensure freerad ownership
+    if ! chown freerad:freerad "${FREERADIUS_MODS_AVAIL_PATH}/sqlcounter" >/dev/null 2>&1 || \
+        ! chown -h freerad:freerad "${FREERADIUS_MODS_ENABL_PATH}/sqlcounter" >/dev/null 2>&1; then
+        print_red "KO"
+        echo "[!] Failed to set ownership of freeRADIUS SQL counter module. Aborting." >&2
+        exit 1
     fi
 
     if ! grep -q "^[[:space:]]*noresetcounter[[:space:]]*$" "${FREERADIUS_SITES_AVAIL_PATH}/default"; then


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enforces `freerad:freerad` ownership on FreeRADIUS modules and the `default` site to prevent permission errors. Standardizes FreeRADIUS and daloRADIUS paths and ensures the `default` site is enabled and correctly linked.

- **Bug Fixes**
  - Always set `freerad:freerad` ownership on `mods-available/sql`, `mods-available/sqlcounter`, and their symlinks in `mods-enabled`.
  - Ensure ownership for `sites-available/default` and its `sites-enabled` symlink.
  - Add safety checks for missing, non-symlink, or mispointed `sites-enabled/default`; abort on misconfigurations.

- **Refactors**
  - Introduce `FREERADIUS_ROOT_DIR`, `FREERADIUS_MODS_AVAIL_PATH`, `FREERADIUS_MODS_ENABL_PATH`, `FREERADIUS_SITES_AVAIL_PATH`, `FREERADIUS_SITES_ENABL_PATH`.
  - Rename `DALORADIUS_ROOT_DIRECTORY` to `DALORADIUS_ROOT_DIR` (still exported as `DALORADIUS_ROOT_DIRECTORY`).
  - Add `freeradius_ensure_default_site` and call it in `main`.

<sup>Written for commit 6e33534ff806ee478f86b95d84af7d4c0d9059e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

