### PR TITLE
🤖🤖🤖 feat: add NAS JSON import and export

### DIFF
--- a/app/operators/include/management/nasImportExport.php
+++ b/app/operators/include/management/nasImportExport.php
@@ -11,7 +11,7 @@ if (strpos($_SERVER['PHP_SELF'] ?? '', '/include/management/nasImportExport.php'
 const NAS_BACKUP_FORMAT = 'daloradius-nas-backup';
 const NAS_BACKUP_VERSION = 1;
 const NAS_BACKUP_BINARY_VERSION = 2;
-const NAS_BACKUP_MAX_BYTES = 2097152;
+const NAS_BACKUP_MAX_BYTES = 8388608;
 const NAS_BACKUP_MAX_ENTRIES = 5000;
 
 function nas_backup_lock_name($dbSocket, $table) {
@@ -20,7 +20,7 @@ function nas_backup_lock_name($dbSocket, $table) {
         return false;
     }
 
-    return 'daloradius:nas:' . substr(hash('sha256', $database . "\0" . $table), 0, 40);
+    return 'daloradius:nas:' . substr(hash('sha256', $database . "\0" . $table), 0, 48);
 }
 
 function nas_backup_acquire_lock($dbSocket, $table, $timeout) {
@@ -58,8 +58,22 @@ function nas_backup_is_valid_utf8($value) {
     return !is_string($value) || preg_match('//u', $value) === 1;
 }
 
+function nas_backup_decode_database_hex($value) {
+    if ($value === null) {
+        return null;
+    }
+    if ($value === '') {
+        return '';
+    }
+    if (!is_string($value) || strlen($value) % 2 !== 0 || !ctype_xdigit($value)) {
+        return false;
+    }
+    return hex2bin($value);
+}
+
 function nas_backup_encode_export_value($value, &$usesBinaryEncoding) {
-    if (!is_string($value) || nas_backup_is_valid_utf8($value)) {
+    if (!is_string($value) ||
+        (nas_backup_is_valid_utf8($value) && !preg_match('/[\x00-\x1F\x7F]/', $value))) {
         return $value;
     }
 
@@ -67,10 +81,11 @@ function nas_backup_encode_export_value($value, &$usesBinaryEncoding) {
     return array(
         'encoding' => 'base64',
         'data' => base64_encode($value),
+        'byte_length' => strlen($value),
     );
 }
 
-function nas_backup_decode_entry($entry, $version, &$errors) {
+function nas_backup_decode_entry($entry, $version, &$errors, &$binaryFields) {
     if (!is_array($entry) || $version !== NAS_BACKUP_BINARY_VERSION) {
         return $entry;
     }
@@ -82,19 +97,26 @@ function nas_backup_decode_entry($entry, $version, &$errors) {
         }
 
         $encoded = $entry[$field];
-        if (($encoded['encoding'] ?? '') !== 'base64' || !is_string($encoded['data'] ?? null)) {
+        if (($encoded['encoding'] ?? '') !== 'base64' || !is_string($encoded['data'] ?? null) ||
+            !is_int($encoded['byte_length'] ?? null) || $encoded['byte_length'] < 0) {
             $errors[] = sprintf('%s has an invalid binary encoding descriptor', $field);
             $entry[$field] = null;
             continue;
         }
 
         $decoded = base64_decode($encoded['data'], true);
-        if ($decoded === false) {
+        if ($decoded === false || base64_encode($decoded) !== $encoded['data']) {
             $errors[] = sprintf('%s contains invalid Base64 data', $field);
             $entry[$field] = null;
             continue;
         }
+        if (strlen($decoded) !== $encoded['byte_length']) {
+            $errors[] = sprintf('%s byte length does not match its binary data', $field);
+            $entry[$field] = null;
+            continue;
+        }
         $entry[$field] = $decoded;
+        $binaryFields[$field] = true;
     }
 
     return $entry;
@@ -107,7 +129,7 @@ function nas_backup_string_length($value) {
     return strlen($value);
 }
 
-function nas_backup_normalize_optional_string($value, $field, $max_length, &$errors) {
+function nas_backup_normalize_optional_string($value, $field, $max_length, &$errors, $allowBinary = false) {
     if ($value === null) {
         return null;
     }
@@ -117,7 +139,7 @@ function nas_backup_normalize_optional_string($value, $field, $max_length, &$err
         return null;
     }
 
-    if (preg_match('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', $value)) {
+    if (!$allowBinary && preg_match('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', $value)) {
         $errors[] = sprintf('%s contains control characters', $field);
     }
 
@@ -128,7 +150,7 @@ function nas_backup_normalize_optional_string($value, $field, $max_length, &$err
     return $value;
 }
 
-function nas_backup_normalize_entry($entry, $row_number) {
+function nas_backup_normalize_entry($entry, $row_number, $preserveValues = false, $binaryFields = array()) {
     $errors = array();
 
     if (!is_array($entry)) {
@@ -144,14 +166,16 @@ function nas_backup_normalize_entry($entry, $row_number) {
         $errors[] = 'nasname must be a string';
         $nasname = '';
     } else {
-        $nasname = trim($nasname);
+        if (!$preserveValues) {
+            $nasname = trim($nasname);
+        }
         if ($nasname === '') {
             $errors[] = 'nasname is required';
         }
         if (nas_backup_string_length($nasname) > 128) {
             $errors[] = 'nasname exceeds 128 characters';
         }
-        if (preg_match('/[\x00-\x1F\x7F]/', $nasname)) {
+        if (!isset($binaryFields['nasname']) && preg_match('/[\x00-\x1F\x7F]/', $nasname)) {
             $errors[] = 'nasname contains control characters';
         }
     }
@@ -162,18 +186,18 @@ function nas_backup_normalize_entry($entry, $row_number) {
         $secret = '';
     } elseif (nas_backup_string_length($secret) > 60) {
         $errors[] = 'secret exceeds 60 characters';
-    } elseif (preg_match('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', $secret)) {
+    } elseif (!isset($binaryFields['secret']) && preg_match('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', $secret)) {
         $errors[] = 'secret contains control characters';
     }
 
-    $shortname = nas_backup_normalize_optional_string($entry['shortname'] ?? null, 'shortname', 32, $errors);
+    $shortname = nas_backup_normalize_optional_string($entry['shortname'] ?? null, 'shortname', 32, $errors, isset($binaryFields['shortname']));
     $typeValue = array_key_exists('type', $entry) ? $entry['type'] : 'other';
-    $type = nas_backup_normalize_optional_string($typeValue, 'type', 30, $errors);
-    $server = nas_backup_normalize_optional_string($entry['server'] ?? null, 'server', 64, $errors);
-    $community = nas_backup_normalize_optional_string($entry['community'] ?? null, 'community', 50, $errors);
-    $description = nas_backup_normalize_optional_string($entry['description'] ?? null, 'description', 200, $errors);
+    $type = nas_backup_normalize_optional_string($typeValue, 'type', 30, $errors, isset($binaryFields['type']));
+    $server = nas_backup_normalize_optional_string($entry['server'] ?? null, 'server', 64, $errors, isset($binaryFields['server']));
+    $community = nas_backup_normalize_optional_string($entry['community'] ?? null, 'community', 50, $errors, isset($binaryFields['community']));
+    $description = nas_backup_normalize_optional_string($entry['description'] ?? null, 'description', 200, $errors, isset($binaryFields['description']));
 
-    if ($type !== null && trim($type) === '') {
+    if (!$preserveValues && $type !== null && trim($type) === '') {
         $type = 'other';
     }
 
@@ -244,8 +268,14 @@ function nas_backup_parse_document($contents) {
     $rows = array();
     foreach ($document['nas'] as $index => $entry) {
         $decodeErrors = array();
-        $entry = nas_backup_decode_entry($entry, $version, $decodeErrors);
-        $row = nas_backup_normalize_entry($entry, $index + 1);
+        $binaryFields = array();
+        $entry = nas_backup_decode_entry($entry, $version, $decodeErrors, $binaryFields);
+        $row = nas_backup_normalize_entry(
+            $entry,
+            $index + 1,
+            $version === NAS_BACKUP_BINARY_VERSION,
+            $binaryFields
+        );
         $row['errors'] = array_values(array_unique(array_merge($decodeErrors, $row['errors'])));
         $rows[] = $row;
     }

--- a/app/operators/include/management/nasImportExport.php
+++ b/app/operators/include/management/nasImportExport.php
@@ -10,11 +10,101 @@ if (strpos($_SERVER['PHP_SELF'] ?? '', '/include/management/nasImportExport.php'
 
 const NAS_BACKUP_FORMAT = 'daloradius-nas-backup';
 const NAS_BACKUP_VERSION = 1;
+const NAS_BACKUP_BINARY_VERSION = 2;
 const NAS_BACKUP_MAX_BYTES = 2097152;
 const NAS_BACKUP_MAX_ENTRIES = 5000;
 
+function nas_backup_lock_name($dbSocket, $table) {
+    $database = $dbSocket->getOne('SELECT DATABASE()');
+    if (DB::isError($database) || !is_string($database) || $database === '') {
+        return false;
+    }
+
+    return 'daloradius:nas:' . substr(hash('sha256', $database . "\0" . $table), 0, 40);
+}
+
+function nas_backup_acquire_lock($dbSocket, $table, $timeout) {
+    $lockName = nas_backup_lock_name($dbSocket, $table);
+    if ($lockName === false) {
+        return array('name' => '', 'acquired' => false, 'error' => true);
+    }
+
+    $result = $dbSocket->getOne(sprintf(
+        "SELECT GET_LOCK('%s', %d)",
+        $dbSocket->escapeSimple($lockName),
+        max(0, intval($timeout))
+    ));
+
+    return array(
+        'name' => $lockName,
+        'acquired' => !DB::isError($result) && intval($result) === 1,
+        'error' => DB::isError($result),
+    );
+}
+
+function nas_backup_release_lock($dbSocket, $lockName) {
+    if (!is_string($lockName) || $lockName === '') {
+        return false;
+    }
+
+    $result = $dbSocket->getOne(sprintf(
+        "SELECT RELEASE_LOCK('%s')",
+        $dbSocket->escapeSimple($lockName)
+    ));
+    return !DB::isError($result) && intval($result) === 1;
+}
+
+function nas_backup_is_valid_utf8($value) {
+    return !is_string($value) || preg_match('//u', $value) === 1;
+}
+
+function nas_backup_encode_export_value($value, &$usesBinaryEncoding) {
+    if (!is_string($value) || nas_backup_is_valid_utf8($value)) {
+        return $value;
+    }
+
+    $usesBinaryEncoding = true;
+    return array(
+        'encoding' => 'base64',
+        'data' => base64_encode($value),
+    );
+}
+
+function nas_backup_decode_entry($entry, $version, &$errors) {
+    if (!is_array($entry) || $version !== NAS_BACKUP_BINARY_VERSION) {
+        return $entry;
+    }
+
+    $fields = array('nasname', 'shortname', 'type', 'secret', 'server', 'community', 'description');
+    foreach ($fields as $field) {
+        if (!array_key_exists($field, $entry) || !is_array($entry[$field])) {
+            continue;
+        }
+
+        $encoded = $entry[$field];
+        if (($encoded['encoding'] ?? '') !== 'base64' || !is_string($encoded['data'] ?? null)) {
+            $errors[] = sprintf('%s has an invalid binary encoding descriptor', $field);
+            $entry[$field] = null;
+            continue;
+        }
+
+        $decoded = base64_decode($encoded['data'], true);
+        if ($decoded === false) {
+            $errors[] = sprintf('%s contains invalid Base64 data', $field);
+            $entry[$field] = null;
+            continue;
+        }
+        $entry[$field] = $decoded;
+    }
+
+    return $entry;
+}
+
 function nas_backup_string_length($value) {
-    return function_exists('mb_strlen') ? mb_strlen($value, 'UTF-8') : strlen($value);
+    if (function_exists('mb_strlen') && nas_backup_is_valid_utf8($value)) {
+        return mb_strlen($value, 'UTF-8');
+    }
+    return strlen($value);
 }
 
 function nas_backup_normalize_optional_string($value, $field, $max_length, &$errors) {
@@ -133,8 +223,13 @@ function nas_backup_parse_document($contents) {
     if (($document['format'] ?? '') !== NAS_BACKUP_FORMAT) {
         $errors[] = sprintf('Unsupported backup format; expected %s', NAS_BACKUP_FORMAT);
     }
-    if (($document['version'] ?? null) !== NAS_BACKUP_VERSION) {
-        $errors[] = sprintf('Unsupported backup version; expected %d', NAS_BACKUP_VERSION);
+    $version = $document['version'] ?? null;
+    if (!in_array($version, array(NAS_BACKUP_VERSION, NAS_BACKUP_BINARY_VERSION), true)) {
+        $errors[] = sprintf(
+            'Unsupported backup version; expected %d or %d',
+            NAS_BACKUP_VERSION,
+            NAS_BACKUP_BINARY_VERSION
+        );
     }
     if (!isset($document['nas']) || !is_array($document['nas']) ||
         array_values($document['nas']) !== $document['nas']) {
@@ -148,7 +243,11 @@ function nas_backup_parse_document($contents) {
 
     $rows = array();
     foreach ($document['nas'] as $index => $entry) {
-        $rows[] = nas_backup_normalize_entry($entry, $index + 1);
+        $decodeErrors = array();
+        $entry = nas_backup_decode_entry($entry, $version, $decodeErrors);
+        $row = nas_backup_normalize_entry($entry, $index + 1);
+        $row['errors'] = array_values(array_unique(array_merge($decodeErrors, $row['errors'])));
+        $rows[] = $row;
     }
 
     return array('rows' => $rows, 'errors' => $errors);

--- a/app/operators/include/management/nasImportExport.php
+++ b/app/operators/include/management/nasImportExport.php
@@ -11,7 +11,7 @@ if (strpos($_SERVER['PHP_SELF'] ?? '', '/include/management/nasImportExport.php'
 const NAS_BACKUP_FORMAT = 'daloradius-nas-backup';
 const NAS_BACKUP_VERSION = 1;
 const NAS_BACKUP_BINARY_VERSION = 2;
-const NAS_BACKUP_MAX_BYTES = 8388608;
+const NAS_BACKUP_MAX_BYTES = 2097152;
 const NAS_BACKUP_MAX_ENTRIES = 5000;
 
 function nas_backup_lock_name($dbSocket, $table) {

--- a/app/operators/include/management/nasImportExport.php
+++ b/app/operators/include/management/nasImportExport.php
@@ -77,12 +77,13 @@ function nas_backup_normalize_entry($entry, $row_number) {
     }
 
     $shortname = nas_backup_normalize_optional_string($entry['shortname'] ?? null, 'shortname', 32, $errors);
-    $type = nas_backup_normalize_optional_string($entry['type'] ?? 'other', 'type', 30, $errors);
+    $typeValue = array_key_exists('type', $entry) ? $entry['type'] : 'other';
+    $type = nas_backup_normalize_optional_string($typeValue, 'type', 30, $errors);
     $server = nas_backup_normalize_optional_string($entry['server'] ?? null, 'server', 64, $errors);
     $community = nas_backup_normalize_optional_string($entry['community'] ?? null, 'community', 50, $errors);
     $description = nas_backup_normalize_optional_string($entry['description'] ?? null, 'description', 200, $errors);
 
-    if ($type === null || trim($type) === '') {
+    if ($type !== null && trim($type) === '') {
         $type = 'other';
     }
 
@@ -135,7 +136,8 @@ function nas_backup_parse_document($contents) {
     if (($document['version'] ?? null) !== NAS_BACKUP_VERSION) {
         $errors[] = sprintf('Unsupported backup version; expected %d', NAS_BACKUP_VERSION);
     }
-    if (!isset($document['nas']) || !is_array($document['nas'])) {
+    if (!isset($document['nas']) || !is_array($document['nas']) ||
+        array_values($document['nas']) !== $document['nas']) {
         $errors[] = 'The backup does not contain a NAS list';
         return array('rows' => array(), 'errors' => $errors);
     }
@@ -150,4 +152,19 @@ function nas_backup_parse_document($contents) {
     }
 
     return array('rows' => $rows, 'errors' => $errors);
+}
+
+function nas_import_is_duplicate_error($error) {
+    if (!DB::isError($error)) {
+        return false;
+    }
+
+    $details = $error->getMessage();
+    foreach (array('getUserInfo', 'getDebugInfo') as $method) {
+        if (method_exists($error, $method)) {
+            $details .= ' ' . $error->{$method}();
+        }
+    }
+
+    return preg_match('/(?:nativecode[=:\\s]*1062|duplicate entry|duplicate key|unique constraint)/i', $details) === 1;
 }

--- a/app/operators/include/management/nasImportExport.php
+++ b/app/operators/include/management/nasImportExport.php
@@ -1,0 +1,153 @@
+<?php
+/*
+ * Shared helpers for daloRADIUS NAS JSON import/export.
+ */
+
+if (strpos($_SERVER['PHP_SELF'] ?? '', '/include/management/nasImportExport.php') !== false) {
+    http_response_code(404);
+    exit;
+}
+
+const NAS_BACKUP_FORMAT = 'daloradius-nas-backup';
+const NAS_BACKUP_VERSION = 1;
+const NAS_BACKUP_MAX_BYTES = 2097152;
+const NAS_BACKUP_MAX_ENTRIES = 5000;
+
+function nas_backup_string_length($value) {
+    return function_exists('mb_strlen') ? mb_strlen($value, 'UTF-8') : strlen($value);
+}
+
+function nas_backup_normalize_optional_string($value, $field, $max_length, &$errors) {
+    if ($value === null) {
+        return null;
+    }
+
+    if (!is_string($value)) {
+        $errors[] = sprintf('%s must be a string or null', $field);
+        return null;
+    }
+
+    if (preg_match('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', $value)) {
+        $errors[] = sprintf('%s contains control characters', $field);
+    }
+
+    if (nas_backup_string_length($value) > $max_length) {
+        $errors[] = sprintf('%s exceeds %d characters', $field, $max_length);
+    }
+
+    return $value;
+}
+
+function nas_backup_normalize_entry($entry, $row_number) {
+    $errors = array();
+
+    if (!is_array($entry)) {
+        return array(
+            'row_number' => $row_number,
+            'data' => array('nasname' => sprintf('Row %d', $row_number)),
+            'errors' => array('NAS entry must be a JSON object'),
+        );
+    }
+
+    $nasname = $entry['nasname'] ?? null;
+    if (!is_string($nasname)) {
+        $errors[] = 'nasname must be a string';
+        $nasname = '';
+    } else {
+        $nasname = trim($nasname);
+        if ($nasname === '') {
+            $errors[] = 'nasname is required';
+        }
+        if (nas_backup_string_length($nasname) > 128) {
+            $errors[] = 'nasname exceeds 128 characters';
+        }
+        if (preg_match('/[\x00-\x1F\x7F]/', $nasname)) {
+            $errors[] = 'nasname contains control characters';
+        }
+    }
+
+    $secret = $entry['secret'] ?? null;
+    if (!is_string($secret) || $secret === '') {
+        $errors[] = 'secret is required and must be a string';
+        $secret = '';
+    } elseif (nas_backup_string_length($secret) > 60) {
+        $errors[] = 'secret exceeds 60 characters';
+    } elseif (preg_match('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/', $secret)) {
+        $errors[] = 'secret contains control characters';
+    }
+
+    $shortname = nas_backup_normalize_optional_string($entry['shortname'] ?? null, 'shortname', 32, $errors);
+    $type = nas_backup_normalize_optional_string($entry['type'] ?? 'other', 'type', 30, $errors);
+    $server = nas_backup_normalize_optional_string($entry['server'] ?? null, 'server', 64, $errors);
+    $community = nas_backup_normalize_optional_string($entry['community'] ?? null, 'community', 50, $errors);
+    $description = nas_backup_normalize_optional_string($entry['description'] ?? null, 'description', 200, $errors);
+
+    if ($type === null || trim($type) === '') {
+        $type = 'other';
+    }
+
+    $ports = $entry['ports'] ?? null;
+    if ($ports === '') {
+        $ports = null;
+    }
+    if ($ports !== null) {
+        if (is_int($ports)) {
+            // already normalized
+        } elseif (is_string($ports) && preg_match('/^[0-9]+$/', $ports)) {
+            $ports = intval($ports);
+        } else {
+            $errors[] = 'ports must be an integer or null';
+            $ports = null;
+        }
+
+        if ($ports !== null && ($ports < 0 || $ports > 99999)) {
+            $errors[] = 'ports must be between 0 and 99999';
+        }
+    }
+
+    return array(
+        'row_number' => $row_number,
+        'data' => array(
+            'nasname' => $nasname,
+            'shortname' => $shortname,
+            'type' => $type,
+            'ports' => $ports,
+            'secret' => $secret,
+            'server' => $server,
+            'community' => $community,
+            'description' => $description,
+        ),
+        'errors' => array_values(array_unique($errors)),
+    );
+}
+
+function nas_backup_parse_document($contents) {
+    $document = json_decode($contents, true);
+
+    if (!is_array($document)) {
+        return array('rows' => array(), 'errors' => array('The uploaded file is not valid JSON'));
+    }
+
+    $errors = array();
+    if (($document['format'] ?? '') !== NAS_BACKUP_FORMAT) {
+        $errors[] = sprintf('Unsupported backup format; expected %s', NAS_BACKUP_FORMAT);
+    }
+    if (($document['version'] ?? null) !== NAS_BACKUP_VERSION) {
+        $errors[] = sprintf('Unsupported backup version; expected %d', NAS_BACKUP_VERSION);
+    }
+    if (!isset($document['nas']) || !is_array($document['nas'])) {
+        $errors[] = 'The backup does not contain a NAS list';
+        return array('rows' => array(), 'errors' => $errors);
+    }
+    if (count($document['nas']) > NAS_BACKUP_MAX_ENTRIES) {
+        $errors[] = sprintf('The backup contains more than %d NAS entries', NAS_BACKUP_MAX_ENTRIES);
+        return array('rows' => array(), 'errors' => $errors);
+    }
+
+    $rows = array();
+    foreach ($document['nas'] as $index => $entry) {
+        $rows[] = nas_backup_normalize_entry($entry, $index + 1);
+    }
+
+    return array('rows' => $rows, 'errors' => $errors);
+}

--- a/app/operators/mng-rad-nas-del.php
+++ b/app/operators/mng-rad-nas-del.php
@@ -40,6 +40,7 @@
     if ($csrfValid) {
         $dbSocket->setErrorHandling(PEAR_ERROR_RETURN);
         $nasLock = nas_backup_acquire_lock($dbSocket, $configValues['CONFIG_DB_TBL_RADNAS'], 30);
+        $dbSocket->setErrorHandling(PEAR_ERROR_CALLBACK, 'errorHandler');
     }
 
     // build a whitelist of existing NAS names; only these can be deleted
@@ -117,10 +118,11 @@
         }
     }
 
-    if ($nasLock['acquired'] && !nas_backup_release_lock($dbSocket, $nasLock['name'])) {
-        $logAction .= 'NAS advisory lock release could not be confirmed on page: ';
-    }
-    if ($csrfValid) {
+    if ($nasLock['acquired']) {
+        $dbSocket->setErrorHandling(PEAR_ERROR_RETURN);
+        if (!nas_backup_release_lock($dbSocket, $nasLock['name'])) {
+            $logAction .= 'NAS advisory lock release could not be confirmed on page: ';
+        }
         $dbSocket->setErrorHandling(PEAR_ERROR_CALLBACK, 'errorHandler');
     }
     include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);

--- a/app/operators/mng-rad-nas-del.php
+++ b/app/operators/mng-rad-nas-del.php
@@ -26,6 +26,7 @@
     $operator = $_SESSION['operator_user'];
 
     include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'check_operator_perm.php' ]);
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'nasImportExport.php' ]);
 
     // init logging variables
     $logAction = "";
@@ -33,6 +34,13 @@
     $log = "visited page: ";
 
     include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
+    $nasLock = array('name' => '', 'acquired' => false, 'error' => false);
+    $csrfValid = $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['csrf_token']) &&
+                 dalo_check_csrf_token($_POST['csrf_token']);
+    if ($csrfValid) {
+        $dbSocket->setErrorHandling(PEAR_ERROR_RETURN);
+        $nasLock = nas_backup_acquire_lock($dbSocket, $configValues['CONFIG_DB_TBL_RADNAS'], 30);
+    }
 
     // build a whitelist of existing NAS names; only these can be deleted
     $valid_values = array();
@@ -65,7 +73,7 @@
     }
 
     if ($_SERVER['REQUEST_METHOD'] === 'POST' &&
-        array_key_exists('csrf_token', $_POST) && isset($_POST['csrf_token']) && dalo_check_csrf_token($_POST['csrf_token'])) {
+        $csrfValid && $nasLock['acquired']) {
         $deleted_values = array();
 
         if (count($selected_values) > 0) {
@@ -101,11 +109,20 @@
     } else {
         $success = false;
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            $failureMsg = "CSRF token error";
+            $failureMsg = $csrfValid
+                ? ($nasLock['error'] ? 'Unable to coordinate the NAS change; please retry'
+                                     : 'Another NAS change is currently running; please retry in a moment')
+                : 'CSRF token error';
             $logAction .= "$failureMsg on page: ";
         }
     }
 
+    if ($nasLock['acquired'] && !nas_backup_release_lock($dbSocket, $nasLock['name'])) {
+        $logAction .= 'NAS advisory lock release could not be confirmed on page: ';
+    }
+    if ($csrfValid) {
+        $dbSocket->setErrorHandling(PEAR_ERROR_CALLBACK, 'errorHandler');
+    }
     include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
 
     include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LANG'], 'main.php' ]);

--- a/app/operators/mng-rad-nas-edit.php
+++ b/app/operators/mng-rad-nas-edit.php
@@ -29,6 +29,7 @@
     include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LANG'], 'main.php' ]);
     include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'validation.php' ]);
     include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'layout.php' ]);
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'nasImportExport.php' ]);
 
     // init logging variables
     $log = "visited page: ";
@@ -36,6 +37,13 @@
     $logDebugSQL = "";
 
     include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
+    $nasLock = array('name' => '', 'acquired' => false, 'error' => false);
+    $csrfValid = $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['csrf_token']) &&
+                 dalo_check_csrf_token($_POST['csrf_token']);
+    if ($csrfValid) {
+        $dbSocket->setErrorHandling(PEAR_ERROR_RETURN);
+        $nasLock = nas_backup_acquire_lock($dbSocket, $configValues['CONFIG_DB_TBL_RADNAS'], 30);
+    }
 
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $nasname = (array_key_exists('nasname', $_POST) && !empty(str_replace("%", "", trim($_POST['nasname']))))
@@ -63,7 +71,7 @@
 
 
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-        if (array_key_exists('csrf_token', $_POST) && isset($_POST['csrf_token']) && dalo_check_csrf_token($_POST['csrf_token'])) {
+        if ($csrfValid && $nasLock['acquired']) {
             $secret = (array_key_exists('secret', $_POST) && !empty(str_replace("%", "", trim($_POST['secret']))))
                     ? str_replace("%", "", trim($_POST['secret'])) : "";
 
@@ -133,8 +141,10 @@
             }
 
         } else {
-            // csrf
-            $failureMsg = "CSRF token error";
+            $failureMsg = $csrfValid
+                ? ($nasLock['error'] ? 'Unable to coordinate the NAS change; please retry'
+                                     : 'Another NAS change is currently running; please retry in a moment')
+                : 'CSRF token error';
             $logAction .= "$failureMsg on page: ";
         }
     }
@@ -156,6 +166,12 @@
         $logAction .= sprintf("Requested editing invalid NAS (%s) on page: ", $failureMsg);
     }
 
+    if ($nasLock['acquired'] && !nas_backup_release_lock($dbSocket, $nasLock['name'])) {
+        $logAction .= 'NAS advisory lock release could not be confirmed on page: ';
+    }
+    if ($csrfValid) {
+        $dbSocket->setErrorHandling(PEAR_ERROR_CALLBACK, 'errorHandler');
+    }
     include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
 
     // print HTML prologue

--- a/app/operators/mng-rad-nas-edit.php
+++ b/app/operators/mng-rad-nas-edit.php
@@ -43,6 +43,7 @@
     if ($csrfValid) {
         $dbSocket->setErrorHandling(PEAR_ERROR_RETURN);
         $nasLock = nas_backup_acquire_lock($dbSocket, $configValues['CONFIG_DB_TBL_RADNAS'], 30);
+        $dbSocket->setErrorHandling(PEAR_ERROR_CALLBACK, 'errorHandler');
     }
 
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -166,10 +167,11 @@
         $logAction .= sprintf("Requested editing invalid NAS (%s) on page: ", $failureMsg);
     }
 
-    if ($nasLock['acquired'] && !nas_backup_release_lock($dbSocket, $nasLock['name'])) {
-        $logAction .= 'NAS advisory lock release could not be confirmed on page: ';
-    }
-    if ($csrfValid) {
+    if ($nasLock['acquired']) {
+        $dbSocket->setErrorHandling(PEAR_ERROR_RETURN);
+        if (!nas_backup_release_lock($dbSocket, $nasLock['name'])) {
+            $logAction .= 'NAS advisory lock release could not be confirmed on page: ';
+        }
         $dbSocket->setErrorHandling(PEAR_ERROR_CALLBACK, 'errorHandler');
     }
     include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);

--- a/app/operators/mng-rad-nas-export.php
+++ b/app/operators/mng-rad-nas-export.php
@@ -20,7 +20,10 @@ include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MAN
 include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
 
 $sql = sprintf(
-    "SELECT nasname, shortname, type, ports, secret, server, community, description FROM %s ORDER BY nasname ASC",
+    "SELECT HEX(nasname) AS nasname_hex, HEX(shortname) AS shortname_hex, HEX(type) AS type_hex,
+            ports, HEX(secret) AS secret_hex, HEX(server) AS server_hex,
+            HEX(community) AS community_hex, HEX(description) AS description_hex
+       FROM %s ORDER BY nasname ASC",
     $configValues['CONFIG_DB_TBL_RADNAS']
 );
 $res = $dbSocket->query($sql);
@@ -40,24 +43,40 @@ $encodedFields = array();
 $rowNumber = 0;
 while ($row = $res->fetchRow(DB_FETCHMODE_ASSOC)) {
     $rowNumber++;
+    $decoded = array();
+    foreach (array('nasname', 'shortname', 'type', 'secret', 'server', 'community', 'description') as $field) {
+        $decoded[$field] = nas_backup_decode_database_hex($row[$field . '_hex']);
+        if ($decoded[$field] === false) {
+            include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
+            http_response_code(500);
+            header('Content-Type: application/json; charset=UTF-8');
+            header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+            echo json_encode(array('error' => sprintf('Unable to encode NAS row %d field %s', $rowNumber, $field)));
+            exit;
+        }
+    }
     $entry = array(
-        'nasname' => nas_backup_encode_export_value($row['nasname'], $usesBinaryEncoding),
-        'shortname' => nas_backup_encode_export_value($row['shortname'], $usesBinaryEncoding),
-        'type' => nas_backup_encode_export_value($row['type'], $usesBinaryEncoding),
+        'nasname' => nas_backup_encode_export_value($decoded['nasname'], $usesBinaryEncoding),
+        'shortname' => nas_backup_encode_export_value($decoded['shortname'], $usesBinaryEncoding),
+        'type' => nas_backup_encode_export_value($decoded['type'], $usesBinaryEncoding),
         'ports' => ($row['ports'] === null) ? null : intval($row['ports']),
-        'secret' => nas_backup_encode_export_value($row['secret'], $usesBinaryEncoding),
-        'server' => nas_backup_encode_export_value($row['server'], $usesBinaryEncoding),
-        'community' => nas_backup_encode_export_value($row['community'], $usesBinaryEncoding),
-        'description' => nas_backup_encode_export_value($row['description'], $usesBinaryEncoding),
+        'secret' => nas_backup_encode_export_value($decoded['secret'], $usesBinaryEncoding),
+        'server' => nas_backup_encode_export_value($decoded['server'], $usesBinaryEncoding),
+        'community' => nas_backup_encode_export_value($decoded['community'], $usesBinaryEncoding),
+        'description' => nas_backup_encode_export_value($decoded['description'], $usesBinaryEncoding),
     );
     $rowEncodedFields = array();
     foreach ($entry as $field => $value) {
         if (is_array($value) && ($value['encoding'] ?? '') === 'base64') {
-            $rowEncodedFields[] = $field;
+            $rowEncodedFields[] = array(
+                'row' => $rowNumber,
+                'field' => $field,
+                'byte_length' => $value['byte_length'],
+            );
         }
     }
     if (count($rowEncodedFields) > 0) {
-        $encodedFields[] = array('row' => $rowNumber, 'fields' => $rowEncodedFields);
+        $encodedFields = array_merge($encodedFields, $rowEncodedFields);
     }
     $nas[] = $entry;
 }

--- a/app/operators/mng-rad-nas-export.php
+++ b/app/operators/mng-rad-nas-export.php
@@ -59,6 +59,19 @@ $document = array(
     'nas' => $nas,
 );
 
+$json = json_encode(
+    $document,
+    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+);
+
+if ($json === false) {
+    http_response_code(500);
+    header('Content-Type: application/json; charset=UTF-8');
+    header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+    echo json_encode(array('error' => 'Unable to export the NAS list because it contains invalid UTF-8'));
+    exit;
+}
+
 $filename = sprintf('daloradius-nas-%s.json', gmdate('Ymd-His'));
 header('Content-Type: application/json; charset=UTF-8');
 header(sprintf('Content-Disposition: attachment; filename="%s"', $filename));
@@ -66,8 +79,5 @@ header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
 header('Pragma: no-cache');
 header('X-Content-Type-Options: nosniff');
 
-echo json_encode(
-    $document,
-    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE
-);
+echo $json;
 exit;

--- a/app/operators/mng-rad-nas-export.php
+++ b/app/operators/mng-rad-nas-export.php
@@ -35,29 +35,46 @@ if (DB::isError($res)) {
 }
 
 $nas = array();
+$usesBinaryEncoding = false;
+$encodedFields = array();
+$rowNumber = 0;
 while ($row = $res->fetchRow(DB_FETCHMODE_ASSOC)) {
-    $nas[] = array(
-        'nasname' => $row['nasname'],
-        'shortname' => $row['shortname'],
-        'type' => $row['type'],
+    $rowNumber++;
+    $entry = array(
+        'nasname' => nas_backup_encode_export_value($row['nasname'], $usesBinaryEncoding),
+        'shortname' => nas_backup_encode_export_value($row['shortname'], $usesBinaryEncoding),
+        'type' => nas_backup_encode_export_value($row['type'], $usesBinaryEncoding),
         'ports' => ($row['ports'] === null) ? null : intval($row['ports']),
-        'secret' => $row['secret'],
-        'server' => $row['server'],
-        'community' => $row['community'],
-        'description' => $row['description'],
+        'secret' => nas_backup_encode_export_value($row['secret'], $usesBinaryEncoding),
+        'server' => nas_backup_encode_export_value($row['server'], $usesBinaryEncoding),
+        'community' => nas_backup_encode_export_value($row['community'], $usesBinaryEncoding),
+        'description' => nas_backup_encode_export_value($row['description'], $usesBinaryEncoding),
     );
+    $rowEncodedFields = array();
+    foreach ($entry as $field => $value) {
+        if (is_array($value) && ($value['encoding'] ?? '') === 'base64') {
+            $rowEncodedFields[] = $field;
+        }
+    }
+    if (count($rowEncodedFields) > 0) {
+        $encodedFields[] = array('row' => $rowNumber, 'fields' => $rowEncodedFields);
+    }
+    $nas[] = $entry;
 }
 
 include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
 
 $document = array(
     'format' => NAS_BACKUP_FORMAT,
-    'version' => NAS_BACKUP_VERSION,
+    'version' => $usesBinaryEncoding ? NAS_BACKUP_BINARY_VERSION : NAS_BACKUP_VERSION,
     'exported_at' => gmdate('c'),
     'includes_secrets' => true,
     'count' => count($nas),
     'nas' => $nas,
 );
+if ($usesBinaryEncoding) {
+    $document['encoded_fields'] = $encodedFields;
+}
 
 $json = json_encode(
     $document,
@@ -68,7 +85,7 @@ if ($json === false) {
     http_response_code(500);
     header('Content-Type: application/json; charset=UTF-8');
     header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
-    echo json_encode(array('error' => 'Unable to export the NAS list because it contains invalid UTF-8'));
+    echo json_encode(array('error' => 'Unable to encode the NAS backup'));
     exit;
 }
 

--- a/app/operators/mng-rad-nas-export.php
+++ b/app/operators/mng-rad-nas-export.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ *********************************************************************************************************
+ * daloRADIUS - RADIUS Web Platform
+ * Copyright (C) 2007 - Liran Tal <liran@lirantal.com> All Rights Reserved.
+ *********************************************************************************************************
+ * Export the complete NAS/client list as a versioned JSON backup.
+ *********************************************************************************************************
+ */
+
+include_once implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', 'common', 'includes', 'config_read.php' ]);
+include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'checklogin.php' ]);
+$operator = $_SESSION['operator_user'];
+
+// This helper endpoint uses the same permission as the NAS list page.
+$operator_perm_file = 'mng_rad_nas_list';
+$operator_perm_deny_http_status = 403;
+include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'check_operator_perm.php' ]);
+include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'nasImportExport.php' ]);
+include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
+
+$sql = sprintf(
+    "SELECT nasname, shortname, type, ports, secret, server, community, description FROM %s ORDER BY nasname ASC",
+    $configValues['CONFIG_DB_TBL_RADNAS']
+);
+$res = $dbSocket->query($sql);
+
+if (DB::isError($res)) {
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
+    http_response_code(500);
+    header('Content-Type: application/json; charset=UTF-8');
+    header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+    echo json_encode(array('error' => 'Unable to export the NAS list'));
+    exit;
+}
+
+$nas = array();
+while ($row = $res->fetchRow(DB_FETCHMODE_ASSOC)) {
+    $nas[] = array(
+        'nasname' => $row['nasname'],
+        'shortname' => $row['shortname'],
+        'type' => $row['type'],
+        'ports' => ($row['ports'] === null) ? null : intval($row['ports']),
+        'secret' => $row['secret'],
+        'server' => $row['server'],
+        'community' => $row['community'],
+        'description' => $row['description'],
+    );
+}
+
+include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
+
+$document = array(
+    'format' => NAS_BACKUP_FORMAT,
+    'version' => NAS_BACKUP_VERSION,
+    'exported_at' => gmdate('c'),
+    'includes_secrets' => true,
+    'count' => count($nas),
+    'nas' => $nas,
+);
+
+$filename = sprintf('daloradius-nas-%s.json', gmdate('Ymd-His'));
+header('Content-Type: application/json; charset=UTF-8');
+header(sprintf('Content-Disposition: attachment; filename="%s"', $filename));
+header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+header('Pragma: no-cache');
+header('X-Content-Type-Options: nosniff');
+
+echo json_encode(
+    $document,
+    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE
+);
+exit;

--- a/app/operators/mng-rad-nas-import.php
+++ b/app/operators/mng-rad-nas-import.php
@@ -1,0 +1,419 @@
+<?php
+/*
+ *********************************************************************************************************
+ * daloRADIUS - RADIUS Web Platform
+ * Copyright (C) 2007 - Liran Tal <liran@lirantal.com> All Rights Reserved.
+ *********************************************************************************************************
+ * Preview and add NAS/client entries from a versioned JSON backup.
+ *********************************************************************************************************
+ */
+
+include_once implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', 'common', 'includes', 'config_read.php' ]);
+include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'checklogin.php' ]);
+$operator = $_SESSION['operator_user'];
+
+// This page uses the same permission as the NAS list page.
+$operator_perm_file = 'mng_rad_nas_list';
+include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'check_operator_perm.php' ]);
+include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LANG'], 'main.php' ]);
+include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'validation.php' ]);
+include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'layout.php' ]);
+include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'nasImportExport.php' ]);
+
+$log = 'visited page: ';
+$logAction = '';
+$logDebugSQL = '';
+$previewRows = array();
+$resultRows = array();
+$previewToken = '';
+$readyCount = 0;
+$skippedCount = 0;
+$invalidCount = 0;
+
+function nas_import_name_key($nasname) {
+    $nasname = (string)$nasname;
+    return function_exists('mb_strtolower') ? mb_strtolower($nasname, 'UTF-8') : strtolower($nasname);
+}
+
+function nas_import_existing_names($dbSocket, $table) {
+    $sql = sprintf('SELECT nasname FROM %s', $table);
+    $res = $dbSocket->query($sql);
+    if (DB::isError($res)) {
+        return false;
+    }
+
+    $names = array();
+    while ($row = $res->fetchRow()) {
+        $names[nas_import_name_key($row[0])] = true;
+    }
+    return $names;
+}
+
+function nas_import_badge($status) {
+    switch ($status) {
+        case 'ready':
+            return '<span class="badge text-bg-success">Ready to import</span>';
+        case 'imported':
+            return '<span class="badge text-bg-success">Imported</span>';
+        case 'skipped':
+            return '<span class="badge text-bg-warning">Skipped</span>';
+        default:
+            return '<span class="badge text-bg-danger">Invalid</span>';
+    }
+}
+
+function nas_import_render_rows($rows, $table_id) {
+    if (count($rows) === 0) {
+        return;
+    }
+
+    printf(
+        '<div class="row g-2 mb-2"><div class="col-12 col-md-8"><input type="search" class="form-control nas-import-search" data-table="%s" placeholder="Filter by NAS name or short name"></div>',
+        htmlspecialchars($table_id, ENT_QUOTES, 'UTF-8')
+    );
+    printf(
+        '<div class="col-12 col-md-4"><select class="form-select nas-import-status" data-table="%s"><option value="">All statuses</option><option value="ready">Ready</option><option value="imported">Imported</option><option value="skipped">Skipped</option><option value="invalid">Invalid</option></select></div></div>',
+        htmlspecialchars($table_id, ENT_QUOTES, 'UTF-8')
+    );
+
+    echo '<div class="table-responsive border rounded nas-import-table-wrap">';
+    printf('<table id="%s" class="table table-striped table-hover table-sm align-middle mb-0">', htmlspecialchars($table_id, ENT_QUOTES, 'UTF-8'));
+    echo '<thead class="table-light"><tr><th>#</th><th>NAS name</th><th>Short name</th><th>Type</th><th>Status</th><th>Information</th></tr></thead><tbody>';
+
+    foreach ($rows as $row) {
+        $data = $row['data'];
+        $status = $row['status'];
+        $information = $row['information'] ?? '';
+        printf(
+            '<tr data-status="%s"><td>%d</td><td><code>%s</code></td><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>',
+            htmlspecialchars($status, ENT_QUOTES, 'UTF-8'),
+            intval($row['row_number']),
+            htmlspecialchars((string)($data['nasname'] ?? ''), ENT_QUOTES, 'UTF-8'),
+            htmlspecialchars((string)($data['shortname'] ?? ''), ENT_QUOTES, 'UTF-8'),
+            htmlspecialchars((string)($data['type'] ?? ''), ENT_QUOTES, 'UTF-8'),
+            nas_import_badge($status),
+            htmlspecialchars($information, ENT_QUOTES, 'UTF-8')
+        );
+    }
+
+    echo '</tbody></table></div>';
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    unset($_SESSION['nas_import_preview']);
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $csrfValid = isset($_POST['csrf_token']) && dalo_check_csrf_token($_POST['csrf_token']);
+    $action = $_POST['nas_import_action'] ?? '';
+
+    if (!$csrfValid) {
+        $failureMsg = 'CSRF token error';
+        $logAction .= 'NAS import rejected due to CSRF validation failure on page: ';
+    } elseif ($action === 'preview') {
+        unset($_SESSION['nas_import_preview']);
+
+        if (!isset($_FILES['nas_backup']) || !is_array($_FILES['nas_backup'])) {
+            $failureMsg = 'Select a daloRADIUS NAS JSON backup file';
+        } elseif ($_FILES['nas_backup']['error'] !== UPLOAD_ERR_OK) {
+            $failureMsg = sprintf('NAS backup upload failed with error code %d', intval($_FILES['nas_backup']['error']));
+        } elseif (intval($_FILES['nas_backup']['size']) <= 0 || intval($_FILES['nas_backup']['size']) > NAS_BACKUP_MAX_BYTES) {
+            $failureMsg = sprintf('NAS backup must be between 1 byte and %d MiB', intval(NAS_BACKUP_MAX_BYTES / 1048576));
+        } elseif (!is_uploaded_file($_FILES['nas_backup']['tmp_name'])) {
+            $failureMsg = 'The NAS backup upload could not be verified';
+        } else {
+            $contents = file_get_contents($_FILES['nas_backup']['tmp_name']);
+            $parsed = nas_backup_parse_document($contents);
+
+            if (count($parsed['errors']) > 0) {
+                $failureMsg = implode('; ', $parsed['errors']);
+            } else {
+                include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
+                $existingNames = nas_import_existing_names($dbSocket, $configValues['CONFIG_DB_TBL_RADNAS']);
+                include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
+
+                if ($existingNames === false) {
+                    $failureMsg = 'Unable to read the current NAS list';
+                } else {
+                    $seenNames = array();
+                    $readyEntries = array();
+                    $excludedRows = array();
+
+                    foreach ($parsed['rows'] as $row) {
+                        $data = $row['data'];
+                        $nasname = (string)($data['nasname'] ?? '');
+                        $nasnameKey = nas_import_name_key($nasname);
+                        $status = 'ready';
+                        $information = 'New NAS name';
+
+                        if (count($row['errors']) > 0) {
+                            $status = 'invalid';
+                            $information = implode('; ', $row['errors']);
+                            $invalidCount++;
+                        } elseif (isset($seenNames[$nasnameKey])) {
+                            $status = 'skipped';
+                            $information = 'Duplicate NAS name in the imported file';
+                            $skippedCount++;
+                        } elseif (isset($existingNames[$nasnameKey])) {
+                            $status = 'skipped';
+                            $information = 'NAS name already exists in daloRADIUS';
+                            $skippedCount++;
+                        } else {
+                            $readyEntries[] = array(
+                                'row_number' => $row['row_number'],
+                                'data' => $data,
+                            );
+                            $readyCount++;
+                        }
+
+                        if ($nasname !== '') {
+                            $seenNames[$nasnameKey] = true;
+                        }
+
+                        $row['status'] = $status;
+                        $row['information'] = $information;
+                        $previewRows[] = $row;
+                        if ($status !== 'ready') {
+                            $excludedRows[] = $row;
+                        }
+                    }
+
+                    $previewToken = bin2hex(random_bytes(16));
+                    $_SESSION['nas_import_preview'] = array(
+                        'token' => $previewToken,
+                        'created_at' => time(),
+                        'entries' => $readyEntries,
+                        'excluded_rows' => $excludedRows,
+                    );
+
+                    $logAction .= sprintf(
+                        'Previewed NAS import with %d ready, %d skipped and %d invalid entries on page: ',
+                        $readyCount,
+                        $skippedCount,
+                        $invalidCount
+                    );
+                }
+            }
+        }
+    } elseif ($action === 'confirm') {
+        $preview = $_SESSION['nas_import_preview'] ?? null;
+        $submittedToken = $_POST['preview_token'] ?? '';
+
+        if (!is_array($preview) || !hash_equals((string)($preview['token'] ?? ''), (string)$submittedToken)) {
+            $failureMsg = 'The NAS import preview is missing or no longer valid';
+        } elseif (time() - intval($preview['created_at'] ?? 0) > 1800) {
+            unset($_SESSION['nas_import_preview']);
+            $failureMsg = 'The NAS import preview has expired; upload the backup again';
+        } else {
+            $entries = $preview['entries'] ?? array();
+            $excludedRows = $preview['excluded_rows'] ?? array();
+            include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
+
+            $transaction = $dbSocket->query('START TRANSACTION');
+            $importError = DB::isError($transaction);
+            $insertedRows = array();
+            $skippedRows = array();
+
+            $insertSql = sprintf(
+                'INSERT INTO %s (nasname, shortname, type, ports, secret, server, community, description) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+                $configValues['CONFIG_DB_TBL_RADNAS']
+            );
+            $prepared = $dbSocket->prepare($insertSql);
+
+            foreach ($entries as $index => $candidate) {
+                if ($importError) {
+                    break;
+                }
+
+                $entry = $candidate['data'];
+                $rowNumber = intval($candidate['row_number']);
+                $existsSql = sprintf(
+                    "SELECT COUNT(id) FROM %s WHERE nasname='%s'",
+                    $configValues['CONFIG_DB_TBL_RADNAS'],
+                    $dbSocket->escapeSimple($entry['nasname'])
+                );
+                $exists = $dbSocket->getOne($existsSql);
+
+                if (DB::isError($exists)) {
+                    $importError = true;
+                    break;
+                }
+
+                if (intval($exists) > 0) {
+                    $skippedRows[] = array(
+                        'row_number' => $rowNumber,
+                        'data' => $entry,
+                        'status' => 'skipped',
+                        'information' => 'NAS name was added after the preview and already exists',
+                    );
+                    continue;
+                }
+
+                $res = $dbSocket->execute($prepared, array(
+                    $entry['nasname'],
+                    $entry['shortname'],
+                    $entry['type'],
+                    $entry['ports'],
+                    $entry['secret'],
+                    $entry['server'],
+                    $entry['community'],
+                    $entry['description'],
+                ));
+
+                if (DB::isError($res)) {
+                    $importError = true;
+                    break;
+                }
+
+                $insertedRows[] = array(
+                    'row_number' => $rowNumber,
+                    'data' => $entry,
+                    'status' => 'imported',
+                    'information' => 'NAS added successfully',
+                );
+            }
+
+            if ($importError) {
+                $dbSocket->query('ROLLBACK');
+                $failureMsg = 'The NAS import failed and all new rows were rolled back';
+                foreach ($entries as $candidate) {
+                    $resultRows[] = array(
+                        'row_number' => intval($candidate['row_number']),
+                        'data' => $candidate['data'],
+                        'status' => 'invalid',
+                        'information' => 'Not imported because the transaction was rolled back',
+                    );
+                }
+                $logAction .= 'NAS import failed and was rolled back on page: ';
+            } else {
+                $commit = $dbSocket->query('COMMIT');
+                if (DB::isError($commit)) {
+                    $dbSocket->query('ROLLBACK');
+                    $failureMsg = 'The NAS import could not be committed';
+                    $logAction .= 'NAS import commit failed on page: ';
+                } else {
+                    $resultRows = array_merge($insertedRows, $skippedRows, $excludedRows);
+                    usort($resultRows, function ($a, $b) {
+                        return intval($a['row_number']) <=> intval($b['row_number']);
+                    });
+                    $previewSkippedCount = 0;
+                    $previewInvalidCount = 0;
+                    foreach ($excludedRows as $excludedRow) {
+                        if (($excludedRow['status'] ?? '') === 'skipped') {
+                            $previewSkippedCount++;
+                        } elseif (($excludedRow['status'] ?? '') === 'invalid') {
+                            $previewInvalidCount++;
+                        }
+                    }
+                    $totalSkipped = count($skippedRows) + $previewSkippedCount;
+                    $successMsg = sprintf(
+                        'Imported %d NAS entr%s; skipped %d duplicate or existing entr%s; rejected %d invalid entr%s. Restart or reload FreeRADIUS for the changes to take effect.',
+                        count($insertedRows),
+                        count($insertedRows) === 1 ? 'y' : 'ies',
+                        $totalSkipped,
+                        $totalSkipped === 1 ? 'y' : 'ies',
+                        $previewInvalidCount,
+                        $previewInvalidCount === 1 ? 'y' : 'ies'
+                    );
+                    $logAction .= sprintf(
+                        'Imported %d NAS entries, skipped %d duplicate or existing entries and rejected %d invalid entries on page: ',
+                        count($insertedRows),
+                        $totalSkipped,
+                        $previewInvalidCount
+                    );
+                }
+            }
+
+            if (!DB::isError($prepared)) {
+                $dbSocket->freePrepared($prepared);
+            }
+            include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
+            unset($_SESSION['nas_import_preview']);
+        }
+    } else {
+        $failureMsg = 'Unsupported NAS import action';
+    }
+}
+
+$title = 'Import NAS JSON backup';
+$help = 'Upload a JSON backup exported by daloRADIUS. New NAS entries are added. Existing NAS names are skipped and never modified.';
+$inline_extra_css = <<<CSS
+.nas-import-table-wrap { max-height: 30rem; overflow: auto; }
+.nas-import-table-wrap thead th { position: sticky; top: 0; z-index: 2; white-space: nowrap; }
+.nas-import-table-wrap td { max-width: 28rem; overflow-wrap: anywhere; }
+CSS;
+
+print_html_prologue($title, $langCode, array(), array(), $inline_extra_css);
+print_title_and_help($title, $help);
+include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'actionMessages.php' ]);
+
+if (count($previewRows) > 0) {
+    echo '<div class="row g-2 mb-3">';
+    printf('<div class="col-12 col-md-4"><div class="alert alert-success mb-0"><strong>%d</strong> ready to import</div></div>', $readyCount);
+    printf('<div class="col-12 col-md-4"><div class="alert alert-warning mb-0"><strong>%d</strong> skipped</div></div>', $skippedCount);
+    printf('<div class="col-12 col-md-4"><div class="alert alert-danger mb-0"><strong>%d</strong> invalid</div></div>', $invalidCount);
+    echo '</div>';
+
+    echo '<h5>Import preview</h5>';
+    echo '<p class="text-muted">Secrets are intentionally hidden. Existing NAS entries will not be changed.</p>';
+    nas_import_render_rows($previewRows, 'nas-import-preview-table');
+
+    echo '<div class="d-flex flex-wrap gap-2 mt-3">';
+    if ($readyCount > 0) {
+        $csrfToken = dalo_csrf_token();
+        echo '<form method="POST" action="mng-rad-nas-import.php">';
+        printf('<input type="hidden" name="csrf_token" value="%s">', htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'));
+        echo '<input type="hidden" name="nas_import_action" value="confirm">';
+        printf('<input type="hidden" name="preview_token" value="%s">', htmlspecialchars($previewToken, ENT_QUOTES, 'UTF-8'));
+        echo '<button type="submit" class="btn btn-primary">Import ready NAS entries</button></form>';
+    }
+    echo '<a class="btn btn-light" href="mng-rad-nas-import.php">Cancel and choose another file</a>';
+    echo '<a class="btn btn-light" href="mng-rad-nas-list.php">Back to NAS list</a>';
+    echo '</div>';
+} elseif (count($resultRows) > 0) {
+    echo '<h5>Import result</h5>';
+    nas_import_render_rows($resultRows, 'nas-import-result-table');
+    echo '<div class="d-flex flex-wrap gap-2 mt-3">';
+    echo '<a class="btn btn-primary" href="mng-rad-nas-list.php">Back to NAS list</a>';
+    echo '<a class="btn btn-light" href="mng-rad-nas-import.php">Import another backup</a>';
+    echo '</div>';
+} else {
+    $csrfToken = dalo_csrf_token();
+    echo '<div class="card my-3"><div class="card-body">';
+    echo '<h5 class="card-title">Select a NAS JSON backup</h5>';
+    echo '<p class="card-text">All valid NAS entries with a new, unique NAS name will be added. Existing NAS entries are skipped and are never modified or deleted. The maximum file size is 2 MiB.</p>';
+    echo '<form method="POST" action="mng-rad-nas-import.php" enctype="multipart/form-data">';
+    printf('<input type="hidden" name="csrf_token" value="%s">', htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'));
+    echo '<input type="hidden" name="nas_import_action" value="preview">';
+    printf('<input type="hidden" name="MAX_FILE_SIZE" value="%d">', NAS_BACKUP_MAX_BYTES);
+    echo '<div class="mb-3"><label for="nas_backup" class="form-label">JSON backup file</label>';
+    echo '<input class="form-control" type="file" id="nas_backup" name="nas_backup" accept="application/json,.json" required></div>';
+    echo '<div class="d-flex flex-wrap gap-2"><button type="submit" class="btn btn-primary">Preview import</button>';
+    echo '<a class="btn btn-light" href="mng-rad-nas-list.php">Back to NAS list</a></div>';
+    echo '</form></div></div>';
+}
+
+include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_CONFIG'], 'logging.php' ]);
+
+$inline_extra_js = <<<JS
+function filterNasImportTable(tableId) {
+    var table = document.getElementById(tableId);
+    if (!table) return;
+    var search = document.querySelector('.nas-import-search[data-table="' + tableId + '"]');
+    var status = document.querySelector('.nas-import-status[data-table="' + tableId + '"]');
+    var needle = search ? search.value.toLowerCase() : '';
+    var wantedStatus = status ? status.value : '';
+    table.querySelectorAll('tbody tr').forEach(function (row) {
+        var matchesText = row.textContent.toLowerCase().indexOf(needle) !== -1;
+        var matchesStatus = !wantedStatus || row.dataset.status === wantedStatus;
+        row.style.display = matchesText && matchesStatus ? '' : 'none';
+    });
+}
+
+document.querySelectorAll('.nas-import-search, .nas-import-status').forEach(function (control) {
+    control.addEventListener('input', function () { filterNasImportTable(control.dataset.table); });
+    control.addEventListener('change', function () { filterNasImportTable(control.dataset.table); });
+});
+JS;
+
+print_footer_and_html_epilogue($inline_extra_js);

--- a/app/operators/mng-rad-nas-import.php
+++ b/app/operators/mng-rad-nas-import.php
@@ -166,7 +166,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                             $readyCount++;
                         }
 
-                        if ($nasname !== '') {
+                        if ($nasname !== '' && count($row['errors']) === 0) {
                             $seenNames[$nasnameKey] = true;
                         }
 
@@ -208,9 +208,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $entries = $preview['entries'] ?? array();
             $excludedRows = $preview['excluded_rows'] ?? array();
             include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
+            $dbSocket->setErrorHandling(PEAR_ERROR_RETURN);
 
-            $transaction = $dbSocket->query('START TRANSACTION');
-            $importError = DB::isError($transaction);
+            $importLock = $dbSocket->getOne("SELECT GET_LOCK('daloradius_nas_import', 30)");
+            $importLockAcquired = !DB::isError($importLock) && intval($importLock) === 1;
+            $transaction = $importLockAcquired ? $dbSocket->query('START TRANSACTION') : false;
+            $importError = !$importLockAcquired || DB::isError($transaction);
             $insertedRows = array();
             $skippedRows = array();
 
@@ -219,6 +222,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $configValues['CONFIG_DB_TBL_RADNAS']
             );
             $prepared = $dbSocket->prepare($insertSql);
+            if (DB::isError($prepared)) {
+                $importError = true;
+            }
 
             foreach ($entries as $index => $candidate) {
                 if ($importError) {
@@ -228,7 +234,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $entry = $candidate['data'];
                 $rowNumber = intval($candidate['row_number']);
                 $existsSql = sprintf(
-                    "SELECT COUNT(id) FROM %s WHERE nasname='%s'",
+                    "SELECT COUNT(id) FROM %s WHERE LOWER(nasname)=LOWER('%s')",
                     $configValues['CONFIG_DB_TBL_RADNAS'],
                     $dbSocket->escapeSimple($entry['nasname'])
                 );
@@ -259,6 +265,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     $entry['community'],
                     $entry['description'],
                 ));
+
+                if (nas_import_is_duplicate_error($res)) {
+                    $skippedRows[] = array(
+                        'row_number' => $rowNumber,
+                        'data' => $entry,
+                        'status' => 'skipped',
+                        'information' => 'NAS name was added after the preview and already exists',
+                    );
+                    continue;
+                }
 
                 if (DB::isError($res)) {
                     $importError = true;
@@ -327,6 +343,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             if (!DB::isError($prepared)) {
                 $dbSocket->freePrepared($prepared);
             }
+            if ($importLockAcquired) {
+                $dbSocket->query("SELECT RELEASE_LOCK('daloradius_nas_import')");
+            }
+            $dbSocket->setErrorHandling(PEAR_ERROR_CALLBACK, 'errorHandler');
             include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
             unset($_SESSION['nas_import_preview']);
         }

--- a/app/operators/mng-rad-nas-import.php
+++ b/app/operators/mng-rad-nas-import.php
@@ -210,8 +210,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
             $dbSocket->setErrorHandling(PEAR_ERROR_RETURN);
 
-            $importLock = $dbSocket->getOne("SELECT GET_LOCK('daloradius_nas_import', 30)");
-            $importLockAcquired = !DB::isError($importLock) && intval($importLock) === 1;
+            $importLock = nas_backup_acquire_lock($dbSocket, $configValues['CONFIG_DB_TBL_RADNAS'], 30);
+            $importLockAcquired = $importLock['acquired'];
             $transaction = $importLockAcquired ? $dbSocket->query('START TRANSACTION') : false;
             $confirmExistingNames = ($importLockAcquired && !DB::isError($transaction))
                 ? nas_import_existing_names($dbSocket, $configValues['CONFIG_DB_TBL_RADNAS'])
@@ -308,7 +308,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
 
             if (!$importLockAcquired) {
-                $failureMsg = DB::isError($importLock)
+                $failureMsg = $importLock['error']
                     ? 'Unable to acquire the NAS import lock; please retry the import'
                     : 'Another NAS import is currently running; please retry in a moment';
                 $logAction .= 'NAS import lock was unavailable on page: ';
@@ -390,8 +390,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $dbSocket->freePrepared($prepared);
             }
             if ($importLockAcquired) {
-                $releaseLock = $dbSocket->getOne("SELECT RELEASE_LOCK('daloradius_nas_import')");
-                if (DB::isError($releaseLock) || intval($releaseLock) !== 1) {
+                if (!nas_backup_release_lock($dbSocket, $importLock['name'])) {
                     $logAction .= 'NAS import advisory lock release could not be confirmed on page: ';
                 }
             }

--- a/app/operators/mng-rad-nas-import.php
+++ b/app/operators/mng-rad-nas-import.php
@@ -283,13 +283,25 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     continue;
                 }
 
-                $existsSql = sprintf(
-                    "SELECT COUNT(id) FROM %s WHERE LOWER(nasname)=LOWER('%s') OR HEX(nasname)='%s'",
-                    $configValues['CONFIG_DB_TBL_RADNAS'],
-                    $dbSocket->escapeSimple($entry['nasname']),
-                    nas_import_hex_value($entry['nasname'])
-                );
-                $exists = $dbSocket->getOne($existsSql);
+                $nasnameHex = nas_import_hex_value($entry['nasname']);
+                $nasnameIsText = nas_backup_is_valid_utf8($entry['nasname']) &&
+                                 !preg_match('/[\x00-\x1F\x7F]/', $entry['nasname']);
+                if ($nasnameIsText) {
+                    $existsSql = sprintf(
+                        'SELECT COUNT(id) FROM %s
+                          WHERE LOWER(nasname)=LOWER(CONVERT(UNHEX(?) USING utf8mb4))
+                             OR HEX(nasname)=?',
+                        $configValues['CONFIG_DB_TBL_RADNAS']
+                    );
+                    $existsParams = array($nasnameHex, $nasnameHex);
+                } else {
+                    $existsSql = sprintf(
+                        'SELECT COUNT(id) FROM %s WHERE HEX(nasname)=?',
+                        $configValues['CONFIG_DB_TBL_RADNAS']
+                    );
+                    $existsParams = array($nasnameHex);
+                }
+                $exists = $dbSocket->getOne($existsSql, $existsParams);
 
                 if (DB::isError($exists)) {
                     $importError = true;

--- a/app/operators/mng-rad-nas-import.php
+++ b/app/operators/mng-rad-nas-import.php
@@ -213,7 +213,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $importLock = $dbSocket->getOne("SELECT GET_LOCK('daloradius_nas_import', 30)");
             $importLockAcquired = !DB::isError($importLock) && intval($importLock) === 1;
             $transaction = $importLockAcquired ? $dbSocket->query('START TRANSACTION') : false;
-            $importError = !$importLockAcquired || DB::isError($transaction);
+            $confirmExistingNames = ($importLockAcquired && !DB::isError($transaction))
+                ? nas_import_existing_names($dbSocket, $configValues['CONFIG_DB_TBL_RADNAS'])
+                : false;
+            $importError = $importLockAcquired &&
+                (DB::isError($transaction) || $confirmExistingNames === false);
             $insertedRows = array();
             $skippedRows = array();
 
@@ -221,18 +225,30 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 'INSERT INTO %s (nasname, shortname, type, ports, secret, server, community, description) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
                 $configValues['CONFIG_DB_TBL_RADNAS']
             );
-            $prepared = $dbSocket->prepare($insertSql);
-            if (DB::isError($prepared)) {
+            $prepared = ($importLockAcquired && !$importError) ? $dbSocket->prepare($insertSql) : false;
+            if ($importLockAcquired && DB::isError($prepared)) {
                 $importError = true;
             }
 
             foreach ($entries as $index => $candidate) {
-                if ($importError) {
+                if (!$importLockAcquired || $importError) {
                     break;
                 }
 
                 $entry = $candidate['data'];
                 $rowNumber = intval($candidate['row_number']);
+                $nasnameKey = nas_import_name_key($entry['nasname']);
+
+                if (isset($confirmExistingNames[$nasnameKey])) {
+                    $skippedRows[] = array(
+                        'row_number' => $rowNumber,
+                        'data' => $entry,
+                        'status' => 'skipped',
+                        'information' => 'NAS name was added after the preview and already exists',
+                    );
+                    continue;
+                }
+
                 $existsSql = sprintf(
                     "SELECT COUNT(id) FROM %s WHERE LOWER(nasname)=LOWER('%s')",
                     $configValues['CONFIG_DB_TBL_RADNAS'],
@@ -246,6 +262,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 }
 
                 if (intval($exists) > 0) {
+                    $confirmExistingNames[$nasnameKey] = true;
                     $skippedRows[] = array(
                         'row_number' => $rowNumber,
                         'data' => $entry,
@@ -287,9 +304,38 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     'status' => 'imported',
                     'information' => 'NAS added successfully',
                 );
+                $confirmExistingNames[$nasnameKey] = true;
             }
 
-            if ($importError) {
+            if (!$importLockAcquired) {
+                $failureMsg = DB::isError($importLock)
+                    ? 'Unable to acquire the NAS import lock; please retry the import'
+                    : 'Another NAS import is currently running; please retry in a moment';
+                $logAction .= 'NAS import lock was unavailable on page: ';
+
+                $readyCount = count($entries);
+                $previewToken = (string)($preview['token'] ?? '');
+                foreach ($entries as $candidate) {
+                    $previewRows[] = array(
+                        'row_number' => intval($candidate['row_number']),
+                        'data' => $candidate['data'],
+                        'errors' => array(),
+                        'status' => 'ready',
+                        'information' => 'New NAS name',
+                    );
+                }
+                foreach ($excludedRows as $excludedRow) {
+                    $previewRows[] = $excludedRow;
+                    if (($excludedRow['status'] ?? '') === 'skipped') {
+                        $skippedCount++;
+                    } elseif (($excludedRow['status'] ?? '') === 'invalid') {
+                        $invalidCount++;
+                    }
+                }
+                usort($previewRows, function ($a, $b) {
+                    return intval($a['row_number']) <=> intval($b['row_number']);
+                });
+            } elseif ($importError) {
                 $dbSocket->query('ROLLBACK');
                 $failureMsg = 'The NAS import failed and all new rows were rolled back';
                 foreach ($entries as $candidate) {
@@ -340,15 +386,20 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 }
             }
 
-            if (!DB::isError($prepared)) {
+            if ($prepared !== false && !DB::isError($prepared)) {
                 $dbSocket->freePrepared($prepared);
             }
             if ($importLockAcquired) {
-                $dbSocket->query("SELECT RELEASE_LOCK('daloradius_nas_import')");
+                $releaseLock = $dbSocket->getOne("SELECT RELEASE_LOCK('daloradius_nas_import')");
+                if (DB::isError($releaseLock) || intval($releaseLock) !== 1) {
+                    $logAction .= 'NAS import advisory lock release could not be confirmed on page: ';
+                }
             }
             $dbSocket->setErrorHandling(PEAR_ERROR_CALLBACK, 'errorHandler');
             include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
-            unset($_SESSION['nas_import_preview']);
+            if ($importLockAcquired) {
+                unset($_SESSION['nas_import_preview']);
+            }
         }
     } else {
         $failureMsg = 'Unsupported NAS import action';

--- a/app/operators/mng-rad-nas-import.php
+++ b/app/operators/mng-rad-nas-import.php
@@ -32,11 +32,14 @@ $invalidCount = 0;
 
 function nas_import_name_key($nasname) {
     $nasname = (string)$nasname;
+    if (!nas_backup_is_valid_utf8($nasname)) {
+        return 'binary:' . bin2hex($nasname);
+    }
     return function_exists('mb_strtolower') ? mb_strtolower($nasname, 'UTF-8') : strtolower($nasname);
 }
 
 function nas_import_existing_names($dbSocket, $table) {
-    $sql = sprintf('SELECT nasname FROM %s', $table);
+    $sql = sprintf('SELECT HEX(nasname) FROM %s', $table);
     $res = $dbSocket->query($sql);
     if (DB::isError($res)) {
         return false;
@@ -44,9 +47,28 @@ function nas_import_existing_names($dbSocket, $table) {
 
     $names = array();
     while ($row = $res->fetchRow()) {
-        $names[nas_import_name_key($row[0])] = true;
+        $nasname = nas_backup_decode_database_hex($row[0]);
+        if ($nasname === false) {
+            return false;
+        }
+        $names[nas_import_name_key($nasname)] = true;
     }
     return $names;
+}
+
+function nas_import_hex_value($value) {
+    return ($value === null) ? null : strtoupper(bin2hex($value));
+}
+
+function nas_import_row_matches($stored, $entry) {
+    foreach (array('nasname', 'shortname', 'type', 'secret', 'server', 'community', 'description') as $field) {
+        if (($stored[$field . '_hex'] ?? null) !== nas_import_hex_value($entry[$field])) {
+            return false;
+        }
+    }
+
+    $storedPorts = ($stored['ports'] === null) ? null : intval($stored['ports']);
+    return $storedPorts === $entry['ports'];
 }
 
 function nas_import_badge($status) {
@@ -60,6 +82,17 @@ function nas_import_badge($status) {
         default:
             return '<span class="badge text-bg-danger">Invalid</span>';
     }
+}
+
+function nas_import_display_value($value) {
+    if ($value === null) {
+        return '';
+    }
+    $value = (string)$value;
+    if (!nas_backup_is_valid_utf8($value) || preg_match('/[\x00-\x1F\x7F]/', $value)) {
+        return sprintf('Binary value (%d bytes)', strlen($value));
+    }
+    return $value;
 }
 
 function nas_import_render_rows($rows, $table_id) {
@@ -88,9 +121,9 @@ function nas_import_render_rows($rows, $table_id) {
             '<tr data-status="%s"><td>%d</td><td><code>%s</code></td><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>',
             htmlspecialchars($status, ENT_QUOTES, 'UTF-8'),
             intval($row['row_number']),
-            htmlspecialchars((string)($data['nasname'] ?? ''), ENT_QUOTES, 'UTF-8'),
-            htmlspecialchars((string)($data['shortname'] ?? ''), ENT_QUOTES, 'UTF-8'),
-            htmlspecialchars((string)($data['type'] ?? ''), ENT_QUOTES, 'UTF-8'),
+            htmlspecialchars(nas_import_display_value($data['nasname'] ?? null), ENT_QUOTES, 'UTF-8'),
+            htmlspecialchars(nas_import_display_value($data['shortname'] ?? null), ENT_QUOTES, 'UTF-8'),
+            htmlspecialchars(nas_import_display_value($data['type'] ?? null), ENT_QUOTES, 'UTF-8'),
             nas_import_badge($status),
             htmlspecialchars($information, ENT_QUOTES, 'UTF-8')
         );
@@ -222,7 +255,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $skippedRows = array();
 
             $insertSql = sprintf(
-                'INSERT INTO %s (nasname, shortname, type, ports, secret, server, community, description) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+                'INSERT INTO %s (nasname, shortname, type, ports, secret, server, community, description)
+                 VALUES (UNHEX(?), UNHEX(?), UNHEX(?), ?, UNHEX(?), UNHEX(?), UNHEX(?), UNHEX(?))',
                 $configValues['CONFIG_DB_TBL_RADNAS']
             );
             $prepared = ($importLockAcquired && !$importError) ? $dbSocket->prepare($insertSql) : false;
@@ -250,9 +284,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 }
 
                 $existsSql = sprintf(
-                    "SELECT COUNT(id) FROM %s WHERE LOWER(nasname)=LOWER('%s')",
+                    "SELECT COUNT(id) FROM %s WHERE LOWER(nasname)=LOWER('%s') OR HEX(nasname)='%s'",
                     $configValues['CONFIG_DB_TBL_RADNAS'],
-                    $dbSocket->escapeSimple($entry['nasname'])
+                    $dbSocket->escapeSimple($entry['nasname']),
+                    nas_import_hex_value($entry['nasname'])
                 );
                 $exists = $dbSocket->getOne($existsSql);
 
@@ -273,14 +308,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 }
 
                 $res = $dbSocket->execute($prepared, array(
-                    $entry['nasname'],
-                    $entry['shortname'],
-                    $entry['type'],
+                    nas_import_hex_value($entry['nasname']),
+                    nas_import_hex_value($entry['shortname']),
+                    nas_import_hex_value($entry['type']),
                     $entry['ports'],
-                    $entry['secret'],
-                    $entry['server'],
-                    $entry['community'],
-                    $entry['description'],
+                    nas_import_hex_value($entry['secret']),
+                    nas_import_hex_value($entry['server']),
+                    nas_import_hex_value($entry['community']),
+                    nas_import_hex_value($entry['description']),
                 ));
 
                 if (nas_import_is_duplicate_error($res)) {
@@ -294,6 +329,26 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 }
 
                 if (DB::isError($res)) {
+                    $importError = true;
+                    break;
+                }
+
+                $insertedId = $dbSocket->getOne('SELECT LAST_INSERT_ID()');
+                if (DB::isError($insertedId)) {
+                    $importError = true;
+                    break;
+                }
+                $verifySql = sprintf(
+                    'SELECT HEX(nasname) AS nasname_hex, HEX(shortname) AS shortname_hex,
+                            HEX(type) AS type_hex, ports, HEX(secret) AS secret_hex,
+                            HEX(server) AS server_hex, HEX(community) AS community_hex,
+                            HEX(description) AS description_hex
+                       FROM %s WHERE id=%d',
+                    $configValues['CONFIG_DB_TBL_RADNAS'],
+                    intval($insertedId)
+                );
+                $stored = $dbSocket->getRow($verifySql, array(), DB_FETCHMODE_ASSOC);
+                if (DB::isError($stored) || !is_array($stored) || !nas_import_row_matches($stored, $entry)) {
                     $importError = true;
                     break;
                 }
@@ -451,7 +506,10 @@ if (count($previewRows) > 0) {
     $csrfToken = dalo_csrf_token();
     echo '<div class="card my-3"><div class="card-body">';
     echo '<h5 class="card-title">Select a NAS JSON backup</h5>';
-    echo '<p class="card-text">All valid NAS entries with a new, unique NAS name will be added. Existing NAS entries are skipped and are never modified or deleted. The maximum file size is 2 MiB.</p>';
+    printf(
+        '<p class="card-text">All valid NAS entries with a new, unique NAS name will be added. Existing NAS entries are skipped and are never modified or deleted. The maximum file size is %d MiB.</p>',
+        intval(NAS_BACKUP_MAX_BYTES / 1048576)
+    );
     echo '<form method="POST" action="mng-rad-nas-import.php" enctype="multipart/form-data">';
     printf('<input type="hidden" name="csrf_token" value="%s">', htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'));
     echo '<input type="hidden" name="nas_import_action" value="preview">';

--- a/app/operators/mng-rad-nas-list.php
+++ b/app/operators/mng-rad-nas-list.php
@@ -139,6 +139,18 @@
         $descriptors = array();
         $descriptors['start'] = array( 'common_controls' => 'nasname[]', 'additional_controls' => $additional_controls );
         $descriptors['center'] = array( 'draw' => $drawNumberLinks, 'params' => $params );
+        $descriptors['end'] = array(
+            array(
+                'onclick' => "location.href='mng-rad-nas-import.php'",
+                'label' => 'JSON Import',
+                'class' => 'btn-light',
+            ),
+            array(
+                'onclick' => "location.href='mng-rad-nas-export.php'",
+                'label' => 'JSON Export',
+                'class' => 'btn-light',
+            ),
+        );
         print_table_prologue($descriptors);
 
         $form_descriptor = array( 'form' => array( 'action' => $action, 'method' => 'GET', 'name' => $form_name ), );
@@ -211,6 +223,21 @@
         printLinks($links, $drawNumberLinks);
 
     } else {
+        $descriptors = array();
+        $descriptors['end'] = array(
+            array(
+                'onclick' => "location.href='mng-rad-nas-import.php'",
+                'label' => 'JSON Import',
+                'class' => 'btn-light',
+            ),
+            array(
+                'onclick' => "location.href='mng-rad-nas-export.php'",
+                'label' => 'JSON Export',
+                'class' => 'btn-light',
+            ),
+        );
+        print_table_prologue($descriptors);
+
         $failureMsg = "Nothing to display";
         include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'actionMessages.php' ]);
     }

--- a/app/operators/mng-rad-nas-list.php
+++ b/app/operators/mng-rad-nas-list.php
@@ -93,6 +93,19 @@
     $res = $dbSocket->query($sql);
     $numrows = (!DB::isError($res)) ? $res->fetchrow()[0] : 0;
 
+    $nas_import_export_controls = array(
+        array(
+            'onclick' => "location.href='mng-rad-nas-import.php'",
+            'label' => 'JSON Import',
+            'class' => 'btn-light',
+        ),
+        array(
+            'onclick' => "location.href='mng-rad-nas-export.php'",
+            'label' => 'JSON Export',
+            'class' => 'btn-light',
+        ),
+    );
+
     if ($numrows > 0) {
         /* START - Related to pages_numbering.php */
 
@@ -139,18 +152,7 @@
         $descriptors = array();
         $descriptors['start'] = array( 'common_controls' => 'nasname[]', 'additional_controls' => $additional_controls );
         $descriptors['center'] = array( 'draw' => $drawNumberLinks, 'params' => $params );
-        $descriptors['end'] = array(
-            array(
-                'onclick' => "location.href='mng-rad-nas-import.php'",
-                'label' => 'JSON Import',
-                'class' => 'btn-light',
-            ),
-            array(
-                'onclick' => "location.href='mng-rad-nas-export.php'",
-                'label' => 'JSON Export',
-                'class' => 'btn-light',
-            ),
-        );
+        $descriptors['end'] = $nas_import_export_controls;
         print_table_prologue($descriptors);
 
         $form_descriptor = array( 'form' => array( 'action' => $action, 'method' => 'GET', 'name' => $form_name ), );
@@ -224,18 +226,7 @@
 
     } else {
         $descriptors = array();
-        $descriptors['end'] = array(
-            array(
-                'onclick' => "location.href='mng-rad-nas-import.php'",
-                'label' => 'JSON Import',
-                'class' => 'btn-light',
-            ),
-            array(
-                'onclick' => "location.href='mng-rad-nas-export.php'",
-                'label' => 'JSON Export',
-                'class' => 'btn-light',
-            ),
-        );
+        $descriptors['end'] = $nas_import_export_controls;
         print_table_prologue($descriptors);
 
         $failureMsg = "Nothing to display";

--- a/app/operators/mng-rad-nas-new.php
+++ b/app/operators/mng-rad-nas-new.php
@@ -30,6 +30,7 @@
     include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LANG'], 'main.php' ]);
     include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'validation.php' ]);
     include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'layout.php' ]);
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'nasImportExport.php' ]);
 
     // init logging variables
     $log = "visited page: ";
