### PR TITLE
refactor: use common include path for user billing

### DIFF
--- a/app/operators/include/management/userBilling.php
+++ b/app/operators/include/management/userBilling.php
@@ -42,9 +42,9 @@ if (strpos($_SERVER['PHP_SELF'], '/include/management/userBilling.php') !== fals
  *********************************************************************************************************
  */
 function userInvoiceAdd($userId, $invoiceInfo = array(), $invoiceItems = array()) {
-    global $logDebugSQL;
+    global $configValues, $logDebugSQL;
 
-    include implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', '..', '..', 'common', 'includes', 'db_open.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
 
     $user_id = false;
 
@@ -133,7 +133,7 @@ function userInvoiceAdd($userId, $invoiceInfo = array(), $invoiceItems = array()
 
 
 
-    include implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', '..', '..', 'common', 'includes', 'db_close.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
 
     return true;
 


### PR DESCRIPTION
## Description

Follow up on the review feedback in #737 by using the existing
`$configValues['COMMON_INCLUDES']` shortcut for the database includes in
`userInvoiceAdd()`.

## Validation

- PHP syntax check
- `git diff --check`
- Functional invoice creation test from the AJAX working directory

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes database include paths in user billing by using the existing `$configValues['COMMON_INCLUDES']` shortcut in `userInvoiceAdd()`. Replaces hard-coded relative paths; behavior is unchanged but now depends on a configured common include path.

**Review notes**
- Adds `global $configValues` and includes `db_open.php`/`db_close.php` via `$configValues['COMMON_INCLUDES']`.
- Ensure `$configValues` is loaded before calling `userInvoiceAdd`; otherwise the include will fail.
- No changes to invoice creation logic; only include path resolution.

<sup>Written for commit cf89364e94d60479d7c778cdaa57e86814f9573d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

