### PR TITLE
perf: batch user group lookups

### DIFF
--- a/app/operators/mng-rad-usergroup-list.php
+++ b/app/operators/mng-rad-usergroup-list.php
@@ -176,7 +176,9 @@
 
         }
         
+        $usernames = array();
         while ($row0 = $res0->fetchRow()) {
+            $usernames[] = $row0[0];
             $row0len = count($row0);
         
             // escape row elements
@@ -189,11 +191,17 @@
                 'fullname' => (!empty(trim($fullname))) ? $fullname : "(n/d)",
                 'groups' => array()
             );
-            
-            $sql1 = sprintf("SELECT groupname, priority FROM %s WHERE username='%s' ORDER BY priority ASC, groupname ASC",
-                            $configValues['CONFIG_DB_TBL_RADUSERGROUP'], $dbSocket->escapeSimple($this_username));
-            $res1 = $dbSocket->query($sql1);
-            
+        }
+
+        if (count($usernames) > 0) {
+            $placeholders = implode(', ', array_fill(0, count($usernames), '?'));
+            $sql1 = sprintf("SELECT username, groupname, priority FROM %s WHERE username IN (%s) "
+                          . "ORDER BY username ASC, priority ASC, groupname ASC",
+                            $configValues['CONFIG_DB_TBL_RADUSERGROUP'], $placeholders);
+            $stmt = $dbSocket->prepare($sql1);
+            $res1 = $dbSocket->execute($stmt, $usernames);
+            $dbSocket->freePrepared($stmt);
+
             while ($row1 = $res1->fetchRow()) {
                 $row1len = count($row1);
         
@@ -202,7 +210,7 @@
                     $row1[$i] = htmlspecialchars($row1[$i], ENT_QUOTES, 'UTF-8');
                 }
             
-                list($this_groupname, $this_priority) = $row1;
+                list($this_username, $this_groupname, $this_priority) = $row1;
                 $records[$this_username]['groups'][] = array( 'groupname' => $this_groupname, 'priority' => $this_priority );
             }
         }


### PR DESCRIPTION
## Summary

Replace the per-user group query in the User/Group listing with one prepared bulk query.

This reduces the number of SQL queries from:

- 27 to 3 for 25 users per page;
- 102 to 3 for 100 users per page.

No database migration or schema change is required.

## Validation

Tested with MariaDB 11.8 using:

- 20,000 users;
- 60,000 user/group mappings;
- 30 benchmark iterations.

The group lookup phase improved from:

- 4.810 ms to 0.535 ms for 25 users;
- 20.395 ms to 1.602 ms for 100 users.

The before/after results and group ordering were verified as identical. Special-character binding and PHP syntax checks also passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the per-user group lookup in the User/Group listing with one prepared bulk query, cutting SQL queries from 27 to 3 for 25 users per page and from 102 to 3 for 100 users per page.

**Validation**
- Tested with MariaDB 11.8 on 20,000 users, 60,000 user/group mappings, and 30 benchmark iterations.
- Group lookup time fell from 4.810 ms to 0.535 ms (25 users) and from 20.395 ms to 1.602 ms (100 users).
- Before/after results and group ordering verified identical; special-character binding and PHP syntax checks passed.
- No database migration or schema change is required.

<sup>Written for commit 688bf7fc7572d53e37ce147167a71eb857e89a8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

