### PR TITLE
refactor(ajax): migrate read-only information requests to JSON

### DIFF
--- a/app/common/includes/db_open.php
+++ b/app/common/includes/db_open.php
@@ -59,10 +59,16 @@ if (strpos($_SERVER['PHP_SELF'], '/common/includes/db_open.php') !== false) {
     $dbSocket = DB::connect($dbConnectString);
 
     if (DB::isError($dbSocket)) {
+        if (isset($db_error_handler) && is_callable($db_error_handler)) {
+            call_user_func($db_error_handler, $dbSocket);
+        }
         die(sprintf("<b>Database connection error</b><br/><b>Error Message</b>: %s<br/>", $dbSocket->getMessage()));
     }
 
     include_once(dirname(__FILE__) . '/db_error_handler.php');      // we declare the errorHandler() function in errorHandling.php
 
-    $dbSocket->setErrorHandling(PEAR_ERROR_CALLBACK, 'errorHandler');   // setting errorHandler function for the dbSocket obj
+    $error_handler = (isset($db_error_handler) && is_callable($db_error_handler))
+                   ? $db_error_handler
+                   : 'errorHandler';
+    $dbSocket->setErrorHandling(PEAR_ERROR_CALLBACK, $error_handler);   // setting errorHandler function for the dbSocket obj
     $dbSocket->query("SET SESSION sql_mode = '';");

--- a/app/common/static/js/readonly_info.js
+++ b/app/common/static/js/readonly_info.js
@@ -1,0 +1,60 @@
+/* Read-only tooltip content. Server values are text, never executable HTML/JS. */
+const daloInfo = (() => {
+    const pending = new WeakMap();
+
+    async function load(id, path, parameters, fields, description = false) {
+        const target = document.getElementById(id);
+        if (!target) {
+            return;
+        }
+        const request = {};
+        pending.set(target, request);
+        target.textContent = 'Loading...';
+        target.setAttribute('aria-busy', 'true');
+        target.setAttribute('aria-live', 'polite');
+        try {
+            const data = await daloRequestJSON(path, parameters);
+            if (pending.get(target) !== request || !target.isConnected) {
+                return;
+            }
+            const content = document.createDocumentFragment();
+            fields.forEach(([key, label], index) => {
+                if (typeof data[key] !== 'string' && typeof data[key] !== 'number') {
+                    throw new Error('Invalid response from the server.');
+                }
+                if (index > 0) {
+                    content.appendChild(document.createElement('br'));
+                }
+                const normal = document.createElement('span');
+                normal.style.fontWeight = 'normal';
+                normal.textContent = description ? String(data[key]) : label;
+                if (description) {
+                    content.appendChild(document.createTextNode(label + ' '));
+                    content.appendChild(normal);
+                } else {
+                    content.appendChild(normal);
+                    content.appendChild(document.createTextNode(' ' + data[key]));
+                }
+            });
+            target.replaceChildren(content);
+        } catch (error) {
+            if (pending.get(target) === request && target.isConnected) {
+                target.textContent = error.message;
+            }
+        } finally {
+            if (pending.get(target) === request) {
+                target.removeAttribute('aria-busy');
+                pending.delete(target);
+            }
+        }
+    }
+
+    return {
+        user: (id, parameters) => load(id, 'library/ajax/user_info.php', parameters,
+            [['upload', 'Upload:'], ['download', 'Download:']]),
+        hotspot: (id, parameters) => load(id, 'library/ajax/hotspot_info.php', parameters,
+            [['upload', 'Total Uploads:'], ['download', 'Total Downloads:'], ['hits', 'Total Hits:']]),
+        attribute: (id, parameters) => load(id, 'library/ajax/vendor_attribute_info.php', parameters,
+            [['description', 'Description:']], true)
+    };
+})();

--- a/app/common/static/js/request.js
+++ b/app/common/static/js/request.js
@@ -1,0 +1,41 @@
+/* Same-origin JSON reads. Mutation/CSRF support is deliberately out of scope. */
+async function daloRequestJSON(path, parameters) {
+    const url = new URL(path, document.baseURI);
+    if (url.origin !== window.location.origin) {
+        throw new Error('Invalid request destination.');
+    }
+    url.search = new URLSearchParams(parameters).toString();
+    let response;
+    try {
+        response = await fetch(url, {
+            method: 'GET',
+            credentials: 'same-origin',
+            headers: { Accept: 'application/json' },
+            cache: 'no-store'
+        });
+    } catch (error) {
+        throw new Error('Unable to load information. Check your connection and try again.');
+    }
+    // checklogin.php redirects expired sessions to the HTML login page.
+    if (response.redirected || response.status === 401) {
+        throw new Error('Your session has expired. Please sign in again.');
+    }
+    if (response.status === 403) {
+        throw new Error('You do not have permission to view this information.');
+    }
+    if (!response.ok) {
+        throw new Error(`Unable to load information (HTTP ${response.status}).`);
+    }
+    if (!(response.headers.get('Content-Type') || '').toLowerCase().startsWith('application/json')) {
+        throw new Error('Invalid response from the server.');
+    }
+    try {
+        const data = await response.json();
+        if (!data || typeof data !== 'object' || Array.isArray(data)) {
+            throw new Error('Invalid JSON object');
+        }
+        return data;
+    } catch (error) {
+        throw new Error('Invalid response from the server.');
+    }
+}

--- a/app/operators/acct-active.php
+++ b/app/operators/acct-active.php
@@ -75,8 +75,8 @@
     
     // print HTML prologue
     $extra_js = array(
-        "static/js/ajax.js",
-        "static/js/ajaxGeneric.js",
+        "static/js/request.js",
+        "static/js/readonly_info.js",
     );
     
     $title = t('Intro','acctactive.php');
@@ -174,7 +174,7 @@
 
             $ajax_id = "divContainerUserInfo_" . $count;
             $param = sprintf('username=%s', urlencode($username));
-            $onclick = "ajaxGeneric('library/ajax/user_info.php','retBandwidthInfo','$ajax_id','$param')";
+            $onclick = "daloInfo.user('$ajax_id','$param')";
             $tooltip = array(
                                 'subject' => $username,
                                 'onclick' => $onclick,

--- a/app/operators/acct-all.php
+++ b/app/operators/acct-all.php
@@ -62,8 +62,8 @@
 
     // print HTML prologue
     $extra_js = array(
-        "static/js/ajax.js",
-        "static/js/ajaxGeneric.js"
+        "static/js/request.js",
+        "static/js/readonly_info.js"
     );
     
     $title = t('Intro','acctall.php');
@@ -170,7 +170,7 @@
             if (hotspots_exists($dbSocket, $hotspot)) {
                 $ajax_id = "divContainerHotspotInfo_" . $count;
                 $param = sprintf('hotspot=%s', urlencode($hotspot));
-                $onclick = "ajaxGeneric('library/ajax/hotspot_info.php','retHotspotGeneralStat','$ajax_id','$param')";
+                $onclick = "daloInfo.hotspot('$ajax_id','$param')";
 
                 $tooltip1 = [
                                 'subject' => $hotspot,
@@ -191,7 +191,7 @@
             if (!empty($username)) {
                 $ajax_id = "divContainerUserInfo_" . $count;
                 $param = sprintf('username=%s', urlencode($username));
-                $onclick = "ajaxGeneric('library/ajax/user_info.php','retBandwidthInfo','$ajax_id','$param')";
+                $onclick = "daloInfo.user('$ajax_id','$param')";
             
                 $tooltip2 = [
                                 'subject' => $username,

--- a/app/operators/acct-custom-query.php
+++ b/app/operators/acct-custom-query.php
@@ -97,7 +97,7 @@
     $accounting_custom_value = $where_value_enc;
 
     // print HTML prologue
-    $extra_js = [ "static/js/ajax.js", "static/js/ajaxGeneric.js", ];
+    $extra_js = [ "static/js/request.js", "static/js/readonly_info.js", ];
 
     $title = t('Intro','acctcustomquery.php');
     $help = t('helpPage','acctcustomquery');
@@ -225,7 +225,7 @@
                         if (!empty($row[$field])) {
                             $ajax_id = "divContainerUserInfo_" . $count;
                             $param = sprintf('username=%s', urlencode($row[$field]));
-                            $onclick = "ajaxGeneric('library/ajax/user_info.php','retBandwidthInfo','$ajax_id','$param')";
+                            $onclick = "daloInfo.user('$ajax_id','$param')";
 
                             $value = [
                                         'subject' => $row[$field],

--- a/app/operators/acct-date.php
+++ b/app/operators/acct-date.php
@@ -78,8 +78,8 @@
 
     // print HTML prologue
     $extra_js = array(
-        "static/js/ajax.js",
-        "static/js/ajaxGeneric.js",
+        "static/js/request.js",
+        "static/js/readonly_info.js",
         "static/js/pages_common.js",
     );
 
@@ -204,7 +204,7 @@
                 if (hotspots_exists($dbSocket, $hotspot)) {
                     $ajax_id = "divContainerHotspotInfo_" . $count;
                     $param = sprintf('hotspot=%s', urlencode($hotspot));
-                    $onclick = "ajaxGeneric('library/ajax/hotspot_info.php','retHotspotGeneralStat','$ajax_id','$param')";
+                    $onclick = "daloInfo.hotspot('$ajax_id','$param')";
     
                     $tooltip1 = [
                                     'subject' => $hotspot,
@@ -225,7 +225,7 @@
                 if (!empty($username)) {
                     $ajax_id = "divContainerUserInfo_" . $count;
                     $param = sprintf('username=%s', urlencode($username));
-                    $onclick = "ajaxGeneric('library/ajax/user_info.php','retBandwidthInfo','$ajax_id','$param')";
+                    $onclick = "daloInfo.user('$ajax_id','$param')";
                 
                     $tooltip2 = [
                                     'subject' => $username,

--- a/app/operators/acct-hotspot-accounting.php
+++ b/app/operators/acct-hotspot-accounting.php
@@ -98,8 +98,8 @@
 
     // print HTML prologue
     $extra_js = array(
-        "static/js/ajax.js",
-        "static/js/ajaxGeneric.js",
+        "static/js/request.js",
+        "static/js/readonly_info.js",
     );
 
     $title = t('Intro','accthotspot.php');
@@ -223,7 +223,7 @@
             if (hotspots_exists($dbSocket, $hotspot)) {
                 $ajax_id = "divContainerHotspotInfo_" . $count;
                 $param = sprintf('hotspot=%s', urlencode($hotspot));
-                $onclick = "ajaxGeneric('library/ajax/hotspot_info.php','retHotspotGeneralStat','$ajax_id','$param')";
+                $onclick = "daloInfo.hotspot('$ajax_id','$param')";
 
                 $tooltip1 = [
                                 'subject' => $hotspot,
@@ -244,7 +244,7 @@
             if (!empty($username)) {
                 $ajax_id = "divContainerUserInfo_" . $count;
                 $param = sprintf('username=%s', urlencode($username));
-                $onclick = "ajaxGeneric('library/ajax/user_info.php','retBandwidthInfo','$ajax_id','$param')";
+                $onclick = "daloInfo.user('$ajax_id','$param')";
             
                 $tooltip2 = [
                                 'subject' => $username,

--- a/app/operators/acct-ipaddress.php
+++ b/app/operators/acct-ipaddress.php
@@ -75,8 +75,8 @@
     
     // print HTML prologue
     $extra_js = array(
-        "static/js/ajax.js",
-        "static/js/ajaxGeneric.js",
+        "static/js/request.js",
+        "static/js/readonly_info.js",
     );
     
     $title = t('Intro','acctipaddress.php');
@@ -183,7 +183,7 @@
             if (hotspots_exists($dbSocket, $hotspot)) {
                 $ajax_id = "divContainerHotspotInfo_" . $count;
                 $param = sprintf('hotspot=%s', urlencode($hotspot));
-                $onclick = "ajaxGeneric('library/ajax/hotspot_info.php','retHotspotGeneralStat','$ajax_id','$param')";
+                $onclick = "daloInfo.hotspot('$ajax_id','$param')";
 
                 $tooltip1 = [
                                 'subject' => $hotspot,
@@ -204,7 +204,7 @@
             if (!empty($username)) {
                 $ajax_id = "divContainerUserInfo_" . $count;
                 $param = sprintf('username=%s', urlencode($username));
-                $onclick = "ajaxGeneric('library/ajax/user_info.php','retBandwidthInfo','$ajax_id','$param')";
+                $onclick = "daloInfo.user('$ajax_id','$param')";
             
                 $tooltip2 = [
                                 'subject' => $username,

--- a/app/operators/acct-nasipaddress.php
+++ b/app/operators/acct-nasipaddress.php
@@ -77,8 +77,8 @@
     
     // print HTML prologue
     $extra_js = array(
-        "static/js/ajax.js",
-        "static/js/ajaxGeneric.js",
+        "static/js/request.js",
+        "static/js/readonly_info.js",
     );
     
     $title = t('Intro','acctnasipaddress.php');
@@ -184,7 +184,7 @@
             if (hotspots_exists($dbSocket, $hotspot)) {
                 $ajax_id = "divContainerHotspotInfo_" . $count;
                 $param = sprintf('hotspot=%s', urlencode($hotspot));
-                $onclick = "ajaxGeneric('library/ajax/hotspot_info.php','retHotspotGeneralStat','$ajax_id','$param')";
+                $onclick = "daloInfo.hotspot('$ajax_id','$param')";
 
                 $tooltip1 = [
                                 'subject' => $hotspot,
@@ -205,7 +205,7 @@
             if (!empty($username)) {
                 $ajax_id = "divContainerUserInfo_" . $count;
                 $param = sprintf('username=%s', urlencode($username));
-                $onclick = "ajaxGeneric('library/ajax/user_info.php','retBandwidthInfo','$ajax_id','$param')";
+                $onclick = "daloInfo.user('$ajax_id','$param')";
             
                 $tooltip2 = [
                                 'subject' => $username,

--- a/app/operators/acct-plans-usage.php
+++ b/app/operators/acct-plans-usage.php
@@ -96,6 +96,8 @@
     $extra_css = array();
     
     $extra_js = array(
+        "static/js/request.js",
+        "static/js/readonly_info.js",
         "static/js/pages_common.js",
     );
     
@@ -231,7 +233,7 @@
             
             $ajax_id = "divContainerUserInfo_" . $count;
             $param = sprintf('username=%s', urlencode($username));
-            $onclick = "ajaxGeneric('library/ajax/user_info.php','retBandwidthInfo','$ajax_id','$param')";
+            $onclick = "daloInfo.user('$ajax_id','$param')";
             $tooltip = array(
                                 'subject' => $username,
                                 'onclick' => $onclick,

--- a/app/operators/acct-username.php
+++ b/app/operators/acct-username.php
@@ -72,8 +72,8 @@
     // print HTML prologue
     $extra_js = array(
         "static/js/pages_common.js",
-        "static/js/ajax.js",
-        "static/js/ajaxGeneric.js",
+        "static/js/request.js",
+        "static/js/readonly_info.js",
     );
     
     $title = t('Intro','acctusername.php');
@@ -176,7 +176,7 @@
                 if (hotspots_exists($dbSocket, $hotspot)) {
                     $ajax_id = "divContainerHotspotInfo_" . $count;
                     $param = sprintf('hotspot=%s', urlencode($hotspot));
-                    $onclick = "ajaxGeneric('library/ajax/hotspot_info.php','retHotspotGeneralStat','$ajax_id','$param')";
+                    $onclick = "daloInfo.hotspot('$ajax_id','$param')";
     
                     $tooltip1 = [
                                     'subject' => $hotspot,
@@ -197,7 +197,7 @@
                 if (user_exists($dbSocket, $username)) {
                     $ajax_id = "divContainerUserInfo_" . $count;
                     $param = sprintf('username=%s', urlencode($username));
-                    $onclick = "ajaxGeneric('library/ajax/user_info.php','retBandwidthInfo','$ajax_id','$param')";
+                    $onclick = "daloInfo.user('$ajax_id','$param')";
                 
                     $tooltip2 = [
                                     'subject' => $username,

--- a/app/operators/bill-pos-list.php
+++ b/app/operators/bill-pos-list.php
@@ -63,6 +63,8 @@
 
     // print HTML prologue
     $extra_js = array(
+        "static/js/request.js",
+        "static/js/readonly_info.js",
         "static/js/ajax.js",
         "static/js/ajaxGeneric.js"
     );
@@ -247,7 +249,7 @@
             
             $ajax_id = "divContainerUserInfo_" . $count;
             $param = sprintf('username=%s', urlencode($username));
-            $onclick = "ajaxGeneric('library/ajax/user_info.php','retBandwidthInfo','$ajax_id','$param')";
+            $onclick = "daloInfo.user('$ajax_id','$param')";
             $tooltip = array(
                                 'subject' => sprintf('%s%s<span class="badge bg-primary ms-1">%s</span>', $img, $badge, $username),
                                 'onclick' => $onclick,

--- a/app/operators/library/ajax/hotspot_info.php
+++ b/app/operators/library/ajax/hotspot_info.php
@@ -21,104 +21,36 @@
  *********************************************************************************************************
  */
 
+require_once __DIR__ . '/json_info.php';
 include('../checklogin.php');
 $operator_perm_file = 'acct_hotspot_accounting';
 $operator_perm_deny_http_status = 403;
 include('../check_operator_perm.php');
 
+$value = dalo_info_parameter('hotspot');
+include('../../../common/includes/db_open.php');
+// The default PEAR callback prints HTML, which would corrupt the JSON response.
+$dbSocket->setErrorHandling(PEAR_ERROR_RETURN);
+include_once('../../include/management/pages_common.php');
 
-// username and divContainer are required
-if (array_key_exists('hotspot', $_GET) && isset($_GET['hotspot']) &&
-    array_key_exists('divContainer', $_GET) && isset($_GET['divContainer'])) {
-    
-    // divContainer id must begin with a letter ([A-Za-z]) and may be followed by any number of letters,
-    // digits ([0-9]), hyphens ("-"), underscores ("_").
-    if (!preg_match("/^[A-Za-z][A-Za-z0-9_-]+$/", $_GET['divContainer'])) {
-        exit;
-    }
-    
-    $divContainer = $_GET['divContainer'];
-    $hotspot = str_replace("%", "", trim($_GET['hotspot']));
-    
-    // at the moment we have only one action
-    $action = "";
-    if (isset($_GET['retHotspotGeneralStat'])) {
-        $action = 'retHotspotGeneralStat';
-    } else {
-        $action = 'retHotspotGeneralStat';
-    }
-
-    include('../../../common/includes/db_open.php');
-    include_once('../../include/management/pages_common.php');
-    
-    switch ($action) {
-        
-        default:
-        case 'retHotspotGeneralStat':
-            $sql = sprintf("SELECT COUNT(ra.radacctid) AS totalhits,
-                                   SUM(ra.AcctInputOctets) AS sumInputOctets,
-                                   SUM(ra.AcctOutputOctets) AS sumOutputOctets
-                              FROM %s AS ra JOIN %s AS hs ON ra.calledstationid=hs.mac
-                             WHERE hs.name='%s'
-                             GROUP BY hs.name",
-                           $configValues['CONFIG_DB_TBL_RADACCT'], $configValues['CONFIG_DB_TBL_DALOHOTSPOTS'],
-                           $dbSocket->escapeSimple($hotspot));
-                           
-            $res = $dbSocket->query($sql);
-            $row = $res->fetchRow();
-            
-            list( $totalhits, $upload, $download ) = $row;
-            
-            if (empty($totalhits)) {
-                $totalhits = "(n/a)";
-            } else {
-                $totalhits = intval($totalhits);
-                
-                if ($upload < 0) {
-                    $upload = 0;
-                }
-            }
-            
-            if (empty($upload)) {
-                $upload = "(n/a)";
-            } else {
-                $upload = intval($upload);
-                
-                if ($upload < 0) {
-                    $upload = 0;
-                }
-                
-                $upload = toxbyte($upload);
-            }
-        
-            if (empty($download)) {
-                $download = "(n/a)";
-            } else {
-                $download = intval($download);
-                
-                if ($download < 0) {
-                    $download = 0;
-                }
-                
-                $download = toxbyte($download);
-            }
-            
-            echo <<<EOF
-    var divContainer = document.getElementById('$divContainer');
-    divContainer.innerHTML = '<span style="font-weight: normal">Total Uploads:</span> $upload';
-    divContainer.innerHTML += '<br>';
-    divContainer.innerHTML += '<span style="font-weight: normal">Total Downloads:</span> $download';
-    divContainer.innerHTML += '<br>';
-    divContainer.innerHTML += '<span style="font-weight: normal">Total Hits:</span> $totalhits';
-
-EOF;
-            
-            break;
-        
-    }
-
-    include('../../../common/includes/db_close.php');
-
+$sql = sprintf("SELECT COUNT(ra.radacctid) AS totalhits,
+                       SUM(ra.AcctInputOctets) AS sumInputOctets,
+                       SUM(ra.AcctOutputOctets) AS sumOutputOctets
+                  FROM %s AS ra JOIN %s AS hs ON ra.calledstationid=hs.mac
+                 WHERE hs.name='%s'
+                 GROUP BY hs.name",
+               $configValues['CONFIG_DB_TBL_RADACCT'], $configValues['CONFIG_DB_TBL_DALOHOTSPOTS'],
+               $dbSocket->escapeSimple($value));
+$res = $dbSocket->query($sql);
+if (DB::isError($res)) {
+    dalo_info_response(['error' => 'Unable to load hotspot information.'], 500);
 }
+$row = $res->fetchRow();
+$data = [
+    'upload' => dalo_info_bytes($row[1] ?? null),
+    'download' => dalo_info_bytes($row[2] ?? null),
+    'hits' => empty($row[0]) ? '(n/a)' : intval($row[0]),
+];
 
-?>
+include('../../../common/includes/db_close.php');
+dalo_info_response($data);

--- a/app/operators/library/ajax/hotspot_info.php
+++ b/app/operators/library/ajax/hotspot_info.php
@@ -23,6 +23,8 @@
 
 require_once __DIR__ . '/json_info.php';
 include('../checklogin.php');
+$dalo_info_database_error_message = 'Unable to load hotspot information.';
+$db_error_handler = 'dalo_info_database_error';
 $operator_perm_file = 'acct_hotspot_accounting';
 $operator_perm_deny_http_status = 403;
 include('../check_operator_perm.php');
@@ -46,6 +48,9 @@ if (DB::isError($res)) {
     dalo_info_response(['error' => 'Unable to load hotspot information.'], 500);
 }
 $row = $res->fetchRow();
+if (DB::isError($row)) {
+    dalo_info_response(['error' => 'Unable to load hotspot information.'], 500);
+}
 $data = [
     'upload' => dalo_info_bytes($row[1] ?? null),
     'download' => dalo_info_bytes($row[2] ?? null),

--- a/app/operators/library/ajax/json_info.php
+++ b/app/operators/library/ajax/json_info.php
@@ -10,6 +10,14 @@ function dalo_info_response($data, $status = 200) {
     exit;
 }
 
+function dalo_info_database_error($error) {
+    global $dalo_info_database_error_message;
+    $message = isset($dalo_info_database_error_message)
+             ? $dalo_info_database_error_message
+             : 'Unable to load information.';
+    dalo_info_response(['error' => $message], 500);
+}
+
 function dalo_info_parameter($name) {
     if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
         header('Allow: GET');

--- a/app/operators/library/ajax/json_info.php
+++ b/app/operators/library/ajax/json_info.php
@@ -1,0 +1,27 @@
+<?php
+/* JSON response helpers for the read-only operator information endpoints. */
+
+function dalo_info_response($data, $status = 200) {
+    http_response_code($status);
+    header('Content-Type: application/json; charset=UTF-8');
+    header('Cache-Control: no-store');
+    header('X-Content-Type-Options: nosniff');
+    echo json_encode($data, JSON_INVALID_UTF8_SUBSTITUTE);
+    exit;
+}
+
+function dalo_info_parameter($name) {
+    if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
+        header('Allow: GET');
+        dalo_info_response(['error' => 'Method not allowed.'], 405);
+    }
+    if (!isset($_GET[$name]) || !is_string($_GET[$name]) || trim($_GET[$name]) === '') {
+        dalo_info_response(['error' => 'Missing or invalid parameter.'], 400);
+    }
+    // Preserve the existing lookup normalization.
+    return str_replace('%', '', trim($_GET[$name]));
+}
+
+function dalo_info_bytes($value) {
+    return empty($value) ? '(n/a)' : toxbyte(max(0, intval($value)));
+}

--- a/app/operators/library/ajax/user_info.php
+++ b/app/operators/library/ajax/user_info.php
@@ -21,86 +21,26 @@
  *********************************************************************************************************
  */
 
+require_once __DIR__ . '/json_info.php';
 include('../checklogin.php');
 $operator_perm_file = 'acct_username';
 $operator_perm_deny_http_status = 403;
 include('../check_operator_perm.php');
 
+$value = dalo_info_parameter('username');
+include('../../../common/includes/db_open.php');
+// The default PEAR callback prints HTML, which would corrupt the JSON response.
+$dbSocket->setErrorHandling(PEAR_ERROR_RETURN);
+include_once('../../include/management/pages_common.php');
 
-// username and divContainer are required
-if (array_key_exists('username', $_GET) && isset($_GET['username']) &&
-    array_key_exists('divContainer', $_GET) && isset($_GET['divContainer'])) {
-    
-    // divContainer id must begin with a letter ([A-Za-z]) and may be followed by any number of letters,
-    // digits ([0-9]), hyphens ("-"), underscores ("_").
-    if (!preg_match("/^[A-Za-z][A-Za-z0-9_-]+$/", $_GET['divContainer'])) {
-        exit;
-    }
-    
-    $divContainer = $_GET['divContainer'];
-    
-    // user should exist
-    $username = str_replace("%", "", trim($_GET['username']));
-    
-    // at the moment we have only one action
-    $action = "";
-    if (isset($_GET['retBandwidthInfo'])) {
-        $action = 'retBandwidthInfo';
-    } else {
-        $action = 'retBandwidthInfo';
-    }
-    
-    include('../../../common/includes/db_open.php');
-    include_once('../../include/management/pages_common.php');
-    
-    switch ($action) {
-        
-        default:
-        case 'retBandwidthInfo':
-        
-            $sql = sprintf("SELECT SUM(AcctInputOctets) AS Upload, SUM(AcctOutputOctets) AS Download FROM %s WHERE username='%s'",
-                           $configValues['CONFIG_DB_TBL_RADACCT'], $dbSocket->escapeSimple($username));
-            $res = $dbSocket->query($sql);
-            $row = $res->fetchRow();
-            
-            list( $upload, $download ) = $row;
-        
-            if (empty($upload)) {
-                $upload = "(n/a)";
-            } else {
-                $upload = intval($upload);
-                
-                if ($upload < 0) {
-                    $upload = 0;
-                }
-                
-                $upload = toxbyte($upload);
-            }
-        
-            if (empty($download)) {
-                $download = "(n/a)";
-            } else {
-                $download = intval($download);
-                
-                if ($download < 0) {
-                    $download = 0;
-                }
-                
-                $download = toxbyte($download);
-            }
-        
-            echo <<<EOF
-    var divContainer = document.getElementById('$divContainer');
-    divContainer.innerHTML = '<span style="font-weight: normal">Upload:</span> $upload';
-    divContainer.innerHTML += '<br>';
-    divContainer.innerHTML += '<span style="font-weight: normal">Download:</span> $download';
-EOF;
-        
-            break;
-    }
-    
-    include('../../../common/includes/db_close.php');
-
+$sql = sprintf("SELECT SUM(AcctInputOctets) AS Upload, SUM(AcctOutputOctets) AS Download FROM %s WHERE username='%s'",
+               $configValues['CONFIG_DB_TBL_RADACCT'], $dbSocket->escapeSimple($value));
+$res = $dbSocket->query($sql);
+if (DB::isError($res)) {
+    dalo_info_response(['error' => 'Unable to load user information.'], 500);
 }
+$row = $res->fetchRow();
+$data = ['upload' => dalo_info_bytes($row[0] ?? null), 'download' => dalo_info_bytes($row[1] ?? null)];
 
-?>
+include('../../../common/includes/db_close.php');
+dalo_info_response($data);

--- a/app/operators/library/ajax/user_info.php
+++ b/app/operators/library/ajax/user_info.php
@@ -23,6 +23,8 @@
 
 require_once __DIR__ . '/json_info.php';
 include('../checklogin.php');
+$dalo_info_database_error_message = 'Unable to load user information.';
+$db_error_handler = 'dalo_info_database_error';
 $operator_perm_file = 'acct_username';
 $operator_perm_deny_http_status = 403;
 include('../check_operator_perm.php');
@@ -40,6 +42,9 @@ if (DB::isError($res)) {
     dalo_info_response(['error' => 'Unable to load user information.'], 500);
 }
 $row = $res->fetchRow();
+if (DB::isError($row)) {
+    dalo_info_response(['error' => 'Unable to load user information.'], 500);
+}
 $data = ['upload' => dalo_info_bytes($row[0] ?? null), 'download' => dalo_info_bytes($row[1] ?? null)];
 
 include('../../../common/includes/db_close.php');

--- a/app/operators/library/ajax/vendor_attribute_info.php
+++ b/app/operators/library/ajax/vendor_attribute_info.php
@@ -21,54 +21,25 @@
  *********************************************************************************************************
  */
 
+require_once __DIR__ . '/json_info.php';
 include('../checklogin.php');
 $operator_perm_file = 'mng_rad_attributes_list';
 $operator_perm_deny_http_status = 403;
 include('../check_operator_perm.php');
 
+$value = dalo_info_parameter('attribute');
+include('../../../common/includes/db_open.php');
+// The default PEAR callback prints HTML, which would corrupt the JSON response.
+$dbSocket->setErrorHandling(PEAR_ERROR_RETURN);
 
-// attribute and divContainer are required
-if (array_key_exists('attribute', $_GET) && isset($_GET['attribute']) &&
-    array_key_exists('divContainer', $_GET) && isset($_GET['divContainer'])) {
-    
-    // divContainer id must begin with a letter ([A-Za-z]) and may be followed by any number of letters,
-    // digits ([0-9]), hyphens ("-"), underscores ("_").
-    if (!preg_match("/^[A-Za-z][A-Za-z0-9_-]+$/", $_GET['divContainer'])) {
-        exit;
-    }
-    
-    $divContainer = $_GET['divContainer'];
-    $attribute = str_replace("%", "", trim($_GET['attribute']));
-
-    // at the moment we have only one action
-    $action = "";
-    if (isset($_GET['retAttributeInfo'])) {
-        $action = 'retAttributeInfo';
-    } else {
-        $action = 'retAttributeInfo';
-    }
-
-    include('../../../common/includes/db_open.php');
-
-    switch ($action) {
-        
-        default:
-        case 'retAttributeInfo':
-            $sql = sprintf("SELECT RecommendedTooltip FROM %s WHERE Attribute='%s'",
-                           $configValues['CONFIG_DB_TBL_DALODICTIONARY'], $dbSocket->escapeSimple($attribute));
-            $tooltip = trim($dbSocket->getOne($sql));
-            $tooltip = (empty($tooltip)) ? "(n/a)" : addslashes(htmlspecialchars($tooltip, ENT_QUOTES, 'UTF-8'));
-            
-            echo <<<EOF
-
-    document.getElementById('$divContainer').innerHTML = 'Description: <span style="font-weight: normal">$tooltip</span>';
-
-EOF;
-            break;
-    }
-
-    include('../../../common/includes/db_close.php');
-
+$sql = sprintf("SELECT RecommendedTooltip FROM %s WHERE Attribute='%s'",
+               $configValues['CONFIG_DB_TBL_DALODICTIONARY'], $dbSocket->escapeSimple($value));
+$tooltip = $dbSocket->getOne($sql);
+if (DB::isError($tooltip)) {
+    dalo_info_response(['error' => 'Unable to load attribute information.'], 500);
 }
+$tooltip = trim($tooltip ?? '');
+$data = ['description' => empty($tooltip) ? '(n/a)' : $tooltip];
 
-?>
+include('../../../common/includes/db_close.php');
+dalo_info_response($data);

--- a/app/operators/library/ajax/vendor_attribute_info.php
+++ b/app/operators/library/ajax/vendor_attribute_info.php
@@ -23,6 +23,8 @@
 
 require_once __DIR__ . '/json_info.php';
 include('../checklogin.php');
+$dalo_info_database_error_message = 'Unable to load attribute information.';
+$db_error_handler = 'dalo_info_database_error';
 $operator_perm_file = 'mng_rad_attributes_list';
 $operator_perm_deny_http_status = 403;
 include('../check_operator_perm.php');

--- a/app/operators/mng-hs-list.php
+++ b/app/operators/mng-hs-list.php
@@ -62,8 +62,8 @@
 
     // print HTML prologue
     $extra_js = array(
-        "static/js/ajax.js",
-        "static/js/ajaxGeneric.js"
+        "static/js/request.js",
+        "static/js/readonly_info.js"
     );
 
     $title = t('Intro','mnghslist.php');
@@ -151,7 +151,7 @@
 
             $ajax_id = "divContainerHotspotInfo" . $count;
             $param = sprintf('hotspot=%s', urlencode($name));
-            $onclick = "ajaxGeneric('library/ajax/hotspot_info.php','retHotspotGeneralStat','$ajax_id','$param')";
+            $onclick = "daloInfo.hotspot('$ajax_id','$param')";
             $tooltip = array(
                                 'subject' => $name,
                                 'onclick' => $onclick,

--- a/app/operators/mng-list-all.php
+++ b/app/operators/mng-list-all.php
@@ -45,6 +45,8 @@
 
     // print HTML prologue
     $extra_js = array(
+        "static/js/request.js",
+        "static/js/readonly_info.js",
         "static/js/ajax.js",
         "static/js/ajaxGeneric.js",
         "static/js/pages_common.js"
@@ -324,7 +326,7 @@
 
             $ajax_id = "divContainerUserInfo_" . $count;
             $param = sprintf('username=%s', urlencode($username));
-            $onclick = "ajaxGeneric('library/ajax/user_info.php','retBandwidthInfo','$ajax_id','$param')";
+            $onclick = "daloInfo.user('$ajax_id','$param')";
 
             // create username tooltip
             $tooltip1 = array(

--- a/app/operators/mng-rad-attributes-list.php
+++ b/app/operators/mng-rad-attributes-list.php
@@ -65,8 +65,8 @@
 
     // print HTML prologue
     $extra_js = array(
-        "static/js/ajax.js",
-        "static/js/ajaxGeneric.js"
+        "static/js/request.js",
+        "static/js/readonly_info.js"
     );
     
     $title = t('Intro','mngradattributeslist.php');
@@ -163,7 +163,7 @@
             // define tooltip
             $ajax_id = "divContainerAttributeInfo_" . $count;
             $param = sprintf('attribute=%s', urlencode($this_attribute));
-            $onclick = "ajaxGeneric('library/ajax/vendor_attribute_info.php','retAttributeInfo','$ajax_id','$param')";
+            $onclick = "daloInfo.attribute('$ajax_id','$param')";
             $tooltip = array(
                                 'subject' => $this_id,
                                 'onclick' => $onclick,

--- a/app/operators/mng-rad-attributes-search.php
+++ b/app/operators/mng-rad-attributes-search.php
@@ -63,8 +63,8 @@
     
     // print HTML prologue
     $extra_js = array(
-        "static/js/ajax.js",
-        "static/js/ajaxGeneric.js"
+        "static/js/request.js",
+        "static/js/readonly_info.js"
     );
 
     $title = t('Intro','mngradattributessearch.php');
@@ -161,7 +161,7 @@
             // define tooltip
             $ajax_id = "divContainerAttributeInfo_" . $count;
             $param = sprintf('attribute=%s', urlencode($this_attribute));
-            $onclick = "ajaxGeneric('library/ajax/vendor_attribute_info.php','retAttributeInfo','$ajax_id','$param')";
+            $onclick = "daloInfo.attribute('$ajax_id','$param')";
             $tooltip = array(
                                 'subject' => $this_id,
                                 'onclick' => $onclick,

--- a/app/operators/mng-rad-ippool-list.php
+++ b/app/operators/mng-rad-ippool-list.php
@@ -79,8 +79,8 @@
 
     // print HTML prologue
     $extra_js = array(
-        "static/js/ajax.js",
-        "static/js/ajaxGeneric.js",
+        "static/js/request.js",
+        "static/js/readonly_info.js",
     );
 
     $title = t('Intro','mngradippoollist.php');
@@ -241,7 +241,7 @@
                 $ajax_id = sprintf("divContainerUserInfo_%d", $count);
                 $param = sprintf("username=%s", urlencode($username));
                 $onclick = sprintf(
-                    "ajaxGeneric('library/ajax/user_info.php','retBandwidthInfo','%s','%s')",
+                    "daloInfo.user('%s','%s')",
                     $ajax_id, $param
                 );
                 $tooltip4 = [

--- a/app/operators/mng-search.php
+++ b/app/operators/mng-search.php
@@ -61,6 +61,8 @@
 
     // print HTML prologue
     $extra_js = array(
+        "static/js/request.js",
+        "static/js/readonly_info.js",
         "static/js/ajax.js",
         "static/js/ajaxGeneric.js",
         "static/js/pages_common.js"
@@ -370,7 +372,7 @@
 
             $ajax_id = "divContainerUserInfo_" . $count;
             $param = sprintf('username=%s', urlencode($username));
-            $onclick = "ajaxGeneric('library/ajax/user_info.php','retBandwidthInfo','$ajax_id','$param')";
+            $onclick = "daloInfo.user('$ajax_id','$param')";
 
             // create username tooltip
             $tooltip1 = array(

--- a/app/operators/rep-batch-details.php
+++ b/app/operators/rep-batch-details.php
@@ -89,6 +89,8 @@
    
     // print HTML prologue
     $extra_js = array(
+        "static/js/request.js",
+        "static/js/readonly_info.js",
         "static/js/ajax.js",
         "static/js/ajaxGeneric.js"
     );
@@ -422,7 +424,7 @@
                 
                 $ajax_id = "divContainerUserInfo_" . $count;
                 $param = sprintf('username=%s', urlencode($username));
-                $onclick = "ajaxGeneric('library/ajax/user_info.php','retBandwidthInfo','$ajax_id','$param')";
+                $onclick = "daloInfo.user('$ajax_id','$param')";
                 $tooltip = array(
                                     'subject' => $img . $username,
                                     'onclick' => $onclick,

--- a/app/operators/rep-online.php
+++ b/app/operators/rep-online.php
@@ -87,8 +87,8 @@
     $extra_js = array(
         "static/js/chart.umd.min.js",
         "static/js/daloradius-charts.js",
-        "static/js/ajax.js",
-        "static/js/ajaxGeneric.js",
+        "static/js/request.js",
+        "static/js/readonly_info.js",
     );
 
     $title = t('Intro','reponline.php');
@@ -268,7 +268,7 @@
 
             $ajax_id = "divContainerUserInfo_" . $count;
             $param = sprintf('username=%s', urlencode($this_username));
-            $onclick = "ajaxGeneric('library/ajax/user_info.php','retBandwidthInfo','$ajax_id','$param')";
+            $onclick = "daloInfo.user('$ajax_id','$param')";
             $tooltip2 = array(
                                 'subject' => $this_username,
                                 'onclick' => $onclick,

--- a/doc/read-only-json-migration.md
+++ b/doc/read-only-json-migration.md
@@ -1,0 +1,102 @@
+# Read-only information requests: SACK migration, stage 1
+
+This change moves user bandwidth, hotspot totals and dictionary descriptions to
+same-origin GET requests with JSON responses. It does not change RADIUS policy,
+database schema, user actions, billing operations or dynamic attribute helpers.
+SACK remains available for those unmigrated consumers.
+
+## Internal endpoint contracts
+
+Paths are relative to the operators portal (`library/ajax/`).
+
+| Endpoint | Required GET parameter | Successful JSON fields | Existing ACL |
+| --- | --- | --- | --- |
+| `user_info.php` | `username` | `upload`, `download` (formatted strings) | `acct_username` |
+| `hotspot_info.php` | `hotspot` | `upload`, `download`, `hits` (integer or `(n/a)`) | `acct_hotspot_accounting` |
+| `vendor_attribute_info.php` | `attribute` | `description` (plain text) | `mng_rad_attributes_list` |
+
+Examples: `{"upload":"1 KB","download":"(n/a)"}` and
+`{"description":"Description from the dictionary"}`.
+
+The former action flags and `divContainer` are no longer needed. DOM targets stay
+in the browser. Existing trimming and percent-sign removal in lookup values are
+preserved; changing that legacy normalization is not part of this migration.
+
+Missing, blank or array parameters return JSON errors with HTTP 400; non-GET
+requests return 405 and `Allow: GET`. Query failures return 500 without the default
+PEAR HTML error callback. Successful/error JSON responses use `Cache-Control:
+no-store`. Authentication and ACL guards are unchanged: unauthenticated sessions
+redirect to login and denied permissions return 403. The frontend handles those
+before attempting JSON decoding, and rejects HTML or malformed JSON responses.
+
+`request.js` provides only the required JSON GET transport. It does not implement
+mutation retries or speculative CSRF support. `readonly_info.js` renders text and
+DOM nodes, never response code or HTML. The latest request wins independently for
+each target, and detached targets are ignored.
+
+## Migration scope and deployment
+
+All 18 read-only page consumers use the new scripts. The legacy scripts remain on
+`mng-list-all.php`, `mng-search.php`, `bill-pos-list.php` and
+`rep-batch-details.php` because their mutation controls still need SACK. Other
+unmigrated pages/assets are unchanged. `acct-plans-usage.php` now explicitly loads
+the scripts required by its information control.
+
+These are internal endpoints, but their response format and accepted HTTP method
+are breaking changes for custom clients. Update custom clients from executable
+JavaScript/POST to JSON/GET. Deploy the PHP pages, endpoints and new JavaScript
+assets together; reload already-open pages and invalidate cached HTML/assets as
+needed. Roll back the complete code change, not just the endpoints. No SQL
+migration is required.
+
+There is no root `package.json`, Changesets configuration, `RELEASE.md` or
+`.devcontainer/README.md` in this baseline. No npm package or release changeset is
+introduced for this PHP/JavaScript migration.
+
+## Automated checks
+
+From the repository root:
+
+```sh
+node --test tests/readonly-info.test.cjs
+python3 tests/readonly_info_http.py
+git diff --check
+```
+
+The HTTP test requires PHP CLI. `PHP_COMMAND` can supply a PHP container command
+that mounts `/tmp` at the same path and uses the host network (the test PHP server
+binds only to loopback). Use a trusted local image with PHP, for example:
+
+```sh
+PHP_COMMAND='docker run --rm --network host -v /tmp:/tmp --entrypoint php YOUR_PHP_IMAGE' \
+  python3 tests/readonly_info_http.py
+```
+
+The Node tests use a DOM/fetch double: encoding, rendering, HTTP/network/session
+errors, malformed JSON, out-of-order requests, detached targets and all page
+asset references. They also check that mixed read/write pages retain SACK.
+
+The HTTP suite executes the actual endpoints, session guard, ACL guard and byte
+formatter in an isolated temporary application, with a **synthetic database** and
+seeded local sessions. It checks successful responses, missing data, invalid
+parameters, wrong methods, expired/absent sessions, ACL denials and query errors.
+It does not test password login, a real SQL server or production deployment.
+It neither reads nor modifies the lab database.
+
+Also run `php -l` on changed/new PHP files and `node --check` on the new JS files.
+
+## Application-level verification before deployment
+
+On an isolated source-backed application with representative data:
+
+- Open a user traffic dropdown, hotspot dropdown and dictionary description.
+  Confirm labels, units, `(n/a)` cases and quotes/ampersands/Unicode display.
+- Click several rows quickly; each result must stay in its own row. Throttle the
+  network and repeat a click; an earlier result must not replace a newer one.
+- Deny the corresponding ACL and expire a session; verify a visible error rather
+  than stale data or a false success. Test a server/network failure too.
+- Check each migrated page's scripts load, including accounting by plan and IP
+  pool listings. Check that existing mutation controls still load their legacy
+  dependencies without invoking mutations against production data.
+- Inspect the network panel and console: JSON GET responses, no response `eval`,
+  no JavaScript exceptions. No RADIUS/NAS test is required for the transport change.

--- a/tests/readonly-info.test.cjs
+++ b/tests/readonly-info.test.cjs
@@ -1,0 +1,128 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const root = path.resolve(__dirname, '..');
+
+// Minimal DOM double: assigning HTML would fail, not silently pass this test.
+class Element {
+    constructor(tag = 'div') { this.tag = tag; this.children = []; this.style = {}; this.attrs = {}; this.isConnected = true; }
+    set textContent(value) { this.children = [String(value)]; }
+    get textContent() { return this.children.map(x => typeof x === 'string' ? x : x.textContent).join(''); }
+    set innerHTML(value) { throw new Error('Unsafe HTML assignment'); }
+    appendChild(node) { this.children.push(node); }
+    replaceChildren(node) { this.children = node.children; }
+    setAttribute(key, value) { this.attrs[key] = value; }
+    removeAttribute(key) { delete this.attrs[key]; }
+}
+function setup(fetch) {
+    const nodes = { a: new Element(), b: new Element() };
+    const context = vm.createContext({ URL, URLSearchParams, fetch, window: { location: { origin: 'http://localhost' } }, document: {
+        baseURI: 'http://localhost/operators/mng-list-all.php',
+        getElementById: id => nodes[id],
+        createElement: tag => new Element(tag),
+        createDocumentFragment: () => new Element('fragment'),
+        createTextNode: text => { const node = new Element('text'); node.textContent = text; return node; }
+    } });
+    for (const name of ['request.js', 'readonly_info.js']) {
+        vm.runInContext(fs.readFileSync(path.join(root, 'app/common/static/js', name), 'utf8'), context);
+    }
+    return { nodes, info: vm.runInContext('daloInfo', context), request: context.daloRequestJSON };
+}
+function response(data, extra = {}) {
+    return { ok: true, status: 200, redirected: false, headers: { get: () => 'application/json; charset=UTF-8' }, json: async () => data, ...extra };
+}
+
+test('same-origin GET encodes parameter values exactly once', async () => {
+    const value = "é O'Reilly & + / 50%";
+    const { info, nodes } = setup(async (url, options) => {
+        assert.equal(url.pathname, '/operators/library/ajax/user_info.php');
+        assert.equal(url.searchParams.get('username'), value);
+        assert.equal(url.searchParams.has('divContainer'), false);
+        assert.equal(options.method, 'GET');
+        assert.equal(options.credentials, 'same-origin');
+        assert.equal(options.cache, 'no-store');
+        return response({ upload: '1 KB', download: '(n/a)' });
+    });
+    await info.user('a', new URLSearchParams({ username: value }).toString());
+    assert.equal(nodes.a.textContent, 'Upload: 1 KBDownload: (n/a)');
+    assert.equal(nodes.a.attrs['aria-busy'], undefined);
+});
+
+test('hotspot totals and untrusted descriptions render as text', async () => {
+    const payload = "<img src=x onerror=alert(1)> O'Reilly & é";
+    const { info, nodes } = setup(async url => response(url.pathname.endsWith('hotspot_info.php')
+        ? { upload: '(n/a)', download: '2 MB', hits: 7 } : { description: payload }));
+    await info.hotspot('a', 'hotspot=foo');
+    assert.equal(nodes.a.textContent, 'Total Uploads: (n/a)Total Downloads: 2 MBTotal Hits: 7');
+    await info.attribute('b', 'attribute=foo');
+    assert.equal(nodes.b.textContent, 'Description: ' + payload);
+    assert.equal(nodes.b.children[1].tag, 'span');
+});
+
+for (const [name, fetch, expected] of [
+    ['redirected login', async () => response({}, { redirected: true }), /session has expired/],
+    ['401', async () => response({}, { status: 401, ok: false }), /session has expired/],
+    ['403', async () => response({}, { status: 403, ok: false }), /permission/],
+    ['500', async () => response({}, { status: 500, ok: false }), /HTTP 500/],
+    ['network', async () => { throw new Error('offline'); }, /connection/],
+    ['HTML', async () => response({}, { headers: { get: () => 'text/html' } }), /Invalid response/],
+    ['broken JSON', async () => response({}, { json: async () => { throw new Error('parse'); } }), /Invalid response/],
+    ['null JSON', async () => response(null), /Invalid response/],
+    ['array JSON', async () => response([]), /Invalid response/],
+    ['missing fields', async () => response({}), /Invalid response/],
+    ['object value', async () => response({ upload: {}, download: '0 B' }), /Invalid response/]
+]) {
+    test('visible error: ' + name, async () => {
+        const { info, nodes } = setup(fetch);
+        await info.user('a', 'username=test');
+        assert.match(nodes.a.textContent, expected);
+        assert.equal(nodes.a.attrs['aria-busy'], undefined);
+    });
+}
+
+test('cross-origin requests are rejected before fetch', async () => {
+    const { request } = setup(() => assert.fail('must not fetch'));
+    await assert.rejects(request('https://example.com/', {}), /Invalid request destination/);
+});
+
+test('latest request wins per target; other rows remain independent', async () => {
+    const jobs = [];
+    const { info, nodes } = setup(() => new Promise(resolve => jobs.push(resolve)));
+    const first = info.user('a', 'username=old');
+    const second = info.user('a', 'username=new');
+    const other = info.user('b', 'username=other');
+    jobs[1](response({ upload: 'new', download: 'new' })); await second;
+    jobs[2](response({ upload: 'other', download: 'other' })); await other;
+    jobs[0](response({}, { ok: false, status: 500 })); await first;
+    assert.equal(nodes.a.textContent, 'Upload: newDownload: new');
+    assert.equal(nodes.b.textContent, 'Upload: otherDownload: other');
+});
+
+test('missing and detached targets are safe', async () => {
+    let resolve;
+    const { info, nodes } = setup(() => new Promise(r => { resolve = r; }));
+    await info.user('missing', 'username=test');
+    const job = info.user('a', 'username=test');
+    nodes.a.isConnected = false;
+    resolve(response({ upload: 'late', download: 'late' })); await job;
+    assert.equal(nodes.a.textContent, 'Loading...');
+});
+
+test('all read-only page callers load the new scripts; mutation pages keep SACK', () => {
+    const keep = new Set(['bill-pos-list.php', 'mng-list-all.php', 'mng-search.php', 'rep-batch-details.php']);
+    let count = 0;
+    for (const name of fs.readdirSync(path.join(root, 'app/operators'))) {
+        if (!name.endsWith('.php')) continue;
+        const source = fs.readFileSync(path.join(root, 'app/operators', name), 'utf8');
+        assert.doesNotMatch(source, /ajaxGeneric\(['"]library\/ajax\/(user_info|hotspot_info|vendor_attribute_info)\.php/);
+        if (!source.includes('daloInfo.')) continue;
+        count++;
+        assert.ok(source.includes('static/js/request.js'), name);
+        assert.ok(source.includes('static/js/readonly_info.js'), name);
+        assert.equal(source.includes('static/js/ajax.js'), keep.has(name), name);
+        assert.equal(source.includes('static/js/ajaxGeneric.js'), keep.has(name), name);
+    }
+    assert.equal(count, 18);
+});

--- a/tests/readonly_info_http.py
+++ b/tests/readonly_info_http.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""HTTP contract tests: real PHP endpoints/session/ACL code, synthetic DB only.
+
+Requires Python 3 and PHP CLI (or PHP_COMMAND pointing to a PHP container).
+Creates and removes an isolated temporary application; never uses the lab DB.
+"""
+import http.client
+import json
+import os
+from pathlib import Path
+import shlex
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+import urllib.parse
+
+ROOT = Path(__file__).resolve().parents[1]
+PHP = shlex.split(os.environ.get('PHP_COMMAND', 'php'))
+ENDPOINTS = {
+    'user_info.php': ('username', 'acct_username'),
+    'hotspot_info.php': ('hotspot', 'acct_hotspot_accounting'),
+    'vendor_attribute_info.php': ('attribute', 'mng_rad_attributes_list'),
+}
+
+
+def run():
+    checks = 0
+    with tempfile.TemporaryDirectory(prefix='dalo-info-test-') as temp:
+        base = Path(temp)
+        app = base / 'app'
+        for name in [*ENDPOINTS, 'json_info.php']:
+            dest = app / 'operators/library/ajax' / name
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(ROOT / 'app/operators/library/ajax' / name, dest)
+        for name in ['checklogin.php', 'check_operator_perm.php', 'sessions.php']:
+            shutil.copyfile(ROOT / 'app/operators/library' / name, app / 'operators/library' / name)
+        dest = app / 'operators/include/management/pages_common.php'
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(ROOT / 'app/operators/include/management/pages_common.php', dest)
+        includes = app / 'common/includes'
+        includes.mkdir(parents=True)
+        (includes / 'db_close.php').write_text('<?php // Synthetic connection has nothing to close.\n')
+        (includes / 'db_open.php').write_text('''<?php
+require_once __DIR__ . '/fixture.php';
+$configValues = [
+    'CONFIG_DB_TBL_DALOOPERATORS_ACL' => 'operators_acl',
+    'CONFIG_DB_TBL_RADACCT' => 'radacct',
+    'CONFIG_DB_TBL_DALOHOTSPOTS' => 'hotspots',
+    'CONFIG_DB_TBL_DALODICTIONARY' => 'dictionary',
+];
+$dbSocket = new FixtureDB();
+''')
+        (includes / 'fixture.php').write_text('''<?php
+define('PEAR_ERROR_RETURN', 1);
+class DB { static function isError($value) { return $value instanceof Exception; } }
+class FixtureResult {
+    function fetchRow() {
+        if (isset($_GET['empty'])) return null;
+        return basename($_SERVER['SCRIPT_NAME']) === 'hotspot_info.php' ? [3, 1024, 2048] : [1024, 2048];
+    }
+}
+class FixtureDB {
+    private $returnErrors = false;
+    function setErrorHandling($mode) { $this->returnErrors = $mode === PEAR_ERROR_RETURN; }
+    function escapeSimple($value) { return str_replace("'", "''", $value); }
+    function query($sql) {
+        if (!str_starts_with($sql, 'SELECT ')) throw new Exception('Unexpected mutation');
+        if (isset($_GET['failure']) && !$this->returnErrors) echo '<div>Default PEAR error output</div>';
+        return isset($_GET['failure']) ? new Exception('Synthetic DB error') : new FixtureResult();
+    }
+    function getOne($sql) {
+        if (str_contains($sql, 'operators_acl')) {
+            $expected = [
+                'user_info.php' => 'acct_username',
+                'hotspot_info.php' => 'acct_hotspot_accounting',
+                'vendor_attribute_info.php' => 'mng_rad_attributes_list',
+            ][basename($_SERVER['SCRIPT_NAME'])];
+            if (!str_contains($sql, "file='$expected'")) throw new Exception('Wrong ACL');
+            return $_SESSION['operator_id'] === 1 ? 1 : 0;
+        }
+        if (isset($_GET['failure'])) {
+            if (!$this->returnErrors) echo '<div>Default PEAR error output</div>';
+            return new Exception('Synthetic DB error');
+        }
+        return isset($_GET['empty']) ? null : "Description with 'quotes', & é <img src=x onerror=alert(1)>";
+    }
+}
+''')
+        sessions = base / 'sessions'
+        sessions.mkdir(mode=0o777)
+        sessions.chmod(0o777)
+        # Seed local test sessions; this is not a test of password login.
+        for name, operator, age in [('allowed', 1, 0), ('denied', 2, 0), ('expired', 1, 7200)]:
+            script = (f'session_save_path({json.dumps(str(sessions))}); '
+                      f'session_name("daloradius_operator_sid"); session_id("{name}"); session_start(); '
+                      f'$_SESSION=["daloradius_logged_in"=>true,"operator_id"=>{operator},"time"=>time()-{age}]; '
+                      'session_write_close();')
+            subprocess.run(PHP + ['-r', script], check=True, capture_output=True)
+        with socket.socket() as sock:
+            sock.bind(('127.0.0.1', 0))
+            port = sock.getsockname()[1]
+        command = PHP + ['-d', f'session.save_path={sessions}', '-d', 'display_errors=1',
+                         '-d', 'error_reporting=24575', '-S', f'127.0.0.1:{port}', '-t', str(app / 'operators')]
+        with (base / 'server.log').open('w+') as log:
+            server = subprocess.Popen(command, stdout=log, stderr=log)
+            try:
+                for _ in range(100):
+                    try:
+                        with socket.create_connection(('127.0.0.1', port), timeout=.2):
+                            break
+                    except OSError:
+                        if server.poll() is not None:
+                            raise RuntimeError('PHP server exited')
+                        time.sleep(.05)
+                else:
+                    raise RuntimeError('PHP server did not start')
+
+                def request(endpoint, query, session='allowed', method='GET'):
+                    connection = http.client.HTTPConnection('127.0.0.1', port, timeout=5)
+                    headers = {} if session is None else {'Cookie': 'daloradius_operator_sid=' + session}
+                    connection.request(method, '/library/ajax/' + endpoint + '?' + query, headers=headers)
+                    response = connection.getresponse()
+                    result = response.status, dict(response.getheaders()), response.read().decode()
+                    connection.close()
+                    return result
+
+                for endpoint, (parameter, _) in ENDPOINTS.items():
+                    query = urllib.parse.urlencode({parameter: "é O'Reilly & + /"})
+                    status, headers, body = request(endpoint, query)
+                    assert status == 200, (endpoint, status, body)
+                    assert headers['Content-Type'] == 'application/json; charset=UTF-8'
+                    assert headers['Cache-Control'] == 'no-store'
+                    data = json.loads(body)
+                    if endpoint == 'vendor_attribute_info.php':
+                        assert data == {'description': "Description with 'quotes', & é <img src=x onerror=alert(1)>"}
+                    else:
+                        assert data['upload'] == '1 KB' and data['download'] == '2 KB', data
+                        if endpoint == 'hotspot_info.php': assert data['hits'] == 3
+                    checks += 1
+                    status, _, body = request(endpoint, query + '&empty=1')
+                    assert status == 200 and all(x == '(n/a)' for x in json.loads(body).values()), body
+                    checks += 1
+                    for extra, session, method, expected in [
+                        ('', None, 'GET', 302), ('', 'expired', 'GET', 302),
+                        ('', 'denied', 'GET', 403), ('', 'allowed', 'POST', 405),
+                        ('&failure=1', 'allowed', 'GET', 500),
+                    ]:
+                        status, headers, body = request(endpoint, query + extra, session, method)
+                        assert status == expected, (endpoint, expected, status, body)
+                        if expected in [405, 500]: assert 'error' in json.loads(body)
+                        if expected == 405: assert headers['Allow'] == 'GET'
+                        checks += 1
+                    for invalid in ['', parameter + '[]=x', parameter + '=%20']:
+                        status, _, body = request(endpoint, invalid)
+                        assert status == 400 and 'error' in json.loads(body), (endpoint, status, body)
+                        checks += 1
+            finally:
+                server.terminate()
+                try: server.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    server.kill()
+                    server.wait()
+                log.seek(0)
+                output = log.read()
+                assert 'Fatal error' not in output and 'Warning:' not in output, output
+    print(f'PASS: {checks} HTTP contract scenarios (synthetic DB, real PHP/session/ACL code).')
+
+
+if __name__ == '__main__':
+    run()

--- a/tests/readonly_info_http.py
+++ b/tests/readonly_info_http.py
@@ -50,6 +50,13 @@ $configValues = [
     'CONFIG_DB_TBL_DALOHOTSPOTS' => 'hotspots',
     'CONFIG_DB_TBL_DALODICTIONARY' => 'dictionary',
 ];
+if (isset($_GET['connect_failure'])) {
+    $error = new Exception('Synthetic connection error');
+    if (isset($db_error_handler) && is_callable($db_error_handler)) {
+        call_user_func($db_error_handler, $error);
+    }
+    die('<b>Database connection error</b>');
+}
 $dbSocket = new FixtureDB();
 ''')
         (includes / 'fixture.php').write_text('''<?php
@@ -57,6 +64,7 @@ define('PEAR_ERROR_RETURN', 1);
 class DB { static function isError($value) { return $value instanceof Exception; } }
 class FixtureResult {
     function fetchRow() {
+        if (isset($_GET['fetch_failure'])) return new Exception('Synthetic fetch error');
         if (isset($_GET['empty'])) return null;
         return basename($_SERVER['SCRIPT_NAME']) === 'hotspot_info.php' ? [3, 1024, 2048] : [1024, 2048];
     }
@@ -64,20 +72,21 @@ class FixtureResult {
 class FixtureDB {
     private $returnErrors = false;
     function setErrorHandling($mode) { $this->returnErrors = $mode === PEAR_ERROR_RETURN; }
+    function disconnect() {}
     function escapeSimple($value) { return str_replace("'", "''", $value); }
     function query($sql) {
-        if (!str_starts_with($sql, 'SELECT ')) throw new Exception('Unexpected mutation');
+        if (strpos($sql, 'SELECT ') !== 0) throw new Exception('Unexpected mutation');
         if (isset($_GET['failure']) && !$this->returnErrors) echo '<div>Default PEAR error output</div>';
         return isset($_GET['failure']) ? new Exception('Synthetic DB error') : new FixtureResult();
     }
     function getOne($sql) {
-        if (str_contains($sql, 'operators_acl')) {
+        if (strpos($sql, 'operators_acl') !== false) {
             $expected = [
                 'user_info.php' => 'acct_username',
                 'hotspot_info.php' => 'acct_hotspot_accounting',
                 'vendor_attribute_info.php' => 'mng_rad_attributes_list',
             ][basename($_SERVER['SCRIPT_NAME'])];
-            if (!str_contains($sql, "file='$expected'")) throw new Exception('Wrong ACL');
+            if (strpos($sql, "file='$expected'") === false) throw new Exception('Wrong ACL');
             return $_SESSION['operator_id'] === 1 ? 1 : 0;
         }
         if (isset($_GET['failure'])) {
@@ -88,6 +97,41 @@ class FixtureDB {
     }
 }
 ''')
+        # Exercise the production db_open.php connection-failure path with a
+        # minimal PEAR DB double. The endpoint fixture above separately checks
+        # the resulting HTTP contract.
+        production_includes = base / 'production-includes'
+        production_includes.mkdir()
+        shutil.copyfile(ROOT / 'app/common/includes/db_open.php', production_includes / 'db_open.php')
+        shutil.copyfile(ROOT / 'app/operators/library/ajax/json_info.php', base / 'json_info.php')
+        (production_includes / 'config_read.php').write_text('''<?php
+$configValues = [
+    'CONFIG_DB_ENGINE' => 'mysql', 'CONFIG_DB_USER' => 'test', 'CONFIG_DB_PASS' => 'test',
+    'CONFIG_DB_HOST' => 'localhost', 'CONFIG_DB_PORT' => '3306', 'CONFIG_DB_NAME' => 'test',
+];
+''')
+        (production_includes / 'db_table_conventions.php').write_text('<?php\n')
+        (base / 'DB.php').write_text('''<?php
+define('PEAR_ERROR_CALLBACK', 16);
+class SyntheticConnectionError { function getMessage() { return 'synthetic'; } }
+class DB {
+    static function connect($dsn) { return new SyntheticConnectionError(); }
+    static function isError($value) { return $value instanceof SyntheticConnectionError; }
+}
+''')
+        runner = base / 'db_open_failure.php'
+        runner.write_text('''<?php
+$_SERVER['PHP_SELF'] = '/library/ajax/vendor_attribute_info.php';
+require __DIR__ . '/json_info.php';
+$dalo_info_database_error_message = 'Unable to load attribute information.';
+$db_error_handler = 'dalo_info_database_error';
+include __DIR__ . '/production-includes/db_open.php';
+''')
+        result = subprocess.run(PHP + ['-d', f'include_path={base}', str(runner)],
+                                check=True, capture_output=True, text=True)
+        assert json.loads(result.stdout) == {'error': 'Unable to load attribute information.'}, result.stdout
+        assert '<b>' not in result.stdout
+        checks += 1
         sessions = base / 'sessions'
         sessions.mkdir(mode=0o777)
         sessions.chmod(0o777)
@@ -151,6 +195,15 @@ class FixtureDB {
                         assert status == expected, (endpoint, expected, status, body)
                         if expected in [405, 500]: assert 'error' in json.loads(body)
                         if expected == 405: assert headers['Allow'] == 'GET'
+                        checks += 1
+                    status, headers, body = request(endpoint, query + '&connect_failure=1')
+                    assert status == 500, (endpoint, status, body)
+                    assert headers['Content-Type'] == 'application/json; charset=UTF-8'
+                    assert 'error' in json.loads(body) and '<b>' not in body, (endpoint, status, body)
+                    checks += 1
+                    if endpoint != 'vendor_attribute_info.php':
+                        status, _, body = request(endpoint, query + '&fetch_failure=1')
+                        assert status == 500 and 'error' in json.loads(body), (endpoint, status, body)
                         checks += 1
                     for invalid in ['', parameter + '[]=x', parameter + '=%20']:
                         status, _, body = request(endpoint, invalid)


### PR DESCRIPTION
## Summary

Migrates the remaining read-only SACK information requests to same-origin JSON GET endpoints.

This covers:

- user traffic information;
- hotspot usage statistics;
- RADIUS attribute descriptions;
- their consumers across management, accounting, and reporting pages.

## Changes

- Add a shared JSON request utility and explicit rendering helpers.
- Return JSON from:
  - `user_info.php`
  - `hotspot_info.php`
  - `vendor_attribute_info.php`
- Replace the corresponding `ajaxGeneric(...)` calls.
- Preserve existing labels, formatted units, descriptions, and `(n/a)` values.
- Preserve the existing authentication and ACL checks.
- Remove SACK assets only from pages that no longer use them.
- Keep SACK on mixed pages that still contain mutation controls.
- Prevent stale or out-of-order responses from updating the wrong row.
- Render returned values as text rather than executable JavaScript or HTML.

No database migration is required.

## Validation

Automated:

- `node --test tests/readonly-info.test.cjs` — 17 tests passed
- `python3 tests/readonly_info_http.py` — 30 HTTP contract scenarios passed
- PHP syntax checks passed for all changed PHP files
- JavaScript syntax checks passed
- `git diff --check` passed
- Docker images built and services started successfully

The automated coverage includes:

- missing data and `(n/a)` values;
- special characters in parameters and returned text;
- ACL denial and expired sessions;
- invalid methods and parameters;
- server, network, and malformed-response errors;
- multiple and out-of-order requests;
- preservation of SACK on pages with remaining mutation consumers.

Manual validation on the Docker development environment:

- user traffic information;
- hotspot statistics;
- RADIUS attribute descriptions;
- GET/JSON responses and correct row updates.

> Automated HTTP endpoint tests use the real PHP session and ACL code with a synthetic database. Manual UI checks were performed against the deployed development database.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the read-only SACK info requests — user bandwidth, hotspot totals, and dictionary descriptions — to same-origin JSON GET endpoints. The old SACK endpoints returned executable JavaScript assigned to `innerHTML`; the new ones return JSON rendered as text, removing an injection vector and preventing stale or out-of-order responses from updating the wrong row.

- Adds `request.js` (JSON GET transport with session, ACL, and network error handling) and `readonly_info.js` (text-only rendering).
- `user_info.php`, `hotspot_info.php`, and `vendor_attribute_info.php` now return JSON with `Cache-Control: no-store`, preserving existing labels, units, `(n/a)` values, and ACL checks.
- `db_open.php` now supports a custom error handler so database connection and query failures return JSON 500 responses instead of HTML.
- All 18 read-only page consumers use the new scripts; mixed read/write pages keep SACK for mutation controls.

**Migration**
- Custom clients that called these endpoints expecting executable JavaScript or POST must switch to JSON GET.
- No database migration is required.

<sup>Written for commit 86e219060594caf24eb421ab270499370067298f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

