### PR TITLE
feat: generate and export passwords during user import

### DIFF
--- a/app/operators/include/common/fileExportCSV.php
+++ b/app/operators/include/common/fileExportCSV.php
@@ -26,6 +26,7 @@
  */
 
     include('../../library/checklogin.php');
+    include_once('../management/pages_common.php');
 
     $redirect = (array_key_exists('PREV_LIST_PAGE', $_SESSION) && !empty(trim($_SESSION['PREV_LIST_PAGE'])))
               ? trim($_SESSION['PREV_LIST_PAGE'])
@@ -35,18 +36,7 @@
         $accounts = null;
         $filename_prefix = "users";
         $exportToken = $_POST['export_token'] ?? null;
-        $exportLifetime = 300;
-        $now = time();
-
-        if (isset($_SESSION['generated_password_exports']) &&
-            is_array($_SESSION['generated_password_exports'])) {
-            foreach ($_SESSION['generated_password_exports'] as $token => $export) {
-                if (!is_array($export) || !isset($export['created_at']) ||
-                    intval($export['created_at']) <= ($now - $exportLifetime)) {
-                    unset($_SESSION['generated_password_exports'][$token]);
-                }
-            }
-        }
+        cleanupGeneratedPasswordExports();
 
         // This session-bound random token is one-time export authorization and is independent of global CSRF rotation.
         if (is_string($exportToken) && preg_match('/^[a-f0-9]{64}$/', $exportToken) === 1 &&
@@ -86,7 +76,7 @@
                     if (!is_scalar($value)) {
                         continue 2;
                     }
-                    $fields[] = (string)$value;
+                    $fields[] = str_replace([ "\r\n", "\r" ], "\n", (string)$value);
                 }
 
                 if (count($fields) < 2) {

--- a/app/operators/include/common/fileExportCSV.php
+++ b/app/operators/include/common/fileExportCSV.php
@@ -32,21 +32,85 @@
               : "../../index.php";
     
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-        if (array_key_exists('accounts', $_POST) && !empty($_POST['accounts']) && is_array($_POST['accounts'])) {
-            
-            $content = "";
-            foreach ($_POST['accounts'] as $account) {
-                $content .= implode(",", $account) . "\r\n";
+        $accounts = null;
+        $filename_prefix = "users";
+        $exportToken = $_POST['export_token'] ?? null;
+        $exportLifetime = 300;
+        $now = time();
+
+        if (isset($_SESSION['generated_password_exports']) &&
+            is_array($_SESSION['generated_password_exports'])) {
+            foreach ($_SESSION['generated_password_exports'] as $token => $export) {
+                if (!is_array($export) || !isset($export['created_at']) ||
+                    intval($export['created_at']) <= ($now - $exportLifetime)) {
+                    unset($_SESSION['generated_password_exports'][$token]);
+                }
             }
-            
-            $filename_prefix = (array_key_exists('batch_name', $_POST) && !empty(trim($_POST['batch_name'])) &&
-                                preg_match("/^[\w\-. ]+$/", trim($_POST['batch_name'])) !== false)
-                             ? trim($_POST['batch_name']) : "users";
-            
-            header("Content-type: text/csv; charset=utf-8");
-            header(sprintf("Content-disposition: csv; filename=%s__%s.csv; size=%s", $filename_prefix, date("Ymd"), strlen($content)));
-            print $content;
-            exit;
+        }
+
+        // This session-bound random token is one-time export authorization and is independent of global CSRF rotation.
+        if (is_string($exportToken) && preg_match('/^[a-f0-9]{64}$/', $exportToken) === 1 &&
+            isset($_SESSION['generated_password_exports'][$exportToken])) {
+            $export = $_SESSION['generated_password_exports'][$exportToken];
+            unset($_SESSION['generated_password_exports'][$exportToken]);
+
+            if (isset($export['accounts']) && is_array($export['accounts'])) {
+                $accounts = $export['accounts'];
+                $filename_prefix = "generated-passwords";
+            }
+        } else {
+            $csrfToken = $_POST['csrf_token'] ?? null;
+            $csrfValid = is_string($csrfToken) && dalo_check_csrf_token($csrfToken);
+
+            if ($csrfValid && array_key_exists('accounts', $_POST) &&
+                !empty($_POST['accounts']) && is_array($_POST['accounts'])) {
+                $accounts = $_POST['accounts'];
+                $filename_prefix = (array_key_exists('batch_name', $_POST) &&
+                                    is_string($_POST['batch_name']) &&
+                                    !empty(trim($_POST['batch_name'])) &&
+                                    preg_match("/^[\w\-. ]+$/", trim($_POST['batch_name'])) === 1)
+                                 ? trim($_POST['batch_name']) : "users";
+            }
+        }
+
+        if (is_array($accounts)) {
+            $stream = fopen('php://temp', 'w+');
+
+            foreach ($accounts as $account) {
+                if (!is_array($account)) {
+                    continue;
+                }
+
+                $fields = array();
+                foreach ($account as $value) {
+                    if (!is_scalar($value)) {
+                        continue 2;
+                    }
+                    $fields[] = (string)$value;
+                }
+
+                if (count($fields) < 2) {
+                    continue;
+                }
+
+                fputcsv($stream, $fields, ',', '"', '');
+            }
+
+            rewind($stream);
+            $content = str_replace("\n", "\r\n", stream_get_contents($stream));
+            fclose($stream);
+
+            if (!empty($content)) {
+                header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
+                header("Pragma: no-cache");
+                header("X-Content-Type-Options: nosniff");
+                header("Content-type: text/csv; charset=utf-8");
+                header(sprintf('Content-Disposition: attachment; filename="%s__%s.csv"',
+                               $filename_prefix, date("Ymd")));
+                header("Content-Length: " . strlen($content));
+                print $content;
+                exit;
+            }
         }
     }
     

--- a/app/operators/include/management/pages_common.php
+++ b/app/operators/include/management/pages_common.php
@@ -51,6 +51,25 @@ function createPassword($length, $chars) {
     return $pass;
 }
 
+// Generated-password exports are session-bound and short-lived.
+define('GENERATED_PASSWORD_EXPORT_LIFETIME_SECONDS', 300);
+
+function cleanupGeneratedPasswordExports($now = null) {
+    if (!isset($_SESSION['generated_password_exports']) ||
+        !is_array($_SESSION['generated_password_exports'])) {
+        return;
+    }
+
+    $now = is_null($now) ? time() : intval($now);
+
+    foreach ($_SESSION['generated_password_exports'] as $token => $export) {
+        if (!is_array($export) || !isset($export['created_at']) ||
+            intval($export['created_at']) <= ($now - GENERATED_PASSWORD_EXPORT_LIFETIME_SECONDS)) {
+            unset($_SESSION['generated_password_exports'][$token]);
+        }
+    }
+}
+
 /* convert byte to to size */
 function toxbyte($size) {
     if (!is_numeric($size) || $size <= 0) {

--- a/app/operators/lang/ar.php
+++ b/app/operators/lang/ar.php
@@ -1296,7 +1296,6 @@ $l['helpPage']['mngradattributesedit'] = "تعديل سمة-صفة";
 $l['helpPage']['mngradattributessearch'] = "البحث عن سمة-صفة";
 $l['helpPage']['mngradattributesdel'] = "حذف سمة-صفة";
 $l['helpPage']['mngradattributesimport'] = "إستيراد سمات مزود";
-$l['helpPage']['mngimportusers'] = "استيراد مستخدمين";
 
 
 $l['helpPage']['msgerrorpermissions'] = "ليس لديك الصلاحية لعرض هذه الصفحة";

--- a/app/operators/lang/de.php
+++ b/app/operators/lang/de.php
@@ -1250,7 +1250,6 @@ $l['helpPage']['mngradattributesedit'] = "";
 $l['helpPage']['mngradattributessearch'] = "";
 $l['helpPage']['mngradattributesdel'] = "";
 $l['helpPage']['mngradattributesimport'] = "";
-$l['helpPage']['mngimportusers'] = "";
 
 $l['helpPage']['msgerrorpermissions'] = "Leider haben Sie nicht die erforderlichen Berechtigungen, um auf diesen Bereich zuzugreifen. <br>Bitte kontaktieren Sie den System-Administrator.";
 

--- a/app/operators/lang/en.php
+++ b/app/operators/lang/en.php
@@ -59,6 +59,10 @@ $l['all']['RecommendedHelper'] = "Recommended Helper";
 /********************************************************************************/
 
 $l['all']['CSVData'] = "CSV-formatted data";
+$l['all']['GeneratePassword'] = "Generate Password";
+$l['all']['GeneratedPasswords'] = "Generated passwords";
+$l['all']['Yes'] = "yes";
+$l['all']['No'] = "no";
 
 $l['all']['CPU'] = "CPU";
 
@@ -461,6 +465,8 @@ $l['Tooltip']['EditPayType'] = "Edit Payment Type";
 $l['Tooltip']['RemovePayType'] = "Remove Payment Type";
 $l['Tooltip']['paymentTypeTooltip'] = "The payment type friendly name,<br/>to describe the purpose of the payment";
 $l['Tooltip']['paymentTypeNotesTooltip'] = "The payment type description, to describe<br/>the operation of the payment type";
+$l['Tooltip']['generatePasswordTooltip'] = "If set to 'yes', an 8-character random password is generated when the CSV password field is empty.";
+$l['Tooltip']['CSVDataGeneratePasswordHint'] = "Leave the password field empty to generate one when Generate Password is set to yes.";
 $l['Tooltip']['EditPayment'] = "Edit Payment";
 $l['Tooltip']['PaymentId'] = "The Payment Id";
 $l['Tooltip']['RemovePayment'] = "Remove Payment";
@@ -1847,6 +1853,7 @@ EOF;
 
 
 
+$l['messages']['generatedPasswordsExportNotice'] = "Download the generated credentials now. This one-time CSV download expires after %d minutes and contains only passwords generated during this import.";
 $l['messages']['noCheckAttributesForUser'] = "This user has no check attributes associated with it";
 $l['messages']['noReplyAttributesForUser'] = "This user has no reply attributes associated with it";
 
@@ -1887,6 +1894,7 @@ EOF;
 
 $l['buttons']['savesettings'] = "Save Settings";
 $l['buttons']['apply'] = "Apply";
+$l['buttons']['downloadGeneratedPasswordsCSV'] = "Download Generated Passwords CSV";
 
 $l['menu']['Home'] = "Home";
 $l['menu']['Managment'] = "Management";

--- a/app/operators/lang/en.php
+++ b/app/operators/lang/en.php
@@ -1250,7 +1250,22 @@ $l['helpPage']['mngradattributesedit'] = "";
 $l['helpPage']['mngradattributessearch'] = "";
 $l['helpPage']['mngradattributesdel'] = "";
 $l['helpPage']['mngradattributesimport'] = "";
-$l['helpPage']['mngimportusers'] = "";
+$l['helpPage']['mngimportusers'] = <<<EOF
+<h1 class="fs-5">Import Users</h1>
+<p>Use this page to create multiple RADIUS users from CSV-formatted data. You can select the authentication type, assign the imported users to groups, and optionally associate them with a billing plan.</p>
+
+<h2 class="fs-6">Username and password import</h2>
+<p>For <strong>Based on username and password</strong>, each CSV row must contain at least these five fields:</p>
+<pre><code>username,password,email,firstname,lastname</code></pre>
+<p>Additional optional fields can be added after the first five fields, as described in the CSV Data field.</p>
+
+<h2 class="fs-6">Generate Password</h2>
+<p>Set <strong>Generate Password</strong> to <strong>yes</strong> to generate an 8-character random password when the password field in a CSV row is empty. If a password is already provided, it is preserved. When this option is set to <strong>no</strong>, rows with an empty password are rejected.</p>
+<p>To request a generated password, keep the second CSV field empty:</p>
+<pre><code>user001,,user001@example.com,John,Doe</code></pre>
+<p>After a successful import, use <strong>Download Generated Passwords CSV</strong> to retrieve the credentials generated during that import. Passwords supplied in the original CSV are not included. The download is available once and expires after five minutes.</p>
+<p>The generated value is stored using the selected Password Type. With a one-way hashed password type, the original cannot be recovered later from the stored RADIUS attribute. When portal login is disabled, the original is not copied to the user information record; when portal login is enabled, it is also stored as the portal login password.</p>
+EOF;
 
 $l['helpPage']['msgerrorpermissions'] = "Sorry, you do not have the necessary permissions to access this area.<br>Please contact the system administrator.";
 

--- a/app/operators/lang/ja.php
+++ b/app/operators/lang/ja.php
@@ -1437,7 +1437,6 @@ $l['helpPage']['mngradattributesedit'] = "";
 $l['helpPage']['mngradattributessearch'] = "";
 $l['helpPage']['mngradattributesdel'] = "";
 $l['helpPage']['mngradattributesimport'] = "";
-$l['helpPage']['mngimportusers'] = "";
 
 $l['helpPage']['msgerrorpermissions'] = "ページにアクセスする権限がありません。 <br/>
 システム管理者に問い合わせてください <br/>";

--- a/app/operators/lang/tr.php
+++ b/app/operators/lang/tr.php
@@ -1296,7 +1296,6 @@ $l['helpPage']['mngradattributesedit'] = "";
 $l['helpPage']['mngradattributessearch'] = "";
 $l['helpPage']['mngradattributesdel'] = "";
 $l['helpPage']['mngradattributesimport'] = "";
-$l['helpPage']['mngimportusers'] = "";
 
 $l['helpPage']['msgerrorpermissions'] = "You do not have permissions to access the page. <br/>
 Please consult with your System Administrator. <br/>";

--- a/app/operators/lang/zh.php
+++ b/app/operators/lang/zh.php
@@ -1303,7 +1303,6 @@ $l['helpPage']['mngradattributesedit'] = "";
 $l['helpPage']['mngradattributessearch'] = "";
 $l['helpPage']['mngradattributesdel'] = "";
 $l['helpPage']['mngradattributesimport'] = "";
-$l['helpPage']['mngimportusers'] = "";
 
 $l['helpPage']['msgerrorpermissions'] = "你没有权限访问该页面。<br/>
 请咨询您的系统管理员。 <br/>";

--- a/app/operators/mng-import-users.php
+++ b/app/operators/mng-import-users.php
@@ -386,18 +386,11 @@
     $generatedPasswordExportToken = '';
     if (!empty($generatedCredentials)) {
         $exportCreatedAt = time();
-        $exportLifetime = 300;
+        cleanupGeneratedPasswordExports($exportCreatedAt);
 
         if (!isset($_SESSION['generated_password_exports']) ||
             !is_array($_SESSION['generated_password_exports'])) {
             $_SESSION['generated_password_exports'] = array();
-        }
-
-        foreach ($_SESSION['generated_password_exports'] as $token => $export) {
-            if (!is_array($export) || !isset($export['created_at']) ||
-                intval($export['created_at']) <= ($exportCreatedAt - $exportLifetime)) {
-                unset($_SESSION['generated_password_exports'][$token]);
-            }
         }
 
         // Keep generated credentials out of the HTML and expose them through a short-lived, session-bound token.
@@ -425,14 +418,18 @@
     if (!empty($generatedCredentials)) {
         $exportFormId = 'generated-passwords-export-form';
 
+        $exportLifetimeMinutes = intval(GENERATED_PASSWORD_EXPORT_LIFETIME_SECONDS / 60);
+        $exportNotice = sprintf(t('messages', 'generatedPasswordsExportNotice'), $exportLifetimeMinutes);
+
         echo '<div class="alert alert-warning" role="alert">'
-           . '<h2 class="h6">Generated passwords</h2>'
-           . '<p class="mb-2">Download the generated credentials now. This one-time CSV download expires after five minutes and contains only passwords generated during this import.</p>'
+           . sprintf('<h2 class="h6">%s</h2>', t('all', 'GeneratedPasswords'))
+           . sprintf('<p class="mb-2">%s</p>', $exportNotice)
            . sprintf('<form target="_blank" id="%s" method="POST" action="include/common/fileExportCSV.php">', $exportFormId)
            . sprintf('<input type="hidden" name="export_token" value="%s">',
                      htmlspecialchars($generatedPasswordExportToken, ENT_QUOTES, 'UTF-8'))
            . '<button class="btn btn-primary" type="submit">'
-           . '<i class="bi bi-filetype-csv me-2"></i>Download Generated Passwords CSV</button>'
+           . sprintf('<i class="bi bi-filetype-csv me-2"></i>%s</button>',
+                     t('buttons', 'downloadGeneratedPasswordsCSV'))
            . '</form></div>';
     }
 
@@ -524,10 +521,10 @@
         $input_descriptors1[] = array(
                                         "type" => "select",
                                         "name" => "generatepassword",
-                                        "caption" => "Generate Password",
-                                        "options" => [ "yes", "no" ],
+                                        "caption" => t('all', 'GeneratePassword'),
+                                        "options" => [ "yes" => t('all', 'Yes'), "no" => t('all', 'No') ],
                                         "selected_value" => ((isset($failureMsg)) ? $generatepassword : "no"),
-                                        "tooltipText" => "If set to 'yes', an 8-character random password is generated when the CSV password field is empty.",
+                                        "tooltipText" => t('Tooltip', 'generatePasswordTooltip'),
                                     );
 
         $input_descriptors1[] = array(
@@ -536,7 +533,7 @@
                                         "name" => "csvdata",
                                         "tooltipText" => 'Paste a CSV-formatted data input of users.<br/><br/>' .
                                                          '<b>Required fields (5):</b> username,password,email,firstname,lastname<br/>' .
-                                                         'Leave the password field empty to generate one when Generate Password is set to yes.<br/><br/>' .
+                                                         t('Tooltip', 'CSVDataGeneratePasswordHint') . '<br/><br/>' .
                                                          '<b>Optional fields (15):</b><br/>' .
                                                          '• framedipaddress - Valid IPv4 address<br/>' .
                                                          '• expiration - Date in YYYY-MM-DD format<br/>' .

--- a/app/operators/mng-import-users.php
+++ b/app/operators/mng-import-users.php
@@ -31,6 +31,7 @@
     include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'layout.php' ]);
  
     include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'functions.php' ]);
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'pages_common.php' ]);
     include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'populate_selectbox.php' ]);
 
     // init logging variables
