### PR TITLE
Fix/cleartext password handling

### DIFF
--- a/app/common/includes/validation.php
+++ b/app/common/includes/validation.php
@@ -149,6 +149,11 @@ $valid_authTypes = array(
                             "pincodeAuth" => "Based on PIN code"
                         );
 
+// complete list of password types. it is used as-is wherever a password type
+// identifies a RADIUS request attribute (e.g. the maintenance test-user flow),
+// which is unrelated to what gets stored in the database.
+// pages offering a password type to be *stored* must narrow this list down
+// through dalo_filter_password_types() first.
 $valid_passwordTypes = array(
                                 "Cleartext-Password",
                                 "NT-Password",
@@ -159,8 +164,6 @@ $valid_passwordTypes = array(
                                 "Crypt-Password",
                                 //~ "CHAP-Password"
                              );
-
-$valid_passwordTypes = dalo_filter_password_types($valid_passwordTypes);
 
 // https://wiki.freeradius.org/config/Operators
 $valid_ops = [

--- a/app/common/includes/validation.php
+++ b/app/common/includes/validation.php
@@ -94,6 +94,41 @@ if (!function_exists('normalize_custom_attributes')) {
     }
 }
 
+if (!function_exists('dalo_cleartext_password_attributes')) {
+    function dalo_cleartext_password_attributes() {
+        return array("Cleartext-Password", "User-Password");
+    }
+}
+
+if (!function_exists('dalo_cleartext_password_allowed')) {
+    function dalo_cleartext_password_allowed() {
+        global $configValues;
+
+        return !isset($configValues['CONFIG_DB_PASSWORD_ENCRYPTION']) ||
+               strtolower(trim($configValues['CONFIG_DB_PASSWORD_ENCRYPTION'])) === 'yes';
+    }
+}
+
+if (!function_exists('dalo_filter_cleartext_password_attributes')) {
+    function dalo_filter_cleartext_password_attributes($attributes) {
+        if (!is_array($attributes)) {
+            return array();
+        }
+
+        if (dalo_cleartext_password_allowed()) {
+            return array_values($attributes);
+        }
+
+        return array_values(array_diff($attributes, dalo_cleartext_password_attributes()));
+    }
+}
+
+if (!function_exists('dalo_filter_password_types')) {
+    function dalo_filter_password_types($passwordTypes) {
+        return dalo_filter_cleartext_password_attributes($passwordTypes);
+    }
+}
+
 define("SENDER_NAME_REGEX", '/^[a-zA-Z0-9 -]+$/');
 define("SUBJECT_PREFIX_REGEX", '/^[a-zA-Z0-9 -\[\]]+$/');
 define("RECIPIENT_NAME_REGEX", '/^[a-zA-Z0-9 -]+$/');
@@ -124,6 +159,8 @@ $valid_passwordTypes = array(
                                 "Crypt-Password",
                                 //~ "CHAP-Password"
                              );
+
+$valid_passwordTypes = dalo_filter_password_types($valid_passwordTypes);
 
 // https://wiki.freeradius.org/config/Operators
 $valid_ops = [

--- a/app/operators/bill-pos-new.php
+++ b/app/operators/bill-pos-new.php
@@ -38,12 +38,7 @@
     $logAction = "";
     $logDebugSQL = "";
 
-    // if cleartext passwords are not allowed,
-    // we remove Cleartext-Password from the $valid_passwordTypes array
-    if (isset($configValues['CONFIG_DB_PASSWORD_ENCRYPTION']) &&
-        strtolower(trim($configValues['CONFIG_DB_PASSWORD_ENCRYPTION'])) !== 'yes') {
-        $valid_passwordTypes = array_values(array_diff($valid_passwordTypes, array("Cleartext-Password")));
-    }
+    $valid_passwordTypes = dalo_filter_password_types($valid_passwordTypes);
 
     $username = (array_key_exists('username', $_POST) && isset($_POST['username']))
               ? trim(str_replace("%", "", $_POST['username'])) : "";

--- a/app/operators/bill-pos-new.php
+++ b/app/operators/bill-pos-new.php
@@ -21,17 +21,17 @@
  *********************************************************************************************************
  */
 
-    include("library/checklogin.php");
+    include_once implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', 'common', 'includes', 'config_read.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'checklogin.php' ]);
     $operator = $_SESSION['operator_user'];
 
-    include('../common/includes/config_read.php');
-    include('library/check_operator_perm.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'check_operator_perm.php' ]);
 
-    include_once("lang/main.php");
-    include_once("../common/includes/validation.php");
-    include("../common/includes/layout.php");
-    include_once("include/management/functions.php");
-    include('include/management/pages_common.php');
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LANG'], 'main.php' ]);
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'validation.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'layout.php' ]);
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'functions.php' ]);
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'pages_common.php' ]);
 
     // init logging variables
     $log = "visited page: ";
@@ -267,7 +267,7 @@
             $current_datetime = date('Y-m-d H:i:s');
             $currBy = $operator;
 
-            include('../common/includes/db_open.php');
+            include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
 
             // check if username is already present in the radcheck table
             $userExists = user_exists($dbSocket, $username);
@@ -287,7 +287,7 @@
                     // handleAttributes() - called later - will take care of it.
                     $_POST['injected_attribute'] = array( $passwordType, $password, ':=', 'check' );
 
-                    include("library/attributes.php");
+                    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'attributes.php' ]);
 
                     $skipList = array(
                                         "username", "password", "passwordType", "profiles", "planName",
@@ -336,7 +336,7 @@
 
                     // create any invoices if required (meaning, if a plan was chosen)
                     if ($planName) {
-                        include_once("include/management/userBilling.php");
+                        include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'userBilling.php' ]);
 
                         // get plan information
                         $sql = "SELECT id, planCost, planSetupCost, planTax FROM ".$configValues['CONFIG_DB_TBL_DALOBILLINGPLANS'].
