### PR TITLE
fix/pr 726

### DIFF
--- a/app/common/includes/validation.php
+++ b/app/common/includes/validation.php
@@ -52,6 +52,48 @@ define("DB_TABLE_NAME_REGEX", '/^[a-zA-Z0-9_]+$/');
 define("ALLOWED_RANDOM_CHARS_REGEX", DB_TABLE_NAME_REGEX);
 define("ALLOWED_ATTRIBUTE_CHARS_REGEX", '/^[a-zA-Z0-9-]+$/');
 
+if (!function_exists('normalize_custom_attributes')) {
+    /**
+     * Validate optional custom RADIUS attributes and drop malformed entries.
+     *
+     * Keeps only items shaped like `Attribute=Value`, rejects empty values,
+     * rejects `User-Name`, and allows only attribute names that match the
+     * shared whitelist regex.
+     *
+     * @param string $customAttributes Comma-separated `Attr=Value` pairs.
+     * @return string Normalized comma-separated list of valid pairs.
+     */
+    function normalize_custom_attributes($customAttributes) {
+        $customAttributes = trim((string)$customAttributes);
+        if ($customAttributes === "") {
+            return "";
+        }
+
+        $out = array();
+        foreach (explode(",", $customAttributes) as $pair) {
+            if (strpos($pair, "=") === false) {
+                continue;
+            }
+
+            list($attr, $value) = explode("=", $pair, 2);
+            $attr  = trim($attr);
+            $value = trim($value);
+
+            if ($attr === "" || $value === "" || $attr === 'User-Name') {
+                continue;
+            }
+
+            if (preg_match(ALLOWED_ATTRIBUTE_CHARS_REGEX, $attr) !== 1) {
+                continue;
+            }
+
+            $out[] = sprintf("%s=%s", $attr, $value);
+        }
+
+        return implode(", ", $out);
+    }
+}
+
 define("SENDER_NAME_REGEX", '/^[a-zA-Z0-9 -]+$/');
 define("SUBJECT_PREFIX_REGEX", '/^[a-zA-Z0-9 -\[\]]+$/');
 define("RECIPIENT_NAME_REGEX", '/^[a-zA-Z0-9 -]+$/');

--- a/app/operators/config-maint-disconnect-user.php
+++ b/app/operators/config-maint-disconnect-user.php
@@ -150,6 +150,11 @@
                 $failureMsg = "CSRF token error";
                 $logAction .= "$failureMsg on page: ";
             }
+        } elseif ($_SERVER['REQUEST_METHOD'] === 'GET') {
+            $username = (isset($_GET['username']) && !empty(trim($_GET['username']))) ? trim($_GET['username']) : "";
+            $packetType = (isset($_GET['username']) && !empty(trim($_GET['username']))) ? "disconnect" : "";
+            $nas_id = (isset($_GET['nasaddr']) && !empty(trim($_GET['nasaddr']))) ? trim($_GET['nasaddr']) : "";
+
         }
 
     } else {

--- a/app/operators/config-maint-disconnect-user.php
+++ b/app/operators/config-maint-disconnect-user.php
@@ -86,7 +86,7 @@
                     $packetType = (isset($_POST['packetType']) && array_key_exists(trim($_POST['packetType']), $valid_packetTypes))
                                 ? trim($_POST['packetType']) : array_key_first($valid_packetTypes);
                     $customAttributes = (array_key_exists('customAttributes', $_POST) && !empty(trim($_POST['customAttributes'])))
-                                      ? trim($_POST['customAttributes']) : "";
+                                      ? normalize_custom_attributes($_POST['customAttributes']) : "";
 
                     $port = (array_key_exists('port', $_POST) && !empty(trim($_POST['port'])) &&
                              intval(trim($_POST['port'])) >= 1 && intval(trim($_POST['port'])) <= 65535)
@@ -151,10 +151,12 @@
                 $logAction .= "$failureMsg on page: ";
             }
         } elseif ($_SERVER['REQUEST_METHOD'] === 'GET') { //input from online user page
-            $username = (isset($_GET['username']) && !empty(trim($_GET['username']))) ? trim($_GET['username']) : "";
-            $packetType = (isset($_GET['username']) && !empty(trim($_GET['username']))) ? "disconnect" : "";
-            $nas_id = (isset($_GET['nasaddr']) && !empty(trim($_GET['nasaddr']))) ? trim($_GET['nasaddr']) : "";
-
+            $username = (isset($_GET['username']) && is_string($_GET['username']) && strlen(trim($_GET['username'])) > 0)
+                      ? trim($_GET['username']) : "";
+            $nas_id = (isset($_GET['nas_id']) && in_array(trim($_GET['nas_id']), array_keys($valid_nas_ids)))
+                    ? trim($_GET['nas_id']) : "";
+            $customAttributes = (array_key_exists('customAttributes', $_GET) && !empty(trim($_GET['customAttributes'])))
+                              ? normalize_custom_attributes($_GET['customAttributes']) : "";
         }
 
     } else {
@@ -189,14 +191,11 @@
                                         "selected_value" => ((isset($username)) ? $username : ""),
                                      );
 