@@ -55,6 +56,10 @@
         $valid_passwordTypes = array_values(array_diff($valid_passwordTypes, array("Cleartext-Password")));
     }
 
+    $generatepassword = 'no';
+    $generatedPasswords = array();
+    $generatedCredentials = array();
+
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if (array_key_exists('csrf_token', $_POST) && isset($_POST['csrf_token']) && dalo_check_csrf_token($_POST['csrf_token'])) {
 
@@ -75,6 +80,9 @@
             $enableportallogin = $_POST['enableportallogin'] ?? 'no';
             $enableportallogin = ($enableportallogin === 'no') ? 0 : 1;
 
+            $generatepassword = (isset($_POST['generatepassword']) && $_POST['generatepassword'] === 'yes')
+                              ? 'yes' : 'no';
+
             $data = array();
             $passwordType = "";
 
@@ -86,6 +94,7 @@
 
                 foreach ($csvFormattedData as $csvLine) {
 
+                    $passwordGenerated = false;
                     $arr = str_getcsv($csvLine, ",");
 
                     // Support 5-20 fields:
@@ -122,6 +131,11 @@
                     $sessiontimeout = trim($sessiontimeout);
                     $idletimeout = trim($idletimeout);
                     $maxdailysession = trim($maxdailysession);
+
+                    if ($generatepassword === 'yes' && $password === '') {
+                        $password = createPassword(8, $configValues['CONFIG_USER_ALLOWEDRANDOMCHARS'] ?? '');
+                        $passwordGenerated = true;
+                    }
 
                     // Validate IP address format if provided
                     if (!empty($framedipaddress) && preg_match(IP_REGEX, $framedipaddress) !== 1) {
@@ -164,6 +178,10 @@
                                                   $department, $company, $mobilephone, $workphone, $homephone,
                                                   $address, $city, $state, $country, $zip,
                                                   $sessiontimeout, $idletimeout, $maxdailysession );
+
+                        if ($passwordGenerated) {
+                            $generatedPasswords[$username] = $password;
+                        }
                     }
                 }
 