@@ -393,7 +393,7 @@
                 }
             }
 
-            include('../common/includes/db_close.php');
+            include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
 
         } else {
             // csrf
@@ -401,8 +401,6 @@
             $logAction .= "$failureMsg on page: ";
         }
     }
-
-    include_once('../common/includes/config_read.php');
 
     $hiddenPassword = (strtolower($configValues['CONFIG_IFACE_PASSWORD_HIDDEN']) == "yes")
                     ? 'password' : 'text';
@@ -425,11 +423,11 @@
 
     print_title_and_help($title, $help);
 
-    include_once('include/management/actionMessages.php');
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'actionMessages.php' ]);
 
     if (!isset($successMsg)) {
 
-        include_once('include/management/populate_selectbox.php');
+        include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'populate_selectbox.php' ]);
 
         // set navbar stuff
         $navkeys = array( 'AccountInfo', 'UserInfo', 'BillingInfo' );
@@ -517,7 +515,7 @@
         open_tab($navkeys, 1);
 
         //~ $customApplyButton = sprintf('<input type="submit" name="submit" value="%s" class="button">', t('buttons','apply'));
-        include_once('include/management/userinfo.php');
+        include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'userinfo.php' ]);
 
         close_tab($navkeys, 1);
 
@@ -525,7 +523,7 @@
         open_tab($navkeys, 2);
 
         //~ $customApplyButton = sprintf('<input type="submit" name="submit" value="%s" class="button">', t('buttons','apply'));
-        include_once('include/management/userbillinfo.php');
+        include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'userbillinfo.php' ]);
 
         close_tab($navkeys, 2);
 
@@ -556,7 +554,7 @@
 
     print_back_to_previous_page();
 
-    include('include/config/logging.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_CONFIG'], 'logging.php' ]);
     print_footer_and_html_epilogue();
 
 ?>

--- a/app/operators/bill-pos-new.php
+++ b/app/operators/bill-pos-new.php
@@ -267,7 +267,7 @@
             $current_datetime = date('Y-m-d H:i:s');
             $currBy = $operator;
 
-            include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
+            include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
 
             // check if username is already present in the radcheck table
             $userExists = user_exists($dbSocket, $username);
@@ -393,7 +393,7 @@
                 }
             }
 
-            include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
+            include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
 
         } else {
             // csrf

--- a/app/operators/bill-pos-new.php
+++ b/app/operators/bill-pos-new.php
@@ -277,10 +277,12 @@
                 $logAction .= "Failed adding new user already existing in database [$username] on page: ";
             } else {
 
-                // username and password are required
-                if (empty($username) || empty($password)) {
-                    $failureMsg = "username or password are empty";
-                    $logAction .= "Failed adding (possible empty user/pass) new user [$username] on page: ";
+                // username, password and password type are required. an empty password type
+                // means the posted one is unknown or no longer permitted (e.g. a cleartext
+                // type submitted while CONFIG_DB_PASSWORD_ENCRYPTION is set to 'no')
+                if (empty($username) || empty($password) || empty($passwordType)) {
+                    $failureMsg = "username, password or password type are empty or invalid";
+                    $logAction .= "Failed adding (possible empty user/pass or invalid password type) new user [$username] on page: ";
                 } else {
 
                     // we "inject" the prepared password/auth attribute in the $_POST array.

--- a/app/operators/config-user.php
+++ b/app/operators/config-user.php
@@ -21,15 +21,15 @@
  *********************************************************************************************************
  */
 
-    include ("library/checklogin.php");
+    include_once implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', 'common', 'includes', 'config_read.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'checklogin.php' ]);
     $operator = $_SESSION['operator_user'];
 
-    include('../common/includes/config_read.php');
-    include('library/check_operator_perm.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'check_operator_perm.php' ]);
 
-    include_once("lang/main.php");
-    include("../common/includes/validation.php");
-    include("../common/includes/layout.php");
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LANG'], 'main.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'validation.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'layout.php' ]);
 
     // init logging variables
     $log = "visited page: ";
@@ -82,7 +82,7 @@
                 $failureMsg = sprintf("Invalid input: [%s]", implode(", ", array_values($invalid_input)));
                 $logAction .= "$failureMsg on page: ";
             } else {
-                include("../common/includes/config_write.php");
+                include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'config_write.php' ]);
             }
 
         } else {
@@ -101,7 +101,7 @@
 
     print_title_and_help($title, $help);
 
-    include_once('include/management/actionMessages.php');
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'actionMessages.php' ]);
 
     $fieldset0_descriptor = array(
                                     "title" => t('title','Settings')
@@ -166,7 +166,7 @@
 
     close_form();
 
-    include('include/config/logging.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_CONFIG'], 'logging.php' ]);
 
     print_footer_and_html_epilogue();
 

