### PR TITLE
fix(i18n): remove dead duplicate keys from the language packs 🤖🤖🤖

### DIFF
--- a/app/operators/lang/ar.php
+++ b/app/operators/lang/ar.php
@@ -226,7 +226,6 @@ $l['all']['ActiveUsers'] = "المستخدمين النشطين";
 $l['all']['TotalBilled'] = "إجمالي المفوتر";
 $l['all']['TotalPayed'] = "إجمالي المدفوع";
 $l['all']['Balance'] = "الرصيد";
-$l['all']['CardBank'] = "كارت البنك";
 $l['all']['Type'] = "النوع";
 $l['all']['CardBank'] = "كارت البنك";
 $l['all']['MACAddress'] = "عنوان ماك";
@@ -349,7 +348,6 @@ $l['all']['BandwidthDown'] = "حجم التحميل";
 
 $l['all']['BatchCost'] = "تكلفة الدفعة";
 
-$l['all']['PaymentDate'] = "تاريخ الدفع";
 $l['all']['PaymentStatus'] = "حالة الدفع";
 $l['all']['FirstName'] = "الاسم الاول";
 $l['all']['LastName'] = "الاسم الاخير";
@@ -1013,7 +1011,6 @@ $l['Intro']['configdashboard.php'] = "اعدادات لوحة التحكم";
 $l['Intro']['paymenttypesmain.php'] = "صفحة أصناف الدفع";
 $l['Intro']['paymenttypesdel.php'] = "حذف صنف الدفع";
 $l['Intro']['paymenttypesedit.php'] = "تعديل صنف الدفع";
-$l['Intro']['paymenttypeslist.php'] = "جدول أصناف المدفوعات";
 $l['Intro']['paymenttypesnew.php'] = "انشاء صنف دفع جديد";
 $l['Intro']['paymenttypeslist.php'] = "جدول أصناف المدفوعات";
 $l['Intro']['paymentslist.php'] = "جدول المدفوعات";
@@ -1133,7 +1130,6 @@ $l['Intro']['reptopusers.php'] = "أعلى المستخدمين";
 $l['Intro']['repusername.php'] = "عرض المستخدمين";
 
 
-$l['Intro']['mngbatch.php'] = "إنشاء حزمة كروت";
 $l['Intro']['mngbatchdel.php'] = "حذف جلسات دفعة";
 
 $l['Intro']['mngdel.php'] = "حذف مستخدم";

--- a/app/operators/lang/de.php
+++ b/app/operators/lang/de.php
@@ -352,7 +352,6 @@ $l['all']['BandwidthDown'] = "Downstream-Bandbreite";
 
 $l['all']['BatchCost'] = "Batch-Gebühr";
 
-$l['all']['PaymentDate'] = "Zahlungsdatum";
 $l['all']['PaymentStatus'] = "Zahlungsstatus";
 $l['all']['FirstName'] = "Vorname";
 $l['all']['LastName'] = "Nachname";
@@ -1087,7 +1086,6 @@ $l['Intro']['repstatus.php'] = "Statusseite";
 $l['Intro']['reptopusers.php'] = "Top-Benutzer";
 $l['Intro']['repusername.php'] = "Benutzer auflisten";
 
-$l['Intro']['mngbatch.php'] = "Batch-Benutzer erstellen";
 $l['Intro']['mngbatchdel.php'] = "Batch-Sessions löschen";
 
 $l['Intro']['mngdel.php'] = "Benutzer entfernen";

--- a/app/operators/lang/en.php
+++ b/app/operators/lang/en.php
@@ -233,7 +233,6 @@ $l['all']['ActiveUsers'] = "Active Users";
 $l['all']['TotalBilled'] = "Total Billed";
 $l['all']['TotalPayed'] = "Total Paid";
 $l['all']['Balance'] = "Balance";
-$l['all']['CardBank'] = "Card Bank";
 $l['all']['Type'] = "Type";
 $l['all']['CardBank'] = "CardBank";
 $l['all']['MACAddress'] = "MAC Address";