@@ -69,41 +70,55 @@
                 $logAction .= "Failed adding (possible empty user/pass) new operator on page: ";
             } else {
                 include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
+                $dbSocket->setErrorHandling(PEAR_ERROR_RETURN);
+                $nasLock = nas_backup_acquire_lock($dbSocket, $configValues['CONFIG_DB_TBL_RADNAS'], 30);
 
-                $sql = sprintf("SELECT COUNT(id) FROM %s WHERE nasname='%s'", $configValues['CONFIG_DB_TBL_RADNAS'],
-                                                                              $dbSocket->escapeSimple($nasname));
-                $res = $dbSocket->query($sql);
-                $logDebugSQL .= "$sql;\n";
-
-                $exists = $res->fetchrow()[0] > 0;
-
-                if ($exists) {
-                    // name already taken
-                    $failureMsg = sprintf("This %s already exists: <b>%s</b>", t('all','NasIPHost'), $nasname_enc);
-                    $logAction .= "Failed adding a new NAS [$nasname already exists] on page: ";
+                if (!$nasLock['acquired']) {
+                    $failureMsg = $nasLock['error']
+                        ? 'Unable to coordinate the NAS change; please retry'
+                        : 'Another NAS change is currently running; please retry in a moment';
+                    $logAction .= "Failed adding a new NAS [NAS lock unavailable] on page: ";
                 } else {
-
-                    $sql = sprintf("INSERT INTO %s (nasname, shortname, type, ports, secret, server, community, description)
-                                            VALUES ('%s', '%s', '%s', %d, '%s', '%s', '%s', '%s')", $configValues['CONFIG_DB_TBL_RADNAS'],
-                                   $dbSocket->escapeSimple($nasname), $dbSocket->escapeSimple($shortname), $dbSocket->escapeSimple($nastype),
-                                   $dbSocket->escapeSimple($ports), $dbSocket->escapeSimple($secret), $dbSocket->escapeSimple($server),
-                                   $dbSocket->escapeSimple($community), $dbSocket->escapeSimple($description));
-                    $res = $dbSocket->query($sql);
+                    $sql = sprintf("SELECT COUNT(id) FROM %s WHERE LOWER(nasname)=LOWER('%s')",
+                                   $configValues['CONFIG_DB_TBL_RADNAS'], $dbSocket->escapeSimple($nasname));
+                    $res = $dbSocket->getOne($sql);
                     $logDebugSQL .= "$sql;\n";
 
-                    if (!DB::isError($res)) {
-                        $successMsg = sprintf('Successfully added a new NAS (<strong>%s</strong>) '
-                                            . '<a href="mng-rad-nas-edit.php?nasname=%s" title="Edit">Edit</a>',
-                                              $nasname_enc, urlencode($nasname_enc));
-                        $successMsg .= '<br><strong>Restart FreeRADIUS for NAS changes to take effect.</strong>';
-                        $logAction .= "Successfully added a new NAS [$nasname] on page: ";
+                    if (DB::isError($res)) {
+                        $failureMsg = 'Unable to check whether the NAS already exists';
+                        $logAction .= "Failed adding a new NAS [database lookup failed] on page: ";
+                    } elseif (intval($res) > 0) {
+                        // name already taken
+                        $failureMsg = sprintf("This %s already exists: <b>%s</b>", t('all','NasIPHost'), $nasname_enc);
+                        $logAction .= "Failed adding a new NAS [$nasname already exists] on page: ";
                     } else {
-                        // it seems that operator could not be added
-                        $f = "Failed to add a new NAS [%s] to database";
-                        $failureMsg = sprintf($f, $nasname_enc);
-                        $logAction .= sprintf($f, $nasname);
+
+                        $sql = sprintf("INSERT INTO %s (nasname, shortname, type, ports, secret, server, community, description)
+                                                VALUES ('%s', '%s', '%s', %d, '%s', '%s', '%s', '%s')", $configValues['CONFIG_DB_TBL_RADNAS'],
+                                       $dbSocket->escapeSimple($nasname), $dbSocket->escapeSimple($shortname), $dbSocket->escapeSimple($nastype),
+                                       $dbSocket->escapeSimple($ports), $dbSocket->escapeSimple($secret), $dbSocket->escapeSimple($server),
+                                       $dbSocket->escapeSimple($community), $dbSocket->escapeSimple($description));
+                        $res = $dbSocket->query($sql);
+                        $logDebugSQL .= "$sql;\n";
+
+                        if (!DB::isError($res)) {
+                            $successMsg = sprintf('Successfully added a new NAS (<strong>%s</strong>) '
+                                                . '<a href="mng-rad-nas-edit.php?nasname=%s" title="Edit">Edit</a>',
+                                                  $nasname_enc, urlencode($nasname_enc));
+                            $successMsg .= '<br><strong>Restart FreeRADIUS for NAS changes to take effect.</strong>';
+                            $logAction .= "Successfully added a new NAS [$nasname] on page: ";
+                        } else {
+                            $f = "Failed to add a new NAS [%s] to database";
+                            $failureMsg = sprintf($f, $nasname_enc);
+                            $logAction .= sprintf($f, $nasname);
+                        }
                     }
                 }
+
+                if ($nasLock['acquired'] && !nas_backup_release_lock($dbSocket, $nasLock['name'])) {
+                    $logAction .= 'NAS advisory lock release could not be confirmed on page: ';
+                }
+                $dbSocket->setErrorHandling(PEAR_ERROR_CALLBACK, 'errorHandler');
 
                 include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
             }


### PR DESCRIPTION
## Description

### Summary

Add JSON import and export functionality to the NAS management page.

This provides a dedicated and discoverable way to back up and restore NAS client definitions without using the broader database backup interface.

### Changes

- add JSON Import and JSON Export actions to the NAS list
- export all NAS entries in a versioned JSON document
- preserve NAS fields, including nullable values and custom NAS types
- omit database-generated NAS IDs from exports
- provide an import preview with search, status filters, and counters
- import new NAS entries without modifying or deleting existing entries
- skip existing NAS names and duplicate names within the imported file
- compare NAS names case-insensitively
- mask RADIUS secrets throughout the import preview and result pages
- remind operators to restart or reload FreeRADIUS after importing NAS entries

### Import behavior

The import is intentionally additive:

- existing NAS entries are never modified
- existing NAS entries are never deleted
- new valid NAS entries are inserted
- an existing nasname is skipped
- duplicate names within the imported document are skipped
- names are compared case-insensitively

A second duplicate check is performed when the import is confirmed to handle NAS entries added after the preview was generated.

### Security and validation

- operator authentication and NAS-management ACL required
- CSRF protection on upload and confirmation
- maximum upload size of 2 MiB
- maximum of 5,000 NAS entries per document
- field lengths validated against the database schema
- nasname and secret are required
- imported rows are inserted within a transaction
- complete rollback if an insertion fails
- secrets are not included in audit messages or rendered in preview/result pages
- preview data expires after 30 minutes
- export responses use no-cache headers because the document contains RADIUS secrets

### Validation

Validated in the Docker development environment with MariaDB 11.8 and FreeRADIUS 3.2.8.

Tested scenarios:

- export of all existing NAS entries
- preview containing one existing NAS, one new NAS, and one case-insensitive duplicate
- successful import of the new NAS
- existing and duplicate NAS entries correctly skipped
- no modification of existing NAS entries
- preservation of custom NAS type, comma-containing shortname, secret, and nullable fields
- invalid JSON rejected
- missing secret rejected
- unauthenticated import and export requests redirected to login
- secrets absent from preview and result HTML
- imported test data removed after validation
- PHP syntax checks passed for all changed files
- git diff --check passed
- no fatal PHP, uncaught exception, or parse error found in the web logs

### Security note

The exported JSON document contains RADIUS shared secrets so that it can be used as a complete NAS backup. It must therefore be handled as sensitive data and stored with appropriate access controls.

### Related issues

Fixes: #459

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds NAS JSON import and export so operators can back up and restore NAS clients from the list page instead of using full DB backups. Export is versioned and byte-safe; import is previewed and additive-only, leaving existing NAS unchanged and coordinating concurrent writes to avoid races. Implements #459.

- Export: emits v1 (UTF-8) or v2 (binary-safe) JSON; v2 Base64-encodes non‑UTF‑8/control fields and includes an `encoded_fields` list; omits DB IDs; adds `exported_at`, `count`, `includes_secrets`; sets no‑cache and `nosniff`; returns 500 only on DB/encoding errors.
- Import: additive-only; skips existing and duplicate NAS names (case-insensitive and binary-safe); decodes v2 Base64 fields; masks secrets in UI; rechecks duplicates on confirm; uses a DB advisory lock and a single transaction; if the lock is busy, shows a retry message and preserves the preview so operators can re-confirm without re-uploading.
- Concurrency: NAS create, edit, and delete use the same advisory lock plus a case-insensitive uniqueness check to prevent races with imports.
- UI: adds “JSON Import” and “JSON Export” to the NAS list; preview includes search/status filters and ready/skipped/invalid counters.
- Rollout and limits: login + NAS-management ACL; CSRF on upload/confirm; max upload 2 MiB; up to 5,000 NAS entries; enforces field lengths; normalizes `ports` to 0–99999 or null; preview expires after 30 minutes; exports include RADIUS shared secrets and must be handled as sensitive; restart or reload FreeRADIUS after a successful import.

<sup>Written for commit fa00cdfe3cf8f962e8aa2494d98537edf30d260e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