--- a/app/operators/config-user.php
+++ b/app/operators/config-user.php
@@ -41,7 +41,7 @@
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if (array_key_exists('csrf_token', $_POST) && isset($_POST['csrf_token']) && dalo_check_csrf_token($_POST['csrf_token'])) {
 
-            // validate allow Cleartext-Password attributes
+            // validate cleartext password attributes
             if (
                     array_key_exists('CONFIG_DB_PASSWORD_ENCRYPTION', $_POST) &&
                     !empty(trim($_POST['CONFIG_DB_PASSWORD_ENCRYPTION'])) &&
@@ -112,7 +112,7 @@
     $input_descriptors0[] = array(
                                     "type" => "select",
                                     "options" => array( "yes", "no" ),
-                                    "caption" => "Allow cleartext password in db",
+                                    "caption" => "Allow cleartext password attributes in db",
                                     "name" => 'CONFIG_DB_PASSWORD_ENCRYPTION',
                                     "selected_value" => $configValues['CONFIG_DB_PASSWORD_ENCRYPTION'],
                                  );

--- a/app/operators/include/management/attributes.php
+++ b/app/operators/include/management/attributes.php
@@ -55,6 +55,10 @@ if (isset($configValues['CONFIG_IFACE_AUTO_COMPLETE']) && strtolower($configValu
 
 }
 
+if (function_exists('dalo_filter_cleartext_password_attributes')) {
+    $attributes = dalo_filter_cleartext_password_attributes($attributes);
+}
+
 include('../common/includes/db_close.php');
 
 $_fieldset0_descriptor = array(

--- a/app/operators/include/management/attributes.php
+++ b/app/operators/include/management/attributes.php
@@ -27,7 +27,7 @@ if (strpos($_SERVER['PHP_SELF'], '/include/management/attributes.php') !== false
     exit;
 }
 
-include('../common/includes/db_open.php');
+include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
 
 $vendors = array( "" );
 $sql = sprintf("SELECT DISTINCT(Vendor) AS Vendor
@@ -59,7 +59,7 @@ if (function_exists('dalo_filter_cleartext_password_attributes')) {
     $attributes = dalo_filter_cleartext_password_attributes($attributes);
 }
 
-include('../common/includes/db_close.php');
+include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
 
 $_fieldset0_descriptor = array(
                                 "title" => t('title','Attributes'),

--- a/app/operators/include/management/attributes.php
+++ b/app/operators/include/management/attributes.php
@@ -27,7 +27,7 @@ if (strpos($_SERVER['PHP_SELF'], '/include/management/attributes.php') !== false
     exit;
 }
 
-include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
+include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
 
 $vendors = array( "" );
 $sql = sprintf("SELECT DISTINCT(Vendor) AS Vendor
@@ -59,7 +59,7 @@ if (function_exists('dalo_filter_cleartext_password_attributes')) {
     $attributes = dalo_filter_cleartext_password_attributes($attributes);
 }
 
-include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
+include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
 
 $_fieldset0_descriptor = array(
                                 "title" => t('title','Attributes'),

--- a/app/operators/include/management/attributes.php
+++ b/app/operators/include/management/attributes.php
@@ -55,9 +55,7 @@ if (isset($configValues['CONFIG_IFACE_AUTO_COMPLETE']) && strtolower($configValu
 
 }
 
-if (function_exists('dalo_filter_cleartext_password_attributes')) {
-    $attributes = dalo_filter_cleartext_password_attributes($attributes);
-}
+$attributes = dalo_filter_cleartext_password_attributes($attributes);
 
 include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
 

--- a/app/operators/include/management/fileExport.php
+++ b/app/operators/include/management/fileExport.php
@@ -361,14 +361,15 @@ switch ($reportType) {
 		case "reportsBatchTotalUsers":
         
             $batch_id = intval($_SESSION['reportParams']['batch_id']);
+            $cleartext_password_attributes = array("Cleartext-Password", "User-Password");
 
-            // check if in this batch there are some Cleartext-Password attributes
+            // check if in this batch there are some cleartext password attributes
             $sql = sprintf("SELECT COUNT(ubi.username)
                               FROM %s AS ubi, %s AS rc
                              WHERE rc.username=ubi.username
                                AND ubi.batch_id=%d
                                AND rc.op=':='
-                               AND rc.attribute='Cleartext-Password'",
+                               AND rc.attribute IN ('Cleartext-Password', 'User-Password')",
                            $configValues['CONFIG_DB_TBL_DALOUSERBILLINFO'],
                            $configValues['CONFIG_DB_TBL_RADCHECK'], $batch_id);
 
@@ -408,7 +409,7 @@ switch ($reportType) {
                 
                 list($username, $attribute, $value) = $row;
                 
-                if ($attribute != "Cleartext-Password" || $attribute == "Auth-Type") {
+                if (!in_array($attribute, $cleartext_password_attributes, true)) {
                     $value = "(empty)";
                 }
                 

--- a/app/operators/include/management/fileExport.php
+++ b/app/operators/include/management/fileExport.php
@@ -24,7 +24,8 @@
  *********************************************************************************************************
  */
  
-include('../../library/checklogin.php');
+include_once implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', '..', '..', 'common', 'includes', 'config_read.php' ]);
+include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'checklogin.php' ]);
 
 // reportFormat is either CSV or PDF
 $reportFormat = (array_key_exists('reportFormat', $_GET) && isset($_GET['reportFormat']) &&
@@ -76,7 +77,7 @@ function exportPDFFile($output) {
 	print $output;
 }
 
-include_once('../../../common/includes/db_open.php');
+include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
 
 // we init output
 $output = "";
@@ -440,7 +441,7 @@ switch ($reportType) {
 
 }
 
-include_once('../../../common/includes/db_close.php');
+include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
 
 // at this point, if $output is not empty we can export the file
 if (!empty($output)) {

--- a/app/operators/include/management/populate_selectbox.php
+++ b/app/operators/include/management/populate_selectbox.php
@@ -679,16 +679,31 @@ function populate_proxys($defaultOption = "Select Proxy",$elementName = "", $css
  */
 function populate_password_types($elementName = "", $cssClass = "form", $mode = "") {
 
+    $passwordTypes = array(
+        "Cleartext-Password",
+        "User-Password",
+        "Crypt-Password",
+        "MD5-Password",
+        "SHA1-Password",
+        "SHA2-Password",
+        "CHAP-Password",
+    );
+
+    if (function_exists('dalo_filter_password_types')) {
+        $passwordTypes = dalo_filter_password_types($passwordTypes);
+    } elseif (function_exists('dalo_cleartext_password_allowed') && !dalo_cleartext_password_allowed()) {
+        $passwordTypes = array_values(array_diff($passwordTypes, array("Cleartext-Password", "User-Password")));
+    }
+
     echo "<select $mode
             name='$elementName' class='$cssClass' tabindex=105 />
-            <option value='Cleartext-Password'>Cleartext-Password</option>
-            <option value='User-Password'>User-Password</option>
-            <option value='Crypt-Password'>Crypt-Password</option>
-            <option value='MD5-Password'>MD5-Password</option>
-            <option value='SHA1-Password'>SHA1-Password</option>
-            <option value='SHA2-Password'>SHA2-Password</option>
-            <option value='CHAP-Password'>CHAP-Password</option>
-            </select>";
+            ";
+
+    foreach ($passwordTypes as $passwordType) {
+        echo sprintf("<option value='%s'>%s</option>", $passwordType, $passwordType);
+    }
+
+    echo "</select>";
 }
 
 

--- a/app/operators/include/management/populate_selectbox.php
+++ b/app/operators/include/management/populate_selectbox.php
@@ -669,45 +669,12 @@ function populate_proxys($defaultOption = "Select Proxy",$elementName = "", $css
 
 }
 
-/*
- * populate_passwordTypes
- * creates a select box and populates it with all supported password types
- * 
- * $elementName   - the string used for the select element's name='' value
- * $cssClass      - the css/xhtml class name, default is form for displaying on content divs (not sidebar)
- *
- */
-function populate_password_types($elementName = "", $cssClass = "form", $mode = "") {
-
-    $passwordTypes = array(
-        "Cleartext-Password",
-        "User-Password",
-        "Crypt-Password",
-        "MD5-Password",
-        "SHA1-Password",
-        "SHA2-Password",
-        "CHAP-Password",
-    );
-
-    if (function_exists('dalo_filter_password_types')) {
-        $passwordTypes = dalo_filter_password_types($passwordTypes);
-    } elseif (function_exists('dalo_cleartext_password_allowed') && !dalo_cleartext_password_allowed()) {
-        $passwordTypes = array_values(array_diff($passwordTypes, array("Cleartext-Password", "User-Password")));
-    }
-
-    echo "<select $mode
-            name='$elementName' class='$cssClass' tabindex=105 />
-            ";
-
-    foreach ($passwordTypes as $passwordType) {
-        echo sprintf("<option value='%s'>%s</option>", $passwordType, $passwordType);
-    }
-
-    echo "</select>";
-}
-
-
-
+// populate_password_types() used to live here with its own hardcoded list of
+// password types. It had no callers left: the pages offering a password type
+// build their select box out of $valid_passwordTypes (see
+// common/includes/validation.php), narrowed down through
+// dalo_filter_password_types(). Keeping a second list around only invited the
+// two to drift apart, so it was dropped.
 
 
 

--- a/app/operators/library/ajax/attributes.php
+++ b/app/operators/library/ajax/attributes.php
@@ -31,9 +31,7 @@ include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'chec
 include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LANG'], 'main.php' ]);
 include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'validation.php' ]);
 
-$cleartext_password_attributes = function_exists('dalo_cleartext_password_attributes')
-                                ? dalo_cleartext_password_attributes()
-                                : array("Cleartext-Password", "User-Password");
+$cleartext_password_attributes = dalo_cleartext_password_attributes();
 
 /**
  * @brief Populates an HTML select element with options from table names.
@@ -448,17 +446,25 @@ switch ($action) {
         
         $numrows = $res->numRows();
         
+        // a vendor may hold nothing but cleartext password attributes, which are all
+        // filtered out when CONFIG_DB_PASSWORD_ENCRYPTION is set to 'no'. count what
+        // actually gets offered, so the selector is not left enabled on the placeholder alone
+        $permitted_attributes = 0;
+
         if ($numrows > 0) {
             echo "objAttributes.add(new Option('Select Attribute...', ''));\n";
-            
+
             while ($row = $res->fetchRow()) {
                 $attribute = htmlspecialchars(trim($row[0]), ENT_QUOTES, 'UTF-8');
                 if (!dalo_cleartext_password_allowed() && in_array($attribute, $cleartext_password_attributes, true)) {
                     continue;
                 }
                 printf("objAttributes.add(new Option('%s', '%s'));\n", $attribute, $attribute);
+                $permitted_attributes++;
             }
-            
+        }
+
+        if ($permitted_attributes > 0) {
             echo "objAttributes.disabled = false;\n";
         } else {
             echo "objAttributes.disabled = true;\n";

--- a/app/operators/library/ajax/attributes.php
+++ b/app/operators/library/ajax/attributes.php
@@ -31,6 +31,10 @@ include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'chec
 include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LANG'], 'main.php' ]);
 include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'validation.php' ]);
 
+$cleartext_password_attributes = function_exists('dalo_cleartext_password_attributes')
+                                ? dalo_cleartext_password_attributes()
+                                : array("Cleartext-Password", "User-Password");
+
 /**
  * @brief Populates an HTML select element with options from table names.
  *
@@ -449,6 +453,9 @@ switch ($action) {
             
             while ($row = $res->fetchRow()) {
                 $attribute = htmlspecialchars(trim($row[0]), ENT_QUOTES, 'UTF-8');
+                if (!dalo_cleartext_password_allowed() && in_array($attribute, $cleartext_password_attributes, true)) {
+                    continue;
+                }
                 printf("objAttributes.add(new Option('%s', '%s'));\n", $attribute, $attribute);
             }
             

--- a/app/operators/library/attributes.php
+++ b/app/operators/library/attributes.php
@@ -30,6 +30,21 @@ function is_group($user_or_group) {
     return strtolower(trim($user_or_group)) === 'group';
 }
 
+if (!function_exists('dalo_cleartext_password_attributes')) {
+    function dalo_cleartext_password_attributes() {
+        return array("Cleartext-Password", "User-Password");
+    }
+}
+
+if (!function_exists('dalo_cleartext_password_allowed')) {
+    function dalo_cleartext_password_allowed() {
+        global $configValues;
+
+        return !isset($configValues['CONFIG_DB_PASSWORD_ENCRYPTION']) ||
+               strtolower(trim($configValues['CONFIG_DB_PASSWORD_ENCRYPTION'])) === 'yes';
+    }
+}
+
 function is_passwordlike_attribute($attribute) {
     return preg_match("/-Password$/", $attribute) === 1;
 }
@@ -206,6 +221,11 @@ function handleAttributes($dbSocket, $subject, $skipList, $insert_only=true, $us
         // we have to prepare the "value".
         // we distinguish between password and non-password attributes
         if (is_passwordlike_attribute($attribute)) {
+            if (!dalo_cleartext_password_allowed() &&
+                in_array($attribute, dalo_cleartext_password_attributes(), true)) {
+                continue;
+            }
+
             // before we proceed we need to understand if the password should be updated or skipped
 
             if (!$insert_only) {

--- a/app/operators/library/attributes.php
+++ b/app/operators/library/attributes.php
@@ -30,20 +30,9 @@ function is_group($user_or_group) {
     return strtolower(trim($user_or_group)) === 'group';
 }
 
-if (!function_exists('dalo_cleartext_password_attributes')) {
-    function dalo_cleartext_password_attributes() {
-        return array("Cleartext-Password", "User-Password");
-    }
-}
-
-if (!function_exists('dalo_cleartext_password_allowed')) {
-    function dalo_cleartext_password_allowed() {
-        global $configValues;
-
-        return !isset($configValues['CONFIG_DB_PASSWORD_ENCRYPTION']) ||
-               strtolower(trim($configValues['CONFIG_DB_PASSWORD_ENCRYPTION'])) === 'yes';
-    }
-}
+// dalo_cleartext_password_attributes() and dalo_cleartext_password_allowed()
+// live in common/includes/validation.php, which every caller of this file
+// includes beforehand.
 
 function is_passwordlike_attribute($attribute) {
     return preg_match("/-Password$/", $attribute) === 1;

--- a/app/operators/mng-batch-add.php
+++ b/app/operators/mng-batch-add.php
@@ -40,7 +40,7 @@
 
     $valid_passwordTypes = dalo_filter_password_types($valid_passwordTypes);
 
-    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
 
     // init valid account type
     $valid_accountTypes = array(
@@ -461,7 +461,7 @@
         }
     }
 
-    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
 
     include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'actionMessages.php' ]);
 

--- a/app/operators/mng-batch-add.php
+++ b/app/operators/mng-batch-add.php
@@ -21,17 +21,17 @@
  *********************************************************************************************************
  */
 
-    include("library/checklogin.php");
+    include_once implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', 'common', 'includes', 'config_read.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'checklogin.php' ]);
     $operator = $_SESSION['operator_user'];
 
-    include('../common/includes/config_read.php');
-    include('library/check_operator_perm.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'check_operator_perm.php' ]);
 
-    include_once("lang/main.php");
-    include("../common/includes/validation.php");
-    include("../common/includes/layout.php");
-    include_once("include/management/functions.php");
-    include_once("library/attributes.php");
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LANG'], 'main.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'validation.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'layout.php' ]);
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'functions.php' ]);
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'attributes.php' ]);
 
     // init logging variables
     $log = "visited page: ";
@@ -40,7 +40,7 @@
 
     $valid_passwordTypes = dalo_filter_password_types($valid_passwordTypes);
 
-    include('../common/includes/db_open.php');
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
 
     // init valid account type
     $valid_accountTypes = array(
@@ -62,11 +62,11 @@
     }
 
     // get valid groups and plan names
-    include_once('include/management/populate_selectbox.php');
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'populate_selectbox.php' ]);
     $valid_groups = get_groups();
     $valid_planNames = get_plans();
 
-    include('include/management/pages_common.php');
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'pages_common.php' ]);
 
 
     function addUserBatchHistory($dbSocket) {
@@ -461,9 +461,9 @@
         }
     }
 
-    include('../common/includes/db_close.php');
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
 
-    include_once('include/management/actionMessages.php');
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'actionMessages.php' ]);
 
     if (!empty($exportForm)) {
         echo $exportForm;
@@ -647,17 +647,17 @@
 
         // open 1-st tab
         open_tab($navkeys, 1);
-        include_once('include/management/userinfo.php');
+        include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'userinfo.php' ]);
         close_tab($navkeys, 1);
 
         // open 2-nd tab
         open_tab($navkeys, 2);