@@ -356,7 +355,6 @@ $l['all']['BandwidthDown'] = "Bandwidth Down";
 
 $l['all']['BatchCost'] = "Batch Cost";
 
-$l['all']['PaymentDate'] = "Payment Date";
 $l['all']['PaymentStatus'] = "Payment Status";
 $l['all']['FirstName'] = "First name";
 $l['all']['LastName'] = "Last name";
@@ -974,7 +972,6 @@ $l['Intro']['configdashboard.php'] = "Dashbard Settings";
 $l['Intro']['paymenttypesmain.php'] = "Payment Types Page";
 $l['Intro']['paymenttypesdel.php'] = "Delete Payment Type entry";
 $l['Intro']['paymenttypesedit.php'] = "Edit Payment Type Details";
-$l['Intro']['paymenttypeslist.php'] = "Payment Types Table";
 $l['Intro']['paymenttypesnew.php'] = "New Payment Type entry";
 $l['Intro']['paymenttypeslist.php'] = "Payment Types Table";
 $l['Intro']['paymentslist.php'] = "Payments Table";
@@ -1093,7 +1090,6 @@ $l['Intro']['repstatus.php'] = "Status Page";
 $l['Intro']['reptopusers.php'] = "Top Users";
 $l['Intro']['repusername.php'] = "Users Listing";
 
-$l['Intro']['mngbatch.php'] = "Create batch users";
 $l['Intro']['mngbatchdel.php'] = "Delete batch sessions";
 
 $l['Intro']['mngdel.php'] = "Remove User";

--- a/app/operators/lang/es_ve.php
+++ b/app/operators/lang/es_ve.php
@@ -161,7 +161,6 @@ $l['all']['RateCost'] = "Costo de la tarifa";
 $l['all']['Billed'] = "Cobrado";
 $l['all']['TotalUsers'] = "Cantidad de usuarios";
 $l['all']['TotalBilled'] = "Usuarios a quienes se les ha cobrado";
-$l['all']['CardBank'] = "Banco emisor";
 $l['all']['Type'] = "Tipo";
 $l['all']['CardBank'] = "Banco emisor";
 $l['all']['MACAddress'] = "Direcci&oacute;n MAC";
@@ -798,7 +797,6 @@ $l['Intro']['replogssystem.php'] = "Registro del sistema";
 $l['Intro']['replogsradius.php'] = "Registro del servidor RADIUS";
 $l['Intro']['replogsdaloradius.php'] = "Registro de daloRADIUS";
 $l['Intro']['replogsboot.php'] = "Registro de inicio del sistema";
-$l['Intro']['replogs.php'] = "Registros";
 
 $l['Intro']['rephsall.php'] = "Listado de Hotspots";
 $l['Intro']['repmain.php'] = "Reportes";

--- a/app/operators/lang/hu.php
+++ b/app/operators/lang/hu.php
@@ -159,7 +159,6 @@ $l['all']['RateCost'] = "Rate Cost";
 $l['all']['Billed'] = "Számlázott";
 $l['all']['TotalUsers'] = "Összes felhasználó";
 $l['all']['TotalBilled'] = "Összes számlázott";
-$l['all']['CardBank'] = "Bank neve";
 $l['all']['Type'] = "Típusa";
 $l['all']['CardBank'] = "Bank";
 $l['all']['MACAddress'] = "MAC Cím";
@@ -328,8 +327,6 @@ $l['Tooltip']['RateName'] = "Type the Rate name";
 $l['Tooltip']['OperatorName'] = "Type the Operator name";
 $l['Tooltip']['BillingPlanName'] = "Type the Billing Plan name";
 
-$l['Tooltip']['EditRate'] = "Edit Rate";
-$l['Tooltip']['RemoveRate'] = "Remove Rate";
 
 $l['Tooltip']['EditRate'] = "Edit Rate";
 $l['Tooltip']['RemoveRate'] = "Remove Rate";