@@ -262,7 +280,9 @@
                                    );
 
                     if ($authType == 'userAuth') {
-                        $params["portalloginpassword"] = $value;
+                        if ($enableportallogin === 1) {
+                            $params["portalloginpassword"] = $value;
+                        }
                         $params["enableportallogin"] = $enableportallogin;
                         $params["changeuserinfo"] = $enableportallogin;
                     }
@@ -332,6 +352,10 @@
                         $addedBillingInfo = add_user_billing_info($dbSocket, $subject, $params);
                     }
 
+                    if (array_key_exists($subject, $generatedPasswords)) {
+                        $generatedCredentials[] = array($subject, $generatedPasswords[$subject]);
+                    }
+
                     $counter++;
                 }
 
@@ -359,6 +383,35 @@
     }
 
 
+    $generatedPasswordExportToken = '';
+    if (!empty($generatedCredentials)) {
+        $exportCreatedAt = time();
+        $exportLifetime = 300;
+
+        if (!isset($_SESSION['generated_password_exports']) ||
+            !is_array($_SESSION['generated_password_exports'])) {
+            $_SESSION['generated_password_exports'] = array();
+        }
+
+        foreach ($_SESSION['generated_password_exports'] as $token => $export) {
+            if (!is_array($export) || !isset($export['created_at']) ||
+                intval($export['created_at']) <= ($exportCreatedAt - $exportLifetime)) {
+                unset($_SESSION['generated_password_exports'][$token]);
+            }
+        }
+
+        // Keep generated credentials out of the HTML and expose them through a short-lived, session-bound token.
+        $generatedPasswordExportToken = bin2hex(random_bytes(32));
+        $_SESSION['generated_password_exports'][$generatedPasswordExportToken] = array(
+            'created_at' => $exportCreatedAt,
+            'accounts' => array_merge(array(array('Username', 'Password')), $generatedCredentials),
+        );
+
+        header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+        header('Pragma: no-cache');
+    }
+
+
     // print HTML prologue
     $title = t('Intro','mngimportusers.php');
     $help = t('helpPage','mngimportusers');