-        $options = $valid_packetTypes;
-        array_unshift($options, "");
-
         $input_descriptors0[] = array(
                                         "name" => "packetType",
                                         "caption" => t('all','PacketType'),
                                         "type" => "select",
-                                        "options" => $options,
+                                        "options" => $valid_packetTypes,
                                         "selected_value" => ((isset($packetType)) ? $packetType : ""),
                                      );
 

--- a/app/operators/config-maint-disconnect-user.php
+++ b/app/operators/config-maint-disconnect-user.php
@@ -150,7 +150,7 @@
                 $failureMsg = "CSRF token error";
                 $logAction .= "$failureMsg on page: ";
             }
-        } elseif ($_SERVER['REQUEST_METHOD'] === 'GET') {
+        } elseif ($_SERVER['REQUEST_METHOD'] === 'GET') { //input from online user page
             $username = (isset($_GET['username']) && !empty(trim($_GET['username']))) ? trim($_GET['username']) : "";
             $packetType = (isset($_GET['username']) && !empty(trim($_GET['username']))) ? "disconnect" : "";
             $nas_id = (isset($_GET['nasaddr']) && !empty(trim($_GET['nasaddr']))) ? trim($_GET['nasaddr']) : "";

--- a/app/operators/library/extensions/maintenance_radclient.php
+++ b/app/operators/library/extensions/maintenance_radclient.php
@@ -254,20 +254,15 @@ class RadClient {
 
         include_once implode(DIRECTORY_SEPARATOR, [$configValues['COMMON_INCLUDES'], 'validation.php']);
 
+        $customAttributes = normalize_custom_attributes($params['customAttributes']);
+        if ($customAttributes === "") {
+            return "";
+        }
+
         $out = "";
-        foreach (explode(",", $params['customAttributes']) as $pair) {
-            if (strpos($pair, "=") === false) {
-                continue; // skip malformed entries instead of triggering a notice
-            }
-
+        foreach (explode(",", $customAttributes) as $pair) {
             list($attr, $value) = explode("=", $pair, 2);
-            $attr  = trim($attr);
-            $value = trim($value);
-
-            if ($attr !== "" && $value !== "" && $attr !== 'User-Name'
-                && preg_match(ALLOWED_ATTRIBUTE_CHARS_REGEX, $attr) === 1) {
-                $out .= sprintf(", %s=%s", $attr, escapeshellarg($value));
-            }
+            $out .= sprintf(", %s=%s", trim($attr), escapeshellarg(trim($value)));
         }
 
         return $out;

--- a/app/operators/rep-online.php
+++ b/app/operators/rep-online.php
@@ -141,6 +141,7 @@
                    ra.acctoutputoctets AS download,
                    hs.name AS hotspot,
                    rn.shortname AS nasshortname,
+                   rn.id AS nasid,
                    ui.firstname AS firstname,
                    ui.lastname AS lastname
               FROM %s AS ra LEFT JOIN %s AS hs ON hs.mac=ra.calledstationid
@@ -231,7 +232,7 @@
             list(
                     $this_username, $this_framedipaddress, $this_callingstationid, $this_starttime, $this_sessiontime,
                     $this_nasipaddress, $this_calledstationid, $this_sessionid, $this_upload, $this_download,
-                    $this_hotspot, $this_nasshortname, $this_firstname, $this_lastname
+                    $this_hotspot, $this_nasshortname, $this_nasid, $this_firstname, $this_lastname
                 ) = $row;
 
             $this_sessiontime = time2str($this_sessiontime);
@@ -260,7 +261,7 @@
             // tooltip and ajax stuff
             $custom_attributes = sprintf("Acct-Session-Id=%s,Framed-IP-Address=%s", $this_sessionid, $this_framedipaddress);
             $tooltip_disconnect_href = sprintf("config-maint-disconnect-user.php?username=%s&nasaddr=%s&customattributes=%s",
-                                               urlencode($this_username), urlencode($this_nasipaddress), urlencode($custom_attributes));
+                                               urlencode($this_username), urlencode("nas-" . $this_nasid), urlencode($custom_attributes));
 
             $ajax_id = "divContainerUserInfo_" . $count;
             $param = sprintf('username=%s', urlencode($this_username));

--- a/app/operators/rep-online.php
+++ b/app/operators/rep-online.php
@@ -21,15 +21,15 @@
  *********************************************************************************************************
  */
 
-    include("library/checklogin.php");
+    include_once implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', 'common', 'includes', 'config_read.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'checklogin.php' ]);
     $operator = $_SESSION['operator_user'];
 