@@ -850,7 +847,6 @@ $l['Intro']['replogssystem.php'] = "Rendszernapló";
 $l['Intro']['replogsradius.php'] = "RADIUS Szerver napló";
 $l['Intro']['replogsdaloradius.php'] = "daloRADIUS napló";
 $l['Intro']['replogsboot.php'] = "Boot napló";
-$l['Intro']['replogs.php'] = "Naplók";
 
 $l['Intro']['rephsall.php'] = "Hotspotok listája";
 $l['Intro']['repmain.php'] = "Jelentések oldal";

--- a/app/operators/lang/it.php
+++ b/app/operators/lang/it.php
@@ -146,7 +146,6 @@ $l['all']['Rate'] = "Rate";
 $l['all']['Billed'] = "Billed";
 $l['all']['TotalUsers'] = "Totale Utenti";
 $l['all']['TotalBilled'] = "Total Billed";
-$l['all']['CardBank'] = "Card Bank";
 $l['all']['Type'] = "Type";
 $l['all']['CardBank'] = "CardBank";
 $l['all']['MACAddress'] = "Indirizzo MAC";
@@ -634,7 +633,6 @@ $l['Intro']['replogssystem.php'] = "System Logfile";
 $l['Intro']['replogsradius.php'] = "RADIUS Server Logfile";
 $l['Intro']['replogsdaloradius.php'] = "daloRADIUS Logfile";
 $l['Intro']['replogsboot.php'] = "Boot Logfile";
-$l['Intro']['replogs.php'] = "Logs";
 
 $l['Intro']['rephsall.php'] = "Mostra Hotspot";
 $l['Intro']['repmain.php'] = "Reports Page";

--- a/app/operators/lang/ja.php
+++ b/app/operators/lang/ja.php
@@ -172,7 +172,6 @@ $l['all']['HgPortId'] = "ハントグループポート ID";
 
 $l['all']['NasID'] = "NAS ID";
 $l['all']['Nas'] = "NAS ";
-$l['all']['Nas'] = "NAS ";
 $l['all']['NasIPHost'] = "NAS IP/ホスト";
 $l['all']['NasShortname'] = "NAS 短い名前";
 $l['all']['NasType'] = "NASタイプ";
@@ -382,7 +381,6 @@ $l['all']['BandwidthDown'] = "Bandwidth Down";
 
 $l['all']['BatchCost'] = "バッチコスト";
 
-$l['all']['PaymentDate'] = "支払日";
 
 $l['all']['PaymentStatus'] = "支払い状況";
 $l['all']['FirstName'] = "姓";
@@ -1250,7 +1248,6 @@ $l['Intro']['repstatus.php'] = "状態ページ";
 $l['Intro']['reptopusers.php'] = "トップユーザ";
 $l['Intro']['repusername.php'] = "ユーザ一覧";
 
-$l['Intro']['mngbatch.php'] = "バッチユーザ作成";
 $l['Intro']['mngbatchdel.php'] = "バッチセッション削除";
 
 $l['Intro']['mngdel.php'] = "ユーザ削除";

--- a/app/operators/lang/pt_br.php
+++ b/app/operators/lang/pt_br.php
@@ -158,7 +158,6 @@ $l['all']['RateCost'] = "Custo da taxa";
 $l['all']['Billed'] = "Faturado";
 $l['all']['TotalUsers'] = "Total de Usuários";
 $l['all']['TotalBilled'] = "Total de Cobranças";
-$l['all']['CardBank'] = "Cartão de credito";
 $l['all']['Type'] = "Tipo";
 $l['all']['CardBank'] = "Cartão de credito";
 $l['all']['MACAddress'] = "Endereço do MAC";
@@ -844,7 +843,6 @@ $l['Intro']['replogssystem.php'] = "Logfile do sistema";
 $l['Intro']['replogsradius.php'] = "Logfile do servidor RADIUS";
 $l['Intro']['replogsdaloradius.php'] = "Logfile daloRADIUS";
 $l['Intro']['replogsboot.php'] = "Logfile do Boot";