-        include_once('include/management/userbillinfo.php');
+        include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'userbillinfo.php' ]);
         close_tab($navkeys, 2);
 
         // open 3-rd tab
         open_tab($navkeys, 3);
-        include_once('include/management/attributes.php');
+        include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'attributes.php' ]);
         close_tab($navkeys, 3);
 
         // close tab wrapper
@@ -685,7 +685,7 @@
 
     }
 
-    include('include/config/logging.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_CONFIG'], 'logging.php' ]);
 
     // extra javascript
     $inline_extra_js = <<<EOF

--- a/app/operators/mng-batch-add.php
+++ b/app/operators/mng-batch-add.php
@@ -38,12 +38,7 @@
     $logAction = "";
     $logDebugSQL = "";
 
-    // if cleartext passwords are not allowed,
-    // we remove Cleartext-Password from the $valid_passwordTypes array
-    if (isset($configValues['CONFIG_DB_PASSWORD_ENCRYPTION']) &&
-        strtolower(trim($configValues['CONFIG_DB_PASSWORD_ENCRYPTION'])) !== 'yes') {
-        $valid_passwordTypes = array_values(array_diff($valid_passwordTypes, array("Cleartext-Password")));
-    }
+    $valid_passwordTypes = dalo_filter_password_types($valid_passwordTypes);
 
     include('../common/includes/db_open.php');
 