-    include_once('../common/includes/config_read.php');
-    include('library/check_operator_perm.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'check_operator_perm.php' ]);
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LANG'], 'main.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'validation.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'layout.php' ]);
 
-    include_once("lang/main.php");
-    include_once("../common/includes/validation.php");
-    include("../common/includes/layout.php");
 
     // validate this parameter before including menu
     $username = (array_key_exists('username', $_GET) && !empty(str_replace("%", "", trim($_GET['username']))))
@@ -112,8 +112,8 @@
     // open first tab (shown)
     open_tab($navkeys, 0, true);
 
-    include('../common/includes/db_open.php');
-    include('include/management/pages_common.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'pages_common.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
 
     // ra is a placeholder in the SQL statements below
     // except for $usernameLastConnect, which has been only partially escaped,
@@ -159,8 +159,9 @@
         /* START - Related to pages_numbering.php */
 
         // when $numrows is set, $maxPage is calculated inside this include file
-        include('include/management/pages_numbering.php');    // must be included after opendb because it needs to read
-                                                              // the CONFIG_IFACE_TABLES_LISTING variable from the config file
+        // must be included after opendb because it needs to read
+        // the CONFIG_IFACE_TABLES_LISTING variable from the config file
+        include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'pages_numbering.php' ]);
 
         // here we decide if page numbers should be shown
         $drawNumberLinks = strtolower($configValues['CONFIG_IFACE_TABLES_LISTING_NUM']) == "yes" && $maxPage > 1;
@@ -181,7 +182,7 @@
         // this can be passed as form attribute and
         // printTableFormControls function parameter
         $action = "mng-del.php";
-        
+
         $descriptors = array();
 
         $descriptors['start'] = array( 'common_controls' => 'clearSessionsUsers[]' );
@@ -212,7 +213,7 @@
 
         // second line of table header
         printTableHead($cols, $orderBy, $orderType, $partial_query_string);
-        
+
         // closes table header, opens table body
         print_table_middle();
 
@@ -235,11 +236,11 @@
                     $this_hotspot, $this_nasshortname, $this_nasid, $this_firstname, $this_lastname
                 ) = $row;
 
+            // validation
             $this_sessiontime = time2str($this_sessiontime);
-
             $this_hotspot = (!empty($this_hotspot)) ? $this_hotspot : "(n/d)";
