### PR TITLE
chore: remove unused PHP zip dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,6 @@ RUN apt-get update \
   php-mbstring \
   php-db \
   php-mysql \
-  php-zip \
   mariadb-client \
   && rm -rf /var/lib/apt/lists/*
 

--- a/doc/install/INSTALL.debian.md
+++ b/doc/install/INSTALL.debian.md
@@ -209,7 +209,7 @@ Therefore, the presented steps provide a general outline for enabling communicat
 To proceed with the installation of daloRADIUS, execute the following command which is required to install the Apache 2 web server and the necessary packages:
 ```bash
 apt --no-install-recommends install apache2 php libapache2-mod-php \
-                                    php-mysql php-zip php-mbstring php-common php-curl \
+                                    php-mysql php-mbstring php-common php-curl \
                                     php-gd php-db php-mail php-mail-mime \
                                     mariadb-client freeradius-utils rsyslog
 ```

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -477,7 +477,7 @@ freeradius_enable_restart() {
 # Function to install daloRADIUS and required packages
 daloradius_install_dep() {
     echo -n "[+] Installing daloRADIUS dependencies... "
-    apt --no-install-recommends install apache2 php libapache2-mod-php php-mysql php-zip php-mbstring php-common php-curl \
+    apt --no-install-recommends install apache2 php libapache2-mod-php php-mysql php-mbstring php-common php-curl \
                                         php-gd php-db php-mail php-mail-mime freeradius-utils git rsyslog -y >/dev/null 2>&1 &
     print_spinner $!
     wait $!


### PR DESCRIPTION
## Summary

Remove the unused `php-zip` package from the Docker image, Debian installation guide, and installation script.

daloRADIUS does not use PHP’s ZIP APIs, and PDF generation with dompdf works without the extension.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unused `php-zip` package from the Docker image, Debian install guide, and install script. daloRADIUS doesn't use PHP's ZIP APIs, and PDF generation with dompdf works without the extension.

<sup>Written for commit fefbfa538f7677dc7ade421d7a4576018f5c47f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