-$l['Intro']['replogs.php'] = "Logs";
 
 $l['Intro']['rephsall.php'] = "Lista de Hotspots";
 $l['Intro']['repmain.php'] = "Pagina de relatório";

--- a/app/operators/lang/ro.php
+++ b/app/operators/lang/ro.php
@@ -159,7 +159,6 @@ $l['all']['RateCost'] = "Pretul de cost";
 $l['all']['Billed'] = "Facturat";
 $l['all']['TotalUsers'] = "Total Utilizatori";
 $l['all']['TotalBilled'] = "Total facturat";
-$l['all']['CardBank'] = "Card bancar";
 $l['all']['Type'] = "Tip";
 $l['all']['CardBank'] = "CardBank";
 $l['all']['MACAddress'] = "MAC Address";
@@ -681,7 +680,6 @@ $l['title']['VendorAttribute'] = "Vendor atribut";
 $l['title']['AccountRemoval'] = "Contul de eliminare";
 $l['title']['AccountInfo'] = "Informa?ii despre cont";
 
-$l['title']['Profile'] = "Profiluri";
 $l['title']['ProfileInfo'] = "Profil Info";
 
 $l['title']['GroupInfo'] = "informa?ii despre grup";
@@ -865,7 +863,6 @@ $l['Intro']['replogssystem.php'] = "System Logfile";
 $l['Intro']['replogsradius.php'] = "RADIUS server Logfile";
 $l['Intro']['replogsdaloradius.php'] = "daloRADIUS Logfile";
 $l['Intro']['replogsboot.php'] = "boot Logfile";
-$l['Intro']['replogs.php'] = "Rapoarte";
 
 $l['Intro']['rephsall.php'] = "hotspots Listing ";
 $l['Intro']['repmain.php'] = "Rapoarte Page";

--- a/app/operators/lang/ru.php
+++ b/app/operators/lang/ru.php
@@ -110,7 +110,6 @@ $l['all']['Rate'] = "Rate";
 $l['all']['Billed'] = "Billed";
 $l['all']['TotalUsers'] = "Всего пользователей";
 $l['all']['TotalBilled'] = "Всего начислено";
-$l['all']['CardBank'] = "Card Bank";
 $l['all']['Type'] = "Type";
 $l['all']['CardBank'] = "CardBank";
 $l['all']['MACAddress'] = "MAC-адрес";
@@ -498,7 +497,6 @@ $l['Intro']['replogssystem.php'] = "System Logfile";
 $l['Intro']['replogsradius.php'] = "RADIUS Server Logfile";
 $l['Intro']['replogsdaloradius.php'] = "daloRADIUS Logfile";
 $l['Intro']['replogsboot.php'] = "Boot Logfile";
-$l['Intro']['replogs.php'] = "Logs";
 
 $l['Intro']['rephsall.php'] = "Hotspots Listing";
 $l['Intro']['repmain.php'] = "Reports Page";

--- a/app/operators/lang/tr.php
+++ b/app/operators/lang/tr.php
@@ -68,9 +68,6 @@ $l['all']['RADIUSDictionaryPath'] = "RADIUS Dictionary Path";
 
 
 $l['all']['DashboardSecretKey'] = "Kontrol Paneli Gizli Anahtarı";
-$l['all']['DashboardDebug'] = "Debug";
-$l['all']['DashboardDelaySoft'] = "Time in minutes to consider a 'soft' delay limit";
-$l['all']['DashboardDelayHard'] = "Time in minutes to consider a 'hard' delay limit";
 $l['all']['DashboardDebug'] = "Hata Ayıklama";
 $l['all']['DashboardDelaySoft'] = "'soft' bir gecikme limitini dikkate almak için dakika cinsinden süre";
 $l['all']['DashboardDelayHard'] = "'hard' bir gecikme limitini dikkate almak için dakika cinsinden süre";