@@ -368,6 +421,20 @@
     print_title_and_help($title, $help);
 
     include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'actionMessages.php' ]);
+
+    if (!empty($generatedCredentials)) {
+        $exportFormId = 'generated-passwords-export-form';
+
+        echo '<div class="alert alert-warning" role="alert">'
+           . '<h2 class="h6">Generated passwords</h2>'
+           . '<p class="mb-2">Download the generated credentials now. This one-time CSV download expires after five minutes and contains only passwords generated during this import.</p>'
+           . sprintf('<form target="_blank" id="%s" method="POST" action="include/common/fileExportCSV.php">', $exportFormId)
+           . sprintf('<input type="hidden" name="export_token" value="%s">',
+                     htmlspecialchars($generatedPasswordExportToken, ENT_QUOTES, 'UTF-8'))
+           . '<button class="btn btn-primary" type="submit">'
+           . '<i class="bi bi-filetype-csv me-2"></i>Download Generated Passwords CSV</button>'
+           . '</form></div>';
+    }
 
     if (!isset($successMsg)) {
 
@@ -455,11 +522,21 @@
         }
 
         $input_descriptors1[] = array(
+                                        "type" => "select",
+                                        "name" => "generatepassword",
+                                        "caption" => "Generate Password",
+                                        "options" => [ "yes", "no" ],
+                                        "selected_value" => ((isset($failureMsg)) ? $generatepassword : "no"),
+                                        "tooltipText" => "If set to 'yes', an 8-character random password is generated when the CSV password field is empty.",
+                                    );
+
+        $input_descriptors1[] = array(
                                         "caption" => t('all','CSVData'),
                                         "type" => "textarea",
                                         "name" => "csvdata",
                                         "tooltipText" => 'Paste a CSV-formatted data input of users.<br/><br/>' .
-                                                         '<b>Required fields (5):</b> username,password,email,firstname,lastname<br/><br/>' .
+                                                         '<b>Required fields (5):</b> username,password,email,firstname,lastname<br/>' .
+                                                         'Leave the password field empty to generate one when Generate Password is set to yes.<br/><br/>' .
                                                          '<b>Optional fields (15):</b><br/>' .
                                                          '• framedipaddress - Valid IPv4 address<br/>' .
                                                          '• expiration - Date in YYYY-MM-DD format<br/>' .


### PR DESCRIPTION
## Summary

- Add a Generate Password option to the CSV user import form.
- Generate an 8-character password only when the CSV password field is empty.
- Preserve explicitly supplied passwords, including the literal value `0`.
- Provide generated credentials through a session-bound, one-time CSV download.
- Keep the generated-password export available for five minutes without depending on the page-wide CSRF token.
- Avoid persisting the original password in `userinfo.portalloginpassword` unless portal login is explicitly enabled.
- Add contextual help for the import format, password generation, download lifetime, and password storage behavior.
- Preserve the existing English-help fallback for languages without a translated import help page.
- Harden the shared CSV exporter with proper CSV escaping, malformed-input handling, CSRF validation for the existing batch export, and non-cacheable attachment headers.

## Security and behavior

Generated credentials are not embedded in the result page or included in the URL. They are stored temporarily in the authenticated operator session and exposed through a random 256-bit token that:

- is bound to the originating session;
- is submitted using POST;
- can only be used once;
- expires after 300 seconds;
- remains valid if another form rotates the global CSRF token.

The existing batch-user CSV export remains protected by its CSRF token.

## Testing

Validated in the Docker development environment with PHP 8.4:

- PHP syntax checks for all modified PHP files;
- repository/container file-hash comparison;
- repository/container file-hash comparison;
- missing and tampered Generate Password values;
- missing and tampered Generate Password values;
- existing users, duplicate CSV usernames, invalid rows, and failed inserts;
- 20-column acceptance and 21-column rejection;
- portal login enabled and disabled;
- generated credential exclusion for explicit, existing, invalid, and skipped users;
- generated credential exclusion for explicit, existing, invalid, and skipped users;
- token behavior after global CSRF rotation;
- token behavior after global CSRF rotation;
- unauthenticated and cross-session token rejection;
- legacy batch CSV compatibility and invalid-CSRF rejection;
- MAC/PIN import regression path;
- MAC/PIN import regression path;

All temporary database records were removed after testing.

## Notes

Password generation intentionally reuses the existing `createPassword()` behavior. Changing the underlying random-number implementation is outside the scope of this PR.

Password generation intentionally reuses the existing `createPassword()` behavior. Changing the underlying random-number implementation is outside the scope of this PR.

The existing CRLF format of `app/operators/lang/en.php` is preserved.

## Related issues

Fixes: #706

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generates passwords during CSV user import and offers a one-time CSV download of only the generated credentials. Previously, empty password fields caused rejection; now, when Generate Password=yes, the import creates an 8‑character password for empty fields, preserves any provided password (including 0), and keeps credentials out of the UI.

- Adds a Generate Password selector to the import form. Leave the CSV password field empty to request generation; otherwise the existing behavior applies.
- Provides generated credentials via a session-bound, one-time POST download token (256‑bit, single use, 5‑minute expiry, independent of global CSRF rotation).
- Stores the portal login password only when portal login is enabled; otherwise does not persist the original in userinfo.
- Hardens the shared CSV exporter: proper CSV quoting with fputcsv, skips malformed input, validates CSRF for the existing batch export, sanitizes batch names, and sends non-cacheable, nosniff attachment headers with CRLF line endings.
- Adds contextual help and UI strings for import and password generation; other locales fall back to English until translated.

<sup>Written for commit 843a965fe131b5ee0c2a0a1c2ac60af94af89c1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

