### PR TITLE
fix: correct billing refill actions

### DIFF
--- a/app/operators/include/management/userBilling.php
+++ b/app/operators/include/management/userBilling.php
@@ -44,7 +44,7 @@ if (strpos($_SERVER['PHP_SELF'], '/include/management/userBilling.php') !== fals
 function userInvoiceAdd($userId, $invoiceInfo = array(), $invoiceItems = array()) {
     global $logDebugSQL;
 
-    include('../common/includes/db_open.php');
+    include implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', '..', '..', 'common', 'includes', 'db_open.php' ]);
 
     $user_id = false;
 
@@ -133,7 +133,7 @@ function userInvoiceAdd($userId, $invoiceInfo = array(), $invoiceItems = array()
 
 
 
-    include('../common/includes/db_close.php');
+    include implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', '..', '..', 'common', 'includes', 'db_close.php' ]);
 
     return true;
 

--- a/app/operators/library/ajax/user_actions.php
+++ b/app/operators/library/ajax/user_actions.php
@@ -245,7 +245,7 @@ if (array_key_exists('username', $_GET) && isset($_GET['username']) &&
             }
             break;
 
-        case 'userRefillSessionTime':
+        case 'refillSessionTime':
             // we update the sessiontime value to be 0 - this will only work though
             // for accumulative type accounts. For TTF accounts we need to completely
             // delete the record.
@@ -289,7 +289,7 @@ if (array_key_exists('username', $_GET) && isset($_GET['username']) &&
                                                     creditcardtype, creditcardexp, creationdate, creationby)
                                           VALUES (0, '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s',
                                                   '%s', '%s',  '%s')",
-                                   $configValues['CONFIG_DB_TBL_DALOBILLINGHISTORY'], $username, $row['planName'], $row['planTimeRefillCost'],
+                                   $configValues['CONFIG_DB_TBL_DALOBILLINGHISTORY'], $username, $row['PlanID'], $row['planTimeRefillCost'],
                                    'Refill Session Time', 'daloRADIUS Web Interface', 'Refill Session Time', $row['paymentmethod'],
                                    $row['cash'], $row['creditcardname'], $row['creditcardnumber'], $row['creditcardverification'],
                                    $row['creditcardtype'], $row['creditcardexp'], $current_datetime, $currBy);
@@ -329,7 +329,7 @@ if (array_key_exists('username', $_GET) && isset($_GET['username']) &&
 
             break;
 
-         case 'userRefillSessionTraffic':
+         case 'refillSessionTraffic':
             $sql = sprintf("UPDATE %s SET AcctInputOctets=0, AcctOutputOctets=0 WHERE Username IN (%s)",
                            $configValues['CONFIG_DB_TBL_RADACCT'], $username_list);
 
@@ -369,7 +369,7 @@ if (array_key_exists('username', $_GET) && isset($_GET['username']) &&
                                                     creditcardtype, creditcardexp, creationdate, creationby)
                                           VALUES (0, '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s',
                                                   '%s', '%s',  '%s')",
-                                   $configValues['CONFIG_DB_TBL_DALOBILLINGHISTORY'], $username, $row['planName'], $row['planTimeRefillCost'],
+                                   $configValues['CONFIG_DB_TBL_DALOBILLINGHISTORY'], $username, $row['PlanID'], $row['planTrafficRefillCost'],
                                    'Refill Session Traffic', 'daloRADIUS Web Interface', 'Refill Session Traffic', $row['paymentmethod'],
                                    $row['cash'], $row['creditcardname'], $row['creditcardnumber'], $row['creditcardverification'],
                                    $row['creditcardtype'], $row['creditcardexp'], $current_datetime, $currBy);


### PR DESCRIPTION
Align the AJAX refill action names with their handlers, record the correct plan IDs and traffic costs, and make invoice database includes independent of the caller working directory.

Fixes #729

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken billing refill actions and records the correct plan ID and costs in billing history. Also makes invoice DB includes independent of the caller’s working directory. Fixes #729.

- **Bug Fixes**
  - Renamed AJAX actions to match handlers: `userRefillSessionTime` → `refillSessionTime`, `userRefillSessionTraffic` → `refillSessionTraffic`.
  - Billing history now stores `PlanID` instead of plan name; traffic refills use `planTrafficRefillCost`.
  - Replaced relative includes with `__DIR__`-based paths for `db_open.php` and `db_close.php` to avoid CWD issues.

<sup>Written for commit 1bbe2f5b903347574e20d8b5e4e6e474e66cdd48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