--- a/app/operators/mng-import-users.php
+++ b/app/operators/mng-import-users.php
@@ -48,13 +48,8 @@
     $valid_groups = get_groups();
     $valid_planNames = get_plans();
 
-    // if cleartext passwords are not allowed, 
-    // we remove Cleartext-Password from the $valid_passwordTypes array
-    $cleartextPasswordAllowed = (!isset($configValues['CONFIG_DB_PASSWORD_ENCRYPTION']) ||
-        strtolower(trim($configValues['CONFIG_DB_PASSWORD_ENCRYPTION'])) === 'yes');
-    if (!$cleartextPasswordAllowed) {
-        $valid_passwordTypes = array_values(array_diff($valid_passwordTypes, array("Cleartext-Password")));
-    }
+    $cleartextPasswordAllowed = dalo_cleartext_password_allowed();
+    $valid_passwordTypes = dalo_filter_password_types($valid_passwordTypes);
 
     $generatepassword = 'no';
     $generatedPasswords = array();

--- a/app/operators/mng-new-quick.php
+++ b/app/operators/mng-new-quick.php
@@ -121,7 +121,7 @@
             $bi_changeuserbillinfo = (!empty($ui_PortalLoginPassword) && isset($_POST['bi_changeuserbillinfo']) && $_POST['bi_changeuserbillinfo'] === '1')
                                    ? '1' : '0';
 
