### PR TITLE
fix(auth): rotate sessions after authentication

### DIFF
--- a/app/operators/dologin.php
+++ b/app/operators/dologin.php
@@ -71,6 +71,7 @@ if (isset($_POST['csrf_token']) && dalo_check_csrf_token($_POST['csrf_token']) &
         $totp_secret = (array_key_exists('totp_secret', $row) && !empty($row['totp_secret'])) ? $row['totp_secret'] : '';
 
         if ($verified || $legacy_verified) {
+            session_regenerate_id(true);
             $operator_id = intval($row['id']);
 
             if ($legacy_verified || password_needs_rehash($stored_password, PASSWORD_DEFAULT)) {

--- a/app/operators/login-otp.php
+++ b/app/operators/login-otp.php
@@ -54,6 +54,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         include('../common/includes/db_close.php');
 
         if ($authenticated) {
+            session_regenerate_id(true);
             $_SESSION['daloradius_logged_in'] = true;
             $_SESSION['operator_user'] = $_SESSION['operator_2fa_user'];
             $_SESSION['operator_id'] = intval($_SESSION['operator_2fa_id']);

--- a/app/users/dologin.php
+++ b/app/users/dologin.php
@@ -68,6 +68,7 @@ if (array_key_exists('csrf_token', $_POST) && isset($_POST['csrf_token']) && dal
 
     // we only accept ONE AND ONLY ONE RECORD as result
     if ($numrows === 1) {
+        session_regenerate_id(true);
         $_SESSION['logged_in'] = true;
         $_SESSION['login_user'] = $login_user;
     }


### PR DESCRIPTION
## Summary

Rotate the PHP session ID at each successful authentication boundary:

- after operator password verification;
- after operator TOTP verification;
- after users portal authentication.

This prevents a pre-authentication session ID from being promoted into an authenticated session and invalidates the previous session with `session_regenerate_id(true)`.

## Validation

- Docker image builds successfully
- PHP syntax checks pass for all three modified files
- Runtime smoke test confirms:
  - the session ID changes;
  - session data is preserved;
  - the previous session is invalidated

The change is limited to three insertions and does not modify the database, configuration, or UI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rotates the PHP session ID after successful authentication so a pre-auth session ID can't be promoted into an authenticated session.

Adds `session_regenerate_id(true)` to operator password login, operator TOTP login, and user portal login. The previous session is invalidated while session data is preserved. No database, configuration, or UI changes.

<sup>Written for commit c617cd416b367eca42f4b35a4a0bccd886f4401b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