@@ -233,7 +230,6 @@ $l['all']['ActiveUsers'] = "Aktif Kullanıcılar";
 $l['all']['TotalBilled'] = "Toplam Faturalanan";
 $l['all']['TotalPayed'] = "Toplam Ödenen";
 $l['all']['Balance'] = "Bakiye";
-$l['all']['CardBank'] = "Kart Bankası";
 $l['all']['Type'] = "Tip";
 $l['all']['CardBank'] = "Kart Bankası";
 $l['all']['MACAddress'] = "MAC Adresi";
@@ -355,7 +351,6 @@ $l['all']['BandwidthDown'] = "Bandwidth Down";
 
 $l['all']['BatchCost'] = "Toplu Maliyet";
 
-$l['all']['PaymentDate'] = "Ödeme Tarihi";
 $l['all']['PaymentStatus'] = "Ödeme Durumu";
 $l['all']['FirstName'] = "Ad";
 $l['all']['LastName'] = "Soyadı";
@@ -1014,7 +1009,6 @@ $l['Giriş']['configdashboard.php'] = "Kontrol Paneli Ayarları";
 $l['Giriş']['paymenttypesmain.php'] = "Ödeme Türleri Sayfası";
 $l['Intro']['paymenttypesdel.php'] = "Ödeme Türü Girişini Silin";
 $l['Intro']['paymenttypesedit.php'] = "Ödeme Türü Ayrıntılarını Düzenle";
-$l['Intro']['paymenttypeslist.php'] = "Ödeme Türleri Tablosu";
 $l['Intro']['paymenttypesnew.php'] = "Yeni Ödeme Tipi";
 $l['Intro']['paymenttypeslist.php'] = "Ödeme Türleri Tablosu";
 $l['Giriş']['paymentslist.php'] = "Ödeme Tablosu";

--- a/app/operators/lang/zh.php
+++ b/app/operators/lang/zh.php
@@ -230,7 +230,6 @@ $l['all']['ActiveUsers'] = "活动用户";
 $l['all']['TotalBilled'] = "总记账";
 $l['all']['TotalPayed'] = "总支付";
 $l['all']['Balance'] = "余额";
-$l['all']['CardBank'] = "银行卡";
 $l['all']['Type'] = "类型";
 $l['all']['CardBank'] = "银行卡";
 $l['all']['MACAddress'] = "MAC地址";
@@ -353,7 +352,6 @@ $l['all']['BandwidthDown'] = "下载带宽";
 
 $l['all']['BatchCost'] = "批量花费";
 
-$l['all']['PaymentDate'] = "付款日";
 $l['all']['PaymentStatus'] = "付款状态";
 $l['all']['FirstName'] = "名";
 $l['all']['LastName'] = "姓";
@@ -1021,7 +1019,6 @@ $l['Intro']['configdashboard.php'] = "仪表盘设置";
 $l['Intro']['paymenttypesmain.php'] = "支付类型页面";
 $l['Intro']['paymenttypesdel.php'] = "删除支付类型条目";
 $l['Intro']['paymenttypesedit.php'] = "编辑支付类型明细";
-$l['Intro']['paymenttypeslist.php'] = "支付类型表格";
 $l['Intro']['paymenttypesnew.php'] = "新建支付类型条目";
 $l['Intro']['paymenttypeslist.php'] = "支付类型表格";
 $l['Intro']['paymentslist.php'] = "支付表格";
@@ -1140,7 +1137,6 @@ $l['Intro']['repstatus.php'] = "状态页面";
 $l['Intro']['reptopusers.php'] = "用户使用详情";
 $l['Intro']['repusername.php'] = "用户列表";
 
-$l['Intro']['mngbatch.php'] = "创建批量用户";
 $l['Intro']['mngbatchdel.php'] = "删除批量会话";
 
 $l['Intro']['mngdel.php'] = "移除用户";


### PR DESCRIPTION
## What