-            include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
+            include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
 
             // check if username is already present in the radcheck table
             $userExists = user_exists($dbSocket, $username);
@@ -283,7 +283,7 @@
 
             } // if ($userExists) {
 
-            include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
+            include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
         } else {
             // csrf
             $failureMsg = "CSRF token error";

--- a/app/operators/mng-new-quick.php
+++ b/app/operators/mng-new-quick.php
@@ -21,16 +21,16 @@
  *********************************************************************************************************
  */
 
-    include("library/checklogin.php");
+    include_once implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', 'common', 'includes', 'config_read.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'checklogin.php' ]);
     $operator = $_SESSION['operator_user'];
 
-    include('../common/includes/config_read.php');
-    include('library/check_operator_perm.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'check_operator_perm.php' ]);
 
-    include_once("lang/main.php");
-    include("../common/includes/validation.php");
-    include("../common/includes/layout.php");
-    include_once("include/management/functions.php");
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LANG'], 'main.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'validation.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'layout.php' ]);
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'functions.php' ]);
 
     // init logging variables
     $log = "visited page: ";
@@ -121,7 +121,7 @@
             $bi_changeuserbillinfo = (!empty($ui_PortalLoginPassword) && isset($_POST['bi_changeuserbillinfo']) && $_POST['bi_changeuserbillinfo'] === '1')
                                    ? '1' : '0';
 
-            include('../common/includes/db_open.php');
+            include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
 
             // check if username is already present in the radcheck table
             $userExists = user_exists($dbSocket, $username);
@@ -183,7 +183,7 @@
                          $i++;
                      }
 
-                    include("library/attributes.php");
+                    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'attributes.php' ]);
                     $skipList = array(
                                        "username", "password", "passwordType", "groups", "maxallsession", "expiration",
                                        "sessiontimeout", "idletimeout", "simultaneoususe", "framedipaddress",
@@ -283,7 +283,7 @@
 
             } // if ($userExists) {
 
-            include('../common/includes/db_close.php');
+            include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
         } else {
             // csrf
             $failureMsg = "CSRF token error";
@@ -311,7 +311,7 @@
 
     print_title_and_help($title, $help);
 
-    include_once('include/management/actionMessages.php');
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'actionMessages.php' ]);
 
     // set navbar stuff
     $navkeys = array( 'AccountInfo', 'UserInfo', 'BillingInfo' );
@@ -364,7 +364,7 @@
                                     "type" => "select"
                                 );
 
-    include_once('include/management/populate_selectbox.php');
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'populate_selectbox.php' ]);
     $options = get_groups();
     array_unshift($options, '');
     $input_descriptors0[] = array(
@@ -490,7 +490,7 @@
                        . 'onclick="javascript:small_window(document.newuser.username.value, '
                        . 'document.newuser.password.value, document.newuser.maxallsession.value);" '
                        . 'class="button">';
-    include_once('include/management/userinfo.php');
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'userinfo.php' ]);
 
     close_tab($navkeys, 1);
 
@@ -498,7 +498,7 @@
     open_tab($navkeys, 2);
 
     $customApplyButton = sprintf('<input type="submit" name="submit" value="%s" class="button">', t('buttons','apply'));
-    include_once('include/management/userbillinfo.php');
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'userbillinfo.php' ]);
 
     close_tab($navkeys, 2);
 
@@ -509,6 +509,6 @@
 
     print_back_to_previous_page();
 
-    include('include/config/logging.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_CONFIG'], 'logging.php' ]);
     print_footer_and_html_epilogue();
 ?>