-
             $this_name = $this_firstname . "<br>" . $this_lastname;
+            $this_nasid = intval($this_nasid);
 
             $tooltip1 = "(n/d)";
             $tmp = $this_upload + $this_download;
@@ -249,19 +250,19 @@
                 $this_traffic = t('all','Upload') . ": " . $this_upload
                               . "<br>"
                               . t('all','Download') . ": " . $this_download;
-                              
+
                 $tooltip1 = array(
                                 'subject' => toxbyte($tmp),
                                 'content' => $this_traffic
                              );
-                             
+
                 $tooltip1 = get_tooltip_list_str($tooltip1);
             }
 
             // tooltip and ajax stuff
             $custom_attributes = sprintf("Acct-Session-Id=%s,Framed-IP-Address=%s", $this_sessionid, $this_framedipaddress);
-            $tooltip_disconnect_href = sprintf("config-maint-disconnect-user.php?username=%s&nasaddr=%s&customattributes=%s",
-                                               urlencode($this_username), urlencode("nas-" . $this_nasid), urlencode($custom_attributes));
+            $tooltip_disconnect_href = sprintf("config-maint-disconnect-user.php?username=%s&nas_id=nas-%d&customAttributes=%s",
+                                               urlencode($this_username), $this_nasid, urlencode($custom_attributes));
 
             $ajax_id = "divContainerUserInfo_" . $count;
             $param = sprintf('username=%s', urlencode($this_username));
@@ -272,14 +273,14 @@
                                 'ajax_id' => $ajax_id,
                                 'actions' => array(),
                              );
-                             
+
             $tooltip2['actions'][] = array( 'href' => sprintf('rep-online.php?username=%s', urlencode($this_username)), 'label' => "Filter this user", );
             $tooltip2['actions'][] = array( 'href' => sprintf('mng-edit.php?username=%s', urlencode($this_username)), 'label' => t('Tooltip','UserEdit'), );
             $tooltip2['actions'][] = array( 'href' => $tooltip_disconnect_href, 'label' => t('all','Disconnect'), );
 
             // create tooltip
             $tooltip2 = get_tooltip_list_str($tooltip2);
-            
+
             // create checkbox
             $d = array( 'name' => 'clearSessionsUsers[]',
                         'value' => sprintf("%s||%s", $this_username, $this_starttime));
@@ -315,10 +316,10 @@
 
     } else {
         $failureMsg = "Nothing to display";
-        include_once("include/management/actionMessages.php");
+        include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'actionMessages.php' ]);
     }
 
-    include('../common/includes/db_close.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
 
     close_tab($navkeys, 0);
 
@@ -334,7 +335,6 @@
     // close tab wrapper
     close_tab_wrapper();
 
-    include('include/config/logging.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_CONFIG'], 'logging.php' ]);
 
     print_footer_and_html_epilogue();
-?>


### PR DESCRIPTION
- **Refactor config-maint-disconnect-user.php structure**
- **Refactor user disconnection logic and UI components**
- **Add NAS ID to query and update related variables**
- **feat: autofill disconnect user**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds autofill for the Disconnect User form from the Online Users page and adds NAS ID support to target the correct NAS. Centralizes and hardens RADIUS custom attribute validation to prevent malformed inputs and avoid runtime notices.

- **New Features**
  - Auto-populate disconnect form via GET with `username`, `nas_id`, and `customAttributes` from `rep-online.php`.
  - Use NAS ID in queries and links (`nas.id` → `nas_id=nas-<id>`) for accurate disconnect targeting.

- **Bug Fixes**
  - Validate and normalize `customAttributes` with `normalize_custom_attributes()`, rejecting malformed pairs and `User-Name`.
  - Build radclient attribute string from the normalized list and escape values to avoid errors and injection risks.
  - Standardize includes via `$configValues` paths and correct param casing to `customAttributes`; remove blank packet type option.

<sup>Written for commit 5462cda3e0fd3f57019bf72aad5d46346c26bef7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

