### PR TITLE
fix installer schema error messages

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -757,13 +757,13 @@ daloradius_load_sql_schema() {
 
     if ! mariadb --defaults-extra-file="${MARIADB_CLIENT_FILENAME}" < "${DB_DIR}/mariadb-daloradius.sql" >/dev/null 2>&1; then
         print_red "KO"
-        print_red "[!] Failed to load daloRADIUS dictionaries into MariaDB. Aborting." >&2
+        print_red "[!] Failed to load daloRADIUS base schema into MariaDB. Aborting." >&2
         exit 1
     fi
 
     if ! mariadb --defaults-extra-file="${MARIADB_CLIENT_FILENAME}" < "${DB_DIR}/mariadb-daloradius-dictionaries.sql" >/dev/null 2>&1; then
         print_red "KO"
-        print_red "[!] Failed to load daloRADIUS base schema into MariaDB. Aborting." >&2
+        print_red "[!] Failed to load daloRADIUS dictionaries into MariaDB. Aborting." >&2
         exit 1
     fi
 


### PR DESCRIPTION
## Summary

- report a base-schema import failure as a base-schema error
- report a dictionary import failure as a dictionary error

## Why

PR #722 split dictionary data into a dedicated SQL file and updated the installer import order, but the two corresponding failure messages were accidentally reversed. This follow-up was found while triaging #734.

The change is diagnostic only: it does not alter schema contents, import order, installer control flow, or PHP behavior.

## Validation

- reproduced the mismatch with a targeted shell assertion before the change
- confirmed the same assertion passes after the change
- `bash -n setup/install.sh`
- `git diff --check HEAD^ HEAD`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes swapped installer error messages during MariaDB schema loading: base schema and dictionary SQL import failures now report under the correct labels. Diagnostic-only; no changes to schema contents, import order, or installer behavior.

<sup>Written for commit 05b20f07bb5585449e1713d527ccd8270f602478. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