--- a/app/operators/mng-new-quick.php
+++ b/app/operators/mng-new-quick.php
@@ -131,10 +131,12 @@
                 $logAction .= "Failed adding new user already existing in database [$username] on page: ";
             } else {
 
-                // username and password are required
-                if (empty($username) || empty($password)) {
-                    $failureMsg = "username and/or password are empty";
-                    $logAction .= "Failed adding (possible empty user/pass) new user [$username] on page: ";
+                // username, password and password type are required. an empty password type
+                // means the posted one is unknown or no longer permitted (e.g. a cleartext
+                // type submitted while CONFIG_DB_PASSWORD_ENCRYPTION is set to 'no')
+                if (empty($username) || empty($password) || empty($passwordType)) {
+                    $failureMsg = "username, password and/or password type are empty or invalid";
+                    $logAction .= "Failed adding (possible empty user/pass or invalid password type) new user [$username] on page: ";
                 } else {
 
                     // we "inject" specified attribute in the $_POST array.

--- a/app/operators/mng-new-quick.php
+++ b/app/operators/mng-new-quick.php
@@ -37,12 +37,7 @@
     $logAction = "";
     $logDebugSQL = "";
 
-    // if cleartext passwords are not allowed,
-    // we remove Cleartext-Password from the $valid_passwordTypes array
-    if (isset($configValues['CONFIG_DB_PASSWORD_ENCRYPTION']) &&
-        strtolower(trim($configValues['CONFIG_DB_PASSWORD_ENCRYPTION'])) !== 'yes') {
-        $valid_passwordTypes = array_values(array_diff($valid_passwordTypes, array("Cleartext-Password")));
-    }
+    $valid_passwordTypes = dalo_filter_password_types($valid_passwordTypes);
 
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if (array_key_exists('csrf_token', $_POST) && isset($_POST['csrf_token']) && dalo_check_csrf_token($_POST['csrf_token'])) {

--- a/app/operators/mng-new.php
+++ b/app/operators/mng-new.php
@@ -37,12 +37,7 @@
     $logAction = "";
     $logDebugSQL = "";
 
-    // if cleartext passwords are not allowed,
-    // we remove Cleartext-Password from the $valid_passwordTypes array
-    if (isset($configValues['CONFIG_DB_PASSWORD_ENCRYPTION']) &&
-        strtolower(trim($configValues['CONFIG_DB_PASSWORD_ENCRYPTION'])) !== 'yes') {
-        $valid_passwordTypes = array_values(array_diff($valid_passwordTypes, array("Cleartext-Password")));
-    }
+    $valid_passwordTypes = dalo_filter_password_types($valid_passwordTypes);
 
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if (array_key_exists('csrf_token', $_POST) && isset($_POST['csrf_token']) && dalo_check_csrf_token($_POST['csrf_token'])) {

--- a/app/operators/mng-new.php
+++ b/app/operators/mng-new.php
@@ -133,7 +133,7 @@
             $bi_nextinvoicedue = (array_key_exists('bi_nextinvoicedue', $_POST) && isset($_POST['bi_nextinvoicedue'])) ? $_POST['bi_nextinvoicedue'] : "";
             $bi_billdue = (array_key_exists('bi_billdue', $_POST) && isset($_POST['bi_billdue'])) ? $_POST['bi_billdue'] : "";
 
-            include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
+            include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
 
             // we will have a $username_to_check, only
             // if required arguments have been supplied
@@ -326,7 +326,7 @@
                 }
             }
 
-            include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
+            include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
         } else {
             // csrf
             $failureMsg = "CSRF token error";

--- a/app/operators/mng-new.php
+++ b/app/operators/mng-new.php
@@ -21,16 +21,16 @@
  *********************************************************************************************************
  */
 
-    include("library/checklogin.php");
+    include_once implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', 'common', 'includes', 'config_read.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'checklogin.php' ]);
     $operator = $_SESSION['operator_user'];
 
-    include('../common/includes/config_read.php');
-    include('library/check_operator_perm.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'check_operator_perm.php' ]);
 
-    include_once("lang/main.php");
-    include("../common/includes/validation.php");
-    include("../common/includes/layout.php");
-    include_once("include/management/functions.php");
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LANG'], 'main.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'validation.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'layout.php' ]);
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'functions.php' ]);
 
     // init logging variables
     $log = "visited page: ";
@@ -133,7 +133,7 @@
             $bi_nextinvoicedue = (array_key_exists('bi_nextinvoicedue', $_POST) && isset($_POST['bi_nextinvoicedue'])) ? $_POST['bi_nextinvoicedue'] : "";
             $bi_billdue = (array_key_exists('bi_billdue', $_POST) && isset($_POST['bi_billdue'])) ? $_POST['bi_billdue'] : "";
 
-            include('../common/includes/db_open.php');
+            include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
 
             // we will have a $username_to_check, only
             // if required arguments have been supplied
@@ -215,7 +215,7 @@
                     // handleAttributes() - called later - will take care of it.
                     $_POST['injected_attribute'] = array( $attribute, $value, ':=', 'check' );
 
-                    include("library/attributes.php");
+                    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'attributes.php' ]);
 
                     $skipList = array( "authType", "username", "password", "passwordType", "groups",
                                        "macaddress", "pincode", "submit", "firstname", "lastname", "email",
@@ -326,7 +326,7 @@
                 }
             }
 
-            include('../common/includes/db_close.php');
+            include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
         } else {
             // csrf
             $failureMsg = "CSRF token error";
@@ -355,11 +355,11 @@
 
     print_title_and_help($title, $help);
 
-    include_once('include/management/actionMessages.php');
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'actionMessages.php' ]);
 
     if (!isset($successMsg)) {
 
-        include_once('include/management/populate_selectbox.php');
+        include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'populate_selectbox.php' ]);
 
         $input_descriptors0 = array();
 
@@ -518,18 +518,18 @@
 
         // open 1-th tab (shown)
         open_tab($navkeys, 1);
-        include_once('include/management/userinfo.php');
+        include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'userinfo.php' ]);
         close_tab($navkeys, 1);
 
 
         // open 2-th tab (shown)
         open_tab($navkeys, 2);
-        include_once('include/management/userbillinfo.php');
+        include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'userbillinfo.php' ]);
         close_tab($navkeys, 2);
 
         // open 3-th tab (shown)
         open_tab($navkeys, 3);
-        include_once('include/management/attributes.php');
+        include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'attributes.php' ]);
         close_tab($navkeys, 3);
 
         // close tab wrapper
@@ -558,7 +558,7 @@
 
     print_back_to_previous_page();
 