Twelve language packs assign the same key more than once. PHP keeps the last assignment, so the earlier lines are dead code — 38 of them across `app/operators/lang/`.

This PR removes the overwritten assignments and keeps the last one in every case, so **the rendered output is byte-for-byte unchanged**. 38 deletions, 0 insertions.

| pack | dead assignments | pack | dead assignments |
|---|---|---|---|
| `ar.php` | 4 | `ja.php` | 3 |
| `de.php` | 2 | `pt_br.php` | 2 |
| `en.php` | 4 | `ro.php` | 3 |
| `es_ve.php` | 2 | `ru.php` | 2 |
| `hu.php` | 4 | `tr.php` | 6 |
| `it.php` | 2 | `zh.php` | 4 |

The affected keys are mostly `$l['all']['CardBank']`, `$l['all']['PaymentDate']`, `$l['Intro']['mngbatch.php']` and `$l['Intro']['replogs.php']`, which look like they were introduced twice at different points in the file's history.

## Why it is worth cleaning up

Beyond the dead weight, the duplicates hide what the UI actually renders. A few examples where the two values differ, so the visible string is *not* the one the earlier line suggests:

```php
// en.php - renders "CardBank", not "Card Bank"
$l['all']['CardBank'] = "Card Bank";
$l['all']['CardBank'] = "CardBank";

// en.php - renders "Date", not "Payment Date"
$l['all']['PaymentDate'] = "Payment Date";
$l['all']['PaymentDate'] = "Date";
```

`tr.php` is the clearest case of why keeping the *last* value is the right call — the second block is the actual Turkish translation overriding untranslated English left above it:

```php
$l['all']['DashboardDebug'] = "Debug";
$l['all']['DashboardDelaySoft'] = "Time in minutes to consider a 'soft' delay limit";
$l['all']['DashboardDelayHard'] = "Time in minutes to consider a 'hard' delay limit";
$l['all']['DashboardDebug'] = "Hata Ayıklama";
$l['all']['DashboardDelaySoft'] = "'soft' bir gecikme limitini dikkate almak için dakika cinsinden süre";
$l['all']['DashboardDelayHard'] = "'hard' bir gecikme limitini dikkate almak için dakika cinsinden süre";
```

## Scope

Deliberately **not** included: changing any of the surviving values. `en.php` rendering `CardBank` without a space, and `PaymentDate` rendering as `Date`, both look unintentional — but correcting them changes visible UI text in every locale, which belongs in its own PR. Happy to open one if you agree they should be fixed.

`app/users/lang/` has no duplicates. `contrib/` was left alone.

## Testing

Verified per file by evaluating the `key -> final value` map before and after the edit and asserting the two are identical, so behaviour is provably unchanged. Also checked that only whole assignment lines were removed, that no duplicates remain in any pack, and that all 19 language files still lex cleanly (strings, heredocs and comments balanced).

Line endings are preserved — all twelve files are CRLF and stay CRLF.

## Related

Split out of #743 following review feedback there, which flagged two of these duplicates in a new language pack that had inherited them from `zh.php`. This PR is independent of #743 and can be merged in either order. The two do
overlap in one file, `app/operators/lang/en.php`, but in regions far apart --
this PR removes lines around 233-1093, #743 appends a block at 1906 -- so git
auto-merges them cleanly. I verified that locally: merging the two branches
produces no conflict, and the merged tree still has zero duplicate keys and
full key parity.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes 38 dead duplicate keys from 12 language packs in `app/operators/lang/`. Since PHP keeps the last assignment when a key is set twice, these earlier lines never reach the UI; deleting them keeps rendered output byte-for-byte unchanged.

Deliberately not fixing surviving values that look unintentional, like `en.php` rendering "CardBank" instead of "Card Bank" and `PaymentDate` as "Date" — that changes visible UI text in every locale and deserves its own PR.

<sup>Written for commit 9c1afab129f07578e2e1a18115674239760708ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