-    include('include/config/logging.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_CONFIG'], 'logging.php' ]);
 
     $inline_extra_js = '
 function switchAuthType() {

--- a/app/operators/mng-rad-groupcheck-edit.php
+++ b/app/operators/mng-rad-groupcheck-edit.php
@@ -65,6 +65,10 @@
     while ($row = $res->fetchrow()) {
         $valid_attributes[] = $row[0];
     }
+
+    if (function_exists('dalo_filter_cleartext_password_attributes')) {
+        $valid_attributes = dalo_filter_cleartext_password_attributes($valid_attributes);
+    }
     
     // check if item is valid
     if (!empty($item)) {

--- a/app/operators/mng-rad-groupcheck-edit.php
+++ b/app/operators/mng-rad-groupcheck-edit.php
@@ -48,7 +48,7 @@
     $item_prefix = "groupcheck-";
     $item_table = $configValues['CONFIG_DB_TBL_RADGROUPCHECK'];
     
-    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
     
     // get valid attributes
     $valid_attributes = array();
@@ -195,7 +195,7 @@
         list( $groupname, $attribute, $op, $value ) = $res->fetchrow();
     }
     
-    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
 
     
     // print HTML prologue

--- a/app/operators/mng-rad-groupcheck-edit.php
+++ b/app/operators/mng-rad-groupcheck-edit.php
@@ -21,15 +21,15 @@
  *********************************************************************************************************
  */
 
-    include("library/checklogin.php");
+    include_once implode(DIRECTORY_SEPARATOR, [ __DIR__, '..', 'common', 'includes', 'config_read.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'checklogin.php' ]);
     $operator = $_SESSION['operator_user'];
 
-    include('library/check_operator_perm.php');
-    include_once('../common/includes/config_read.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LIBRARY'], 'check_operator_perm.php' ]);
 
-    include_once("lang/main.php");
-    include_once("../common/includes/validation.php");
-    include("../common/includes/layout.php");
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_LANG'], 'main.php' ]);
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'validation.php' ]);
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'layout.php' ]);
 
     // init logging variables
     $log = "visited page: ";
@@ -48,7 +48,7 @@
     $item_prefix = "groupcheck-";
     $item_table = $configValues['CONFIG_DB_TBL_RADGROUPCHECK'];
     
-    include('../common/includes/db_open.php');
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
     
     // get valid attributes
     $valid_attributes = array();
@@ -195,7 +195,7 @@
         list( $groupname, $attribute, $op, $value ) = $res->fetchrow();
     }
     
-    include('../common/includes/db_close.php');
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_close.php' ]);
 
     
     // print HTML prologue
@@ -213,7 +213,7 @@
 
     print_title_and_help($title, $help);
 
-    include_once('include/management/actionMessages.php');
+    include_once implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_MANAGEMENT'], 'actionMessages.php' ]);
     
     if (!empty($internal_id)) {
         
@@ -299,7 +299,7 @@
     
     print_back_to_previous_page();
 
-    include('include/config/logging.php');
+    include implode(DIRECTORY_SEPARATOR, [ $configValues['OPERATORS_INCLUDE_CONFIG'], 'logging.php' ]);
     print_footer_and_html_epilogue();
     
 ?>

--- a/app/operators/mng-rad-groupcheck-edit.php
+++ b/app/operators/mng-rad-groupcheck-edit.php
@@ -66,10 +66,8 @@
         $valid_attributes[] = $row[0];
     }
 
-    if (function_exists('dalo_filter_cleartext_password_attributes')) {
-        $valid_attributes = dalo_filter_cleartext_password_attributes($valid_attributes);
-    }
-    
+    $valid_attributes = dalo_filter_cleartext_password_attributes($valid_attributes);
+
     // check if item is valid
     if (!empty($item)) {
         $internal_id = intval(str_replace($item_prefix, "", $item));
@@ -121,6 +119,14 @@
                 
                 $attribute = (array_key_exists('attribute', $_POST) && !empty(str_replace("%", "", trim($_POST['attribute']))))
                            ? str_replace("%", "", trim($_POST['attribute'])) : "";
+
+                // the attribute field is free text, so the datalist alone does not keep a
+                // cleartext password attribute out of radgroupcheck: reject it here as well
+                if (!dalo_cleartext_password_allowed() &&
+                    in_array($attribute, dalo_cleartext_password_attributes(), true)) {
+                    $attribute = "";
+                }
+
                 if (!empty($attribute)) {
                     $sql_SET[] = sprintf("attribute='%s'", $dbSocket->escapeSimple($attribute));
                 } else {


### PR DESCRIPTION
## Summary

Reviewed every place where `CONFIG_DB_PASSWORD_ENCRYPTION` ("Allow cleartext password in db")
is read or should have been read. The setting was only honored on part of the pages that
offer a password type, so its effect depended on which page the operator happened to use.

This PR makes the setting apply consistently: when it is set to `no`, password types that
would end up stored in cleartext are no longer offered anywhere in the app, regardless of
the page or the table involved.

The label was also renamed to "Allow cleartext password attributes in db", which better
reflects what the option actually controls: the RADIUS password attributes, not passwords
stored elsewhere in the application. This was a recurring source of confusion in the issues.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the "Allow cleartext password attributes in db" setting apply consistently across all pages that offer password attributes. Previously the setting was only honored on some pages, so the effect depended on which page the operator used. Now when set to "no", cleartext password attributes (`Cleartext-Password` and `User-Password`) are filtered out everywhere, including attribute selection lists, group check editing, batch imports, and the AJAX attribute picker.

- Renames the setting label to "Allow cleartext password attributes in db" to clarify it controls RADIUS password attributes, not all stored passwords.
- Keeps `$valid_passwordTypes` complete for the test-user flow; pages storing passwords narrow it via `dalo_filter_password_types()`, and the unused `populate_password_types()` is removed.
- Rejects cleartext attributes in the group check POST path (the attribute field is free text) and empty password types on user creation.
- Normalizes include paths across operator pages to use `configValues`-based paths, removing reliance on the current working directory.

<sup>Written for commit eb382610e7767ee68979c50c705d5934981d9436. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

