### PR TITLE
Feat/user portal password hashing

### DIFF
--- a/README.docker.md
+++ b/README.docker.md
@@ -85,6 +85,11 @@ docker compose exec -T radius-mysql sh -lc 'mariadb -u"$MYSQL_USER" -p"$MYSQL_PA
   < contrib/db/migrations/2026-06-operator-totp-mfa.sql
 ```
 
+For the user portal password hashing upgrade, apply
+`contrib/db/migrations/2026-09-user-portal-password-hashing.sql`, deploy the
+updated web application, then follow
+[`doc/setup/user-portal-passwords.md`](doc/setup/user-portal-passwords.md).
+
 ## Import an existing database backup
 
 To initialize a new Docker stack from an existing MariaDB dump, copy one or more `.sql` or `.sql.gz` files into `./var/backup` before the first startup:

--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ daloRADIUS supports Operators for complete management of the entire platform. Di
 
 For new installations, use the schemas found in `contrib/db/mariadb-daloradius*.sql`. If you're upgrading an existing daloRADIUS setup, review `contrib/db/migrations/` and apply the relevant SQL migrations before using any newly introduced features. See the [upgrade notes](../../wiki/daloRADIUS-upgrade-notes-(Debian)) in the wiki for details.
 
+User portal passwords are separate from FreeRADIUS password attributes and are stored using PHP's `password_hash()`. Existing installations should follow the [user portal password upgrade guide](doc/setup/user-portal-passwords.md).
+
 
 
 # Credits

--- a/app/common/includes/layout.php
+++ b/app/common/includes/layout.php
@@ -740,6 +740,8 @@ function print_table_row($table_row) {
                             // "tooltipText" => t('Tooltip','usernameTooltip'),
                             // "pattern" => "[a-zA-Z0-9_]+",
                             // "disabled" => true,
+                            // "minlength" => 1, (type=password specific, null omits the attribute)
+                            // "maxlength" => 255, (type=password specific, null omits the attribute)
 
                             // "min" => 1|2018-10-30, (type=number|date specific)
                             // "max" => 10|2022-01-29, (type=number|date specific)
@@ -787,8 +789,17 @@ function print_input_field($input_descriptor) {
     }
 
     if ($input_descriptor['type'] == "password") {
-        printf(' maxlength="%s"', $configValues['CONFIG_DB_PASSWORD_MAX_LENGTH']);
-        printf(' minlength="%s"', $configValues['CONFIG_DB_PASSWORD_MIN_LENGTH']);
+        $maxlength = array_key_exists('maxlength', $input_descriptor)
+                   ? $input_descriptor['maxlength'] : $configValues['CONFIG_DB_PASSWORD_MAX_LENGTH'];
+        $minlength = array_key_exists('minlength', $input_descriptor)
+                   ? $input_descriptor['minlength'] : $configValues['CONFIG_DB_PASSWORD_MIN_LENGTH'];
+
+        if ($maxlength !== null) {
+            printf(' maxlength="%s"', intval($maxlength));
+        }
+        if ($minlength !== null) {
+            printf(' minlength="%s"', intval($minlength));
+        }
     }
 
     if (in_array($input_descriptor['type'], array("number", "date"))) {
@@ -1445,8 +1456,17 @@ function menu_print_input_field($input_descriptor) {
     }
 
     if ($input_descriptor['type'] == "password") {
-        printf(' maxlength="%s"', $configValues['CONFIG_DB_PASSWORD_MAX_LENGTH']);
-        printf(' minlength="%s"', $configValues['CONFIG_DB_PASSWORD_MIN_LENGTH']);
+        $maxlength = array_key_exists('maxlength', $input_descriptor)
+                   ? $input_descriptor['maxlength'] : $configValues['CONFIG_DB_PASSWORD_MAX_LENGTH'];
+        $minlength = array_key_exists('minlength', $input_descriptor)
+                   ? $input_descriptor['minlength'] : $configValues['CONFIG_DB_PASSWORD_MIN_LENGTH'];
+
+        if ($maxlength !== null) {
+            printf(' maxlength="%s"', intval($maxlength));
+        }
+        if ($minlength !== null) {
+            printf(' minlength="%s"', intval($minlength));
+        }
     }
 
     if (in_array($input_descriptor['type'], array("number", "date"))) {

--- a/app/common/includes/portal_password.php
+++ b/app/common/includes/portal_password.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ * Shared helpers for user portal passwords.
+ *
+ * Portal passwords are independent from FreeRADIUS password attributes.
+ */
+
+if (strpos($_SERVER['PHP_SELF'] ?? '', '/common/includes/portal_password.php') !== false) {
+    http_response_code(404);
+    exit;
+}
+
+function dalo_portal_password_is_hash($stored_password) {
+    if (!is_string($stored_password) || $stored_password === '') {
+        return false;
+    }
+
+    $info = password_get_info($stored_password);
+    return isset($info['algoName']) && $info['algoName'] !== 'unknown';
+}
+
+function dalo_portal_password_hash($password) {
+    if (!is_string($password) || $password === '') {
+        return false;
+    }
+
+    return password_hash($password, PASSWORD_DEFAULT);
+}
+
+function dalo_portal_password_verify($password, $stored_password) {
+    $result = array(
+        'verified' => false,
+        'legacy' => false,
+        'needs_rehash' => false,
+    );
+
+    if (!is_string($password) || !is_string($stored_password) || $stored_password === '') {
+        return $result;
+    }
+
+    if (dalo_portal_password_is_hash($stored_password)) {
+        $result['verified'] = password_verify($password, $stored_password);
+        $result['needs_rehash'] = $result['verified']
+                                && password_needs_rehash($stored_password, PASSWORD_DEFAULT);
+        return $result;
+    }
+
+    $result['verified'] = hash_equals($stored_password, $password);
+    $result['legacy'] = $result['verified'];
+    $result['needs_rehash'] = $result['verified'];
+
+    return $result;
+}

--- a/app/common/includes/portal_password.php
+++ b/app/common/includes/portal_password.php
@@ -10,21 +10,62 @@ if (strpos($_SERVER['PHP_SELF'] ?? '', '/common/includes/portal_password.php') !
     exit;
 }
 
-function dalo_portal_password_is_hash($stored_password) {
-    if (!is_string($stored_password) || $stored_password === '') {
+function dalo_portal_password_prefix() {
+    return '$dalo$portal$v1$';
+}
+
+function dalo_portal_password_is_present($password) {
+    return is_string($password) && trim($password) !== '';
+}
+
+function dalo_portal_password_is_acceptable($password) {
+    return dalo_portal_password_is_present($password) && strpos($password, "\0") === false;
+}
+
+function dalo_portal_access_requested($values) {
+    foreach (array('enableUserPortalLogin', 'changeUserInfo', 'bi_changeuserbillinfo') as $field) {
+        if (isset($values[$field]) && $values[$field] === '1') {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function dalo_portal_access_is_valid($values, $has_existing_password = false) {
+    $password = isset($values['portalLoginPassword']) ? $values['portalLoginPassword'] : '';
+    if (dalo_portal_password_is_present($password) && !dalo_portal_password_is_acceptable($password)) {
         return false;
     }
 
-    $info = password_get_info($stored_password);
+    return !dalo_portal_access_requested($values)
+        || $has_existing_password
+        || dalo_portal_password_is_acceptable($password);
+}
+
+function dalo_portal_password_is_hash($stored_password) {
+    $prefix = dalo_portal_password_prefix();
+    if (!is_string($stored_password) || substr($stored_password, 0, strlen($prefix)) !== $prefix) {
+        return false;
+    }
+
+    $hash = substr($stored_password, strlen($prefix));
+    $info = password_get_info($hash);
     return isset($info['algoName']) && $info['algoName'] !== 'unknown';
 }
 
 function dalo_portal_password_hash($password) {
-    if (!is_string($password) || $password === '') {
+    if (!is_string($password) || $password === '' || strpos($password, "\0") !== false) {
         return false;
     }
 
-    return password_hash($password, PASSWORD_DEFAULT);
+    try {
+        $hash = password_hash($password, PASSWORD_DEFAULT);
+    } catch (Throwable $exception) {
+        return false;
+    }
+
+    return is_string($hash) ? dalo_portal_password_prefix() . $hash : false;
 }
 
 function dalo_portal_password_verify($password, $stored_password) {
@@ -34,14 +75,20 @@ function dalo_portal_password_verify($password, $stored_password) {
         'needs_rehash' => false,
     );
 
-    if (!is_string($password) || !is_string($stored_password) || $stored_password === '') {
+    if (!is_string($password) || !is_string($stored_password) || $stored_password === '' ||
+        strpos($password, "\0") !== false) {
         return $result;
     }
 
     if (dalo_portal_password_is_hash($stored_password)) {
-        $result['verified'] = password_verify($password, $stored_password);
+        $hash = substr($stored_password, strlen(dalo_portal_password_prefix()));
+        try {
+            $result['verified'] = password_verify($password, $hash);
+        } catch (Throwable $exception) {
+            return $result;
+        }
         $result['needs_rehash'] = $result['verified']
-                                && password_needs_rehash($stored_password, PASSWORD_DEFAULT);
+                                && password_needs_rehash($hash, PASSWORD_DEFAULT);
         return $result;
     }
 
@@ -50,4 +97,16 @@ function dalo_portal_password_verify($password, $stored_password) {
     $result['needs_rehash'] = $result['verified'];
 
     return $result;
+}
+
+function dalo_portal_db_sensitive_call($dbSocket, $callback, $error_handler = null) {
+    $dbSocket->setErrorHandling(PEAR_ERROR_RETURN);
+
+    try {
+        return $callback();
+    } finally {
+        if (is_callable($error_handler)) {
+            $dbSocket->setErrorHandling(PEAR_ERROR_CALLBACK, $error_handler);
+        }
+    }
 }

--- a/app/operators/bill-pos-edit.php
+++ b/app/operators/bill-pos-edit.php
@@ -185,19 +185,23 @@
             $notes = (array_key_exists('notes', $_POST) && isset($_POST['notes'])) ? $_POST['notes'] : "";
 
             // first we check user portal login password
-            $ui_PortalLoginPassword = (isset($_POST['portalLoginPassword']) && !empty(trim($_POST['portalLoginPassword'])))
+            $ui_PortalLoginPassword = (isset($_POST['portalLoginPassword']) &&
+                                       dalo_portal_password_is_acceptable($_POST['portalLoginPassword']))
                                     ? trim($_POST['portalLoginPassword']) : "";
 
             $ui_hasPortalLoginPassword = user_portal_password_is_set($dbSocket, $username);
-            $portal_password_available = $ui_hasPortalLoginPassword || !empty($ui_PortalLoginPassword);
+            $portal_password_available = $ui_hasPortalLoginPassword
+                                      || dalo_portal_password_is_present($ui_PortalLoginPassword);
+            $portal_access_valid = dalo_portal_access_is_valid($_POST, $ui_hasPortalLoginPassword);
 
             $ui_changeuserinfo = ($portal_password_available && isset($_POST['changeUserInfo']) && $_POST['changeUserInfo'] === '1')
                                ? '1' : '0';
             $ui_enableUserPortalLogin = ($portal_password_available && isset($_POST['enableUserPortalLogin']) && $_POST['enableUserPortalLogin'] === '1')
                                       ? '1' : '0';
 
-            if (!$portal_password_available && isset($_POST['enableUserPortalLogin']) && $_POST['enableUserPortalLogin'] === '1') {
-                $failureMsg = 'A portal password is required before portal login can be enabled.';
+            if (!$portal_access_valid) {
+                $failureMsg = 'A portal password is required before portal access can be enabled.';
+                $logAction .= "Failed updating user because portal access requires a password on page: ";
             }
 
             $groups = (isset($_POST['groups']) && is_array($_POST['groups'])) ? $_POST['groups'] : array();
@@ -235,7 +239,7 @@
             $bi_faxinvoice = (array_key_exists('bi_faxinvoice', $_POST) && isset($_POST['bi_faxinvoice'])) ? $_POST['bi_faxinvoice'] : "";
             $bi_emailinvoice = (array_key_exists('bi_emailinvoice', $_POST) && isset($_POST['bi_emailinvoice'])) ? $_POST['bi_emailinvoice'] : "";
 
-            if (!empty($username)) {
+            if (!empty($username) && $portal_access_valid) {
 
                 $userinfoExist = user_exists($dbSocket, $username, 'CONFIG_DB_TBL_DALOUSERINFO');
                 $params = array(

--- a/app/operators/bill-pos-edit.php
+++ b/app/operators/bill-pos-edit.php
@@ -188,11 +188,17 @@
             $ui_PortalLoginPassword = (isset($_POST['portalLoginPassword']) && !empty(trim($_POST['portalLoginPassword'])))
                                     ? trim($_POST['portalLoginPassword']) : "";
 
-            // these are forced to 0 (disabled) if user portal login password is empty
-            $ui_changeuserinfo = (!empty($ui_PortalLoginPassword) && isset($_POST['changeUserInfo']) && $_POST['changeUserInfo'] === '1')
+            $ui_hasPortalLoginPassword = user_portal_password_is_set($dbSocket, $username);
+            $portal_password_available = $ui_hasPortalLoginPassword || !empty($ui_PortalLoginPassword);
+
+            $ui_changeuserinfo = ($portal_password_available && isset($_POST['changeUserInfo']) && $_POST['changeUserInfo'] === '1')
                                ? '1' : '0';
-            $ui_enableUserPortalLogin = (!empty($ui_PortalLoginPassword) &&  isset($_POST['enableUserPortalLogin']) && $_POST['enableUserPortalLogin'] === '1')
+            $ui_enableUserPortalLogin = ($portal_password_available && isset($_POST['enableUserPortalLogin']) && $_POST['enableUserPortalLogin'] === '1')
                                       ? '1' : '0';
+
+            if (!$portal_password_available && isset($_POST['enableUserPortalLogin']) && $_POST['enableUserPortalLogin'] === '1') {
+                $failureMsg = 'A portal password is required before portal login can be enabled.';
+            }
 
             $groups = (isset($_POST['groups']) && is_array($_POST['groups'])) ? $_POST['groups'] : array();
 
@@ -214,8 +220,7 @@
             $bi_creditcardexp = (array_key_exists('bi_creditcardexp', $_POST) && isset($_POST['bi_creditcardexp'])) ? $_POST['bi_creditcardexp'] : "";
             $bi_notes = (array_key_exists('bi_notes', $_POST) && isset($_POST['bi_notes'])) ? $_POST['bi_notes'] : "";
 
-            // this is forced to 0 (disabled) if user portal login password is empty
-            $bi_changeuserbillinfo = (!empty($ui_PortalLoginPassword) && isset($_POST['bi_changeuserbillinfo']) && $_POST['bi_changeuserbillinfo'] === '1')
+            $bi_changeuserbillinfo = ($portal_password_available && isset($_POST['bi_changeuserbillinfo']) && $_POST['bi_changeuserbillinfo'] === '1')
                                    ? '1' : '0';
 
             $bi_lead = (array_key_exists('bi_lead', $_POST) && isset($_POST['bi_lead'])) ? $_POST['bi_lead'] : "";
@@ -232,57 +237,36 @@
 
             if (!empty($username)) {
 
-                // insert userinfo
-                $sql = sprintf("SELECT COUNT(DISTINCT(username)) FROM %s WHERE username='%s'",
-                               $configValues['CONFIG_DB_TBL_DALOUSERINFO'], $dbSocket->escapeSimple($username));
-                $res = $dbSocket->query($sql);
-                $userinfoExist = intval($res->fetchrow()[0]) > 0;
-                $logDebugSQL .= "$sql;\n";
+                $userinfoExist = user_exists($dbSocket, $username, 'CONFIG_DB_TBL_DALOUSERINFO');
+                $params = array(
+                    'firstname' => $firstname,
+                    'lastname' => $lastname,
+                    'email' => $email,
+                    'department' => $department,
+                    'company' => $company,
+                    'workphone' => $workphone,
+                    'homephone' => $homephone,
+                    'mobilephone' => $mobilephone,
+                    'address' => $address,
+                    'city' => $city,
+                    'state' => $state,
+                    'country' => $country,
+                    'zip' => $zip,
+                    'notes' => $notes,
+                    'changeuserinfo' => $ui_changeuserinfo,
+                    'portalloginpassword' => $ui_PortalLoginPassword,
+                    'enableportallogin' => $ui_enableUserPortalLogin,
+                );
 
-                // if there were no records for this user present in the userinfo table
-                if (!$userinfoExist) {
-                    // insert user information table
-                    $sql = sprintf("INSERT INTO %s (id, username, firstname, lastname, email, department, company,
-                                                    workphone, homephone,  mobilephone, address, city, state, country,
-                                                    zip, notes, changeuserinfo, portalloginpassword, enableportallogin,
-                                                    creationdate, creationby, updatedate, updateby)
-                                            VALUES (0, '%s',  '%s',  '%s',  '%s',  '%s',  '%s',  '%s',  '%s',  '%s',
-                                                    '%s',  '%s',  '%s',  '%s',  '%s',  '%s',  '%s',  '%s',  '%s', '%s',
-                                                    '%s', NULL, NULL)", $configValues['CONFIG_DB_TBL_DALOUSERINFO'],
-                                                                        $dbSocket->escapeSimple($username), $dbSocket->escapeSimple($firstname),
-                                                                        $dbSocket->escapeSimple($lastname), $dbSocket->escapeSimple($email),
-                                                                        $dbSocket->escapeSimple($department), $dbSocket->escapeSimple($company),
-                                                                        $dbSocket->escapeSimple($workphone), $dbSocket->escapeSimple($homephone),
-                                                                        $dbSocket->escapeSimple($mobilephone), $dbSocket->escapeSimple($address),
-                                                                        $dbSocket->escapeSimple($city), $dbSocket->escapeSimple($state),
-                                                                        $dbSocket->escapeSimple($country), $dbSocket->escapeSimple($zip),
-                                                                        $dbSocket->escapeSimple($notes), $dbSocket->escapeSimple($ui_changeuserinfo),
-                                                                        $dbSocket->escapeSimple($ui_PortalLoginPassword),
-                                                                        $dbSocket->escapeSimple($ui_enableUserPortalLogin),
-                                                                        $dbSocket->escapeSimple($current_datetime), $dbSocket->escapeSimple($currBy));
+                if ($userinfoExist) {
+                    $params['updatedate'] = $current_datetime;
+                    $params['updateby'] = $currBy;
+                    update_user_info($dbSocket, $username, $params);
                 } else {
-                   // update user information table
-                   $sql = sprintf("UPDATE %s SET firstname='%s', lastname='%s', email='%s', department='%s', company='%s', workphone='%s',
-                                                 homephone='%s', mobilephone='%s', address='%s', city='%s', state='%s', country='%s',
-                                                 zip='%s', notes='%s', changeuserinfo='%s', portalloginpassword='%s', enableportallogin='%s',
-                                                 updatedate='%s', updateby='%s'
-                                    WHERE username='%s'", $configValues['CONFIG_DB_TBL_DALOUSERINFO'], $dbSocket->escapeSimple($firstname),
-                                                          $dbSocket->escapeSimple($lastname), $dbSocket->escapeSimple($email),
-                                                          $dbSocket->escapeSimple($department), $dbSocket->escapeSimple($company),
-                                                          $dbSocket->escapeSimple($workphone), $dbSocket->escapeSimple($homephone),
-                                                          $dbSocket->escapeSimple($mobilephone), $dbSocket->escapeSimple($address),
-                                                          $dbSocket->escapeSimple($city), $dbSocket->escapeSimple($state),
-                                                          $dbSocket->escapeSimple($country), $dbSocket->escapeSimple($zip),
-                                                          $dbSocket->escapeSimple($notes), $dbSocket->escapeSimple($ui_changeuserinfo),
-                                                          $dbSocket->escapeSimple($ui_PortalLoginPassword),
-                                                          $dbSocket->escapeSimple($ui_enableUserPortalLogin),
-                                                          $dbSocket->escapeSimple($current_datetime), $dbSocket->escapeSimple($currBy),
-                                                          $dbSocket->escapeSimple($username));
+                    $params['creationdate'] = $current_datetime;
+                    $params['creationby'] = $currBy;
+                    add_user_info($dbSocket, $username, $params);
                 }
-
-                // execute the insert/update onto userinfo
-                $res = $dbSocket->query($sql);
-                $logDebugSQL .= "$sql;\n";
 
 
                 /* perform user billing info table instructions */
@@ -386,7 +370,9 @@
 
         /* fill-in all the user info details */
         $sql = sprintf("SELECT firstname, lastname, email, department, company, workphone, homephone, mobilephone, address, city,
-                               state, country, zip, notes, changeuserinfo, portalloginpassword, enableportallogin, creationdate,
+                               state, country, zip, notes, changeuserinfo,
+                               (portalloginpassword IS NOT NULL AND portalloginpassword<>'') AS has_portal_password,
+                               enableportallogin, creationdate,
                                creationby, updatedate, updateby
                           FROM %s WHERE username='%s'", $configValues['CONFIG_DB_TBL_DALOUSERINFO'],
                                                         $dbSocket->escapeSimple($username));
@@ -396,7 +382,7 @@
         list(
               $ui_firstname, $ui_lastname, $ui_email, $ui_department, $ui_company, $ui_workphone, $ui_homephone,
               $ui_mobilephone, $ui_address, $ui_city, $ui_state, $ui_country, $ui_zip, $ui_notes, $ui_changeuserinfo,
-              $ui_PortalLoginPassword, $ui_enableUserPortalLogin, $ui_creationdate, $ui_creationby, $ui_updatedate,
+              $ui_hasPortalLoginPassword, $ui_enableUserPortalLogin, $ui_creationdate, $ui_creationby, $ui_updatedate,
               $ui_updateby
             ) = $res->fetchRow();
 

--- a/app/operators/bill-pos-new.php
+++ b/app/operators/bill-pos-new.php
@@ -69,13 +69,16 @@
     $notes = (array_key_exists('notes', $_POST) && isset($_POST['notes'])) ? $_POST['notes'] : "";
 
     // first we check user portal login password
-    $ui_PortalLoginPassword = (isset($_POST['portalLoginPassword']) && !empty(trim($_POST['portalLoginPassword'])))
+    $ui_PortalLoginPassword = (isset($_POST['portalLoginPassword']) &&
+                               dalo_portal_password_is_acceptable($_POST['portalLoginPassword']))
                             ? trim($_POST['portalLoginPassword']) : "";
 
+    $portal_access_valid = dalo_portal_access_is_valid($_POST);
+
     // these are forced to 0 (disabled) if user portal login password is empty
-    $ui_changeuserinfo = (!empty($ui_PortalLoginPassword) && isset($_POST['changeUserInfo']) && $_POST['changeUserInfo'] === '1')
+    $ui_changeuserinfo = (dalo_portal_password_is_present($ui_PortalLoginPassword) && isset($_POST['changeUserInfo']) && $_POST['changeUserInfo'] === '1')
                        ? '1' : '0';
-    $ui_enableUserPortalLogin = (!empty($ui_PortalLoginPassword) && isset($_POST['enableUserPortalLogin']) && $_POST['enableUserPortalLogin'] === '1')
+    $ui_enableUserPortalLogin = (dalo_portal_password_is_present($ui_PortalLoginPassword) && isset($_POST['enableUserPortalLogin']) && $_POST['enableUserPortalLogin'] === '1')
                               ? '1' : '0';
 
     // billing info variables
@@ -113,7 +116,7 @@
     $bi_billdue = (array_key_exists('bi_billdue', $_POST) && isset($_POST['bi_billdue'])) ? $_POST['bi_billdue'] : "";
 
     // this is forced to 0 (disabled) if user portal login password is empty
-    $bi_changeuserbillinfo = (!empty($ui_PortalLoginPassword) && isset($_POST['bi_changeuserbillinfo']) && $_POST['bi_changeuserbillinfo'] === '1')
+    $bi_changeuserbillinfo = (dalo_portal_password_is_present($ui_PortalLoginPassword) && isset($_POST['bi_changeuserbillinfo']) && $_POST['bi_changeuserbillinfo'] === '1')
                            ? '1' : '0';
 
     function addPlanProfile($dbSocket, $username, $planName) {
@@ -280,7 +283,10 @@
                 // username, password and password type are required. an empty password type
                 // means the posted one is unknown or no longer permitted (e.g. a cleartext
                 // type submitted while CONFIG_DB_PASSWORD_ENCRYPTION is set to 'no')
-                if (empty($username) || empty($password) || empty($passwordType)) {
+                if (!$portal_access_valid) {
+                    $failureMsg = "A portal password is required before portal access can be enabled";
+                    $logAction .= "Failed adding user because portal access requires a password on page: ";
+                } else if (empty($username) || empty($password) || empty($passwordType)) {
                     $failureMsg = "username, password or password type are empty or invalid";
                     $logAction .= "Failed adding (possible empty user/pass or invalid password type) new user [$username] on page: ";
                 } else {

--- a/app/operators/config-user.php
+++ b/app/operators/config-user.php
@@ -115,6 +115,7 @@
                                     "caption" => "Allow cleartext password attributes in db",
                                     "name" => 'CONFIG_DB_PASSWORD_ENCRYPTION',
                                     "selected_value" => $configValues['CONFIG_DB_PASSWORD_ENCRYPTION'],
+                                    "tooltipText" => "This setting only controls RADIUS password attributes in radcheck. User portal passwords are always stored as secure hashes.",
                                  );
 
     $input_descriptors0[] = array(

--- a/app/operators/include/management/functions.php
+++ b/app/operators/include/management/functions.php
@@ -28,6 +28,8 @@ if (strpos($_SERVER['PHP_SELF'], '/include/management/functions.php') !== false)
     exit;
 }
 
+include_once dirname(__DIR__, 3) . '/common/includes/portal_password.php';
+
 
 
 function quote_sql_identifier($identifier) {
@@ -519,6 +521,8 @@ function update_info($dbSocket, $username, $params, $allowedFields, $skipFields,
 
 function update_user_info($dbSocket, $username, $params) {
 
+    global $configValues, $logDebugSQL;
+
     $allowedFields = array(
                             "id", "username", "firstname", "lastname", "email", "department", "company", "workphone",
                             "homephone", "mobilephone", "address", "city", "state", "country", "zip", "notes",
@@ -528,7 +532,26 @@ function update_user_info($dbSocket, $username, $params) {
 
     $skipFields = array( "id", "username" );
 
-    return update_info($dbSocket, $username, $params, $allowedFields, $skipFields, 'CONFIG_DB_TBL_DALOUSERINFO');
+    $password_changed = array_key_exists('portalloginpassword', $params) && $params['portalloginpassword'] !== '';
+    if (array_key_exists('portalloginpassword', $params)) {
+        if ($params['portalloginpassword'] === '') {
+            unset($params['portalloginpassword']);
+        } else {
+            $params['portalloginpassword'] = dalo_portal_password_hash($params['portalloginpassword']);
+            if ($params['portalloginpassword'] === false) {
+                return false;
+            }
+        }
+    }
+
+    $log_before = $logDebugSQL;
+    $result = update_info($dbSocket, $username, $params, $allowedFields, $skipFields, 'CONFIG_DB_TBL_DALOUSERINFO');
+    if ($password_changed) {
+        $logDebugSQL = $log_before . sprintf("UPDATE %s SET [portal password redacted];\n",
+                                             $configValues['CONFIG_DB_TBL_DALOUSERINFO']);
+    }
+
+    return $result;
 }
 
 function update_user_billing_info($dbSocket, $username, $params) {
@@ -569,6 +592,8 @@ function add_info($dbSocket, $username, $params, $allowedFields, $skipFields, $t
 }
 
 function add_user_info($dbSocket, $username, $params) {
+    global $configValues, $logDebugSQL;
+
     $allowedFields = array(
                             "id", "username", "firstname", "lastname", "email", "department", "company", "workphone",
                             "homephone", "mobilephone", "address", "city", "state", "country", "zip", "notes",
@@ -578,7 +603,40 @@ function add_user_info($dbSocket, $username, $params) {
 
     $skipFields = array( "id", "username" );
 
-    return add_info($dbSocket, $username, $params, $allowedFields, $skipFields, 'CONFIG_DB_TBL_DALOUSERINFO');
+    $password_supplied = array_key_exists('portalloginpassword', $params) && $params['portalloginpassword'] !== '';
+    if ($password_supplied) {
+        $params['portalloginpassword'] = dalo_portal_password_hash($params['portalloginpassword']);
+        if ($params['portalloginpassword'] === false) {
+            return false;
+        }
+    }
+
+    $log_before = $logDebugSQL;
+    $result = add_info($dbSocket, $username, $params, $allowedFields, $skipFields, 'CONFIG_DB_TBL_DALOUSERINFO');
+    if ($password_supplied) {
+        $logDebugSQL = $log_before . sprintf("INSERT INTO %s ([portal password redacted]);\n",
+                                             $configValues['CONFIG_DB_TBL_DALOUSERINFO']);
+    }
+
+    return $result;
+}
+
+function user_portal_password_is_set($dbSocket, $username) {
+    global $configValues;
+
+    $sql = sprintf(
+        "SELECT COUNT(id) FROM %s WHERE username=? AND portalloginpassword IS NOT NULL AND portalloginpassword<>''",
+        $configValues['CONFIG_DB_TBL_DALOUSERINFO']
+    );
+    $stmt = $dbSocket->prepare($sql);
+    $res = $dbSocket->execute($stmt, array($username));
+    $dbSocket->freePrepared($stmt);
+
+    if (DB::isError($res)) {
+        return false;
+    }
+
+    return intval($res->fetchRow()[0]) === 1;
 }
 
 function add_user_billing_info($dbSocket, $username, $params) {

--- a/app/operators/include/management/functions.php
+++ b/app/operators/include/management/functions.php
@@ -521,7 +521,7 @@ function update_info($dbSocket, $username, $params, $allowedFields, $skipFields,
 
 function update_user_info($dbSocket, $username, $params) {
 
-    global $configValues, $logDebugSQL;
+    global $configValues, $logDebugSQL, $error_handler;
 
     $allowedFields = array(
                             "id", "username", "firstname", "lastname", "email", "department", "company", "workphone",
@@ -545,7 +545,14 @@ function update_user_info($dbSocket, $username, $params) {
     }
 
     $log_before = $logDebugSQL;
-    $result = update_info($dbSocket, $username, $params, $allowedFields, $skipFields, 'CONFIG_DB_TBL_DALOUSERINFO');
+    $result = dalo_portal_db_sensitive_call(
+        $dbSocket,
+        function() use ($dbSocket, $username, $params, $allowedFields, $skipFields) {
+            return update_info($dbSocket, $username, $params, $allowedFields, $skipFields,
+                               'CONFIG_DB_TBL_DALOUSERINFO');
+        },
+        $error_handler
+    );
     if ($password_changed) {
         $logDebugSQL = $log_before . sprintf("UPDATE %s SET [portal password redacted];\n",
                                              $configValues['CONFIG_DB_TBL_DALOUSERINFO']);
@@ -592,7 +599,7 @@ function add_info($dbSocket, $username, $params, $allowedFields, $skipFields, $t
 }
 
 function add_user_info($dbSocket, $username, $params) {
-    global $configValues, $logDebugSQL;
+    global $configValues, $logDebugSQL, $error_handler;
 
     $allowedFields = array(
                             "id", "username", "firstname", "lastname", "email", "department", "company", "workphone",
@@ -612,7 +619,14 @@ function add_user_info($dbSocket, $username, $params) {
     }
 
     $log_before = $logDebugSQL;
-    $result = add_info($dbSocket, $username, $params, $allowedFields, $skipFields, 'CONFIG_DB_TBL_DALOUSERINFO');
+    $result = dalo_portal_db_sensitive_call(
+        $dbSocket,
+        function() use ($dbSocket, $username, $params, $allowedFields, $skipFields) {
+            return add_info($dbSocket, $username, $params, $allowedFields, $skipFields,
+                            'CONFIG_DB_TBL_DALOUSERINFO');
+        },
+        $error_handler
+    );
     if ($password_supplied) {
         $logDebugSQL = $log_before . sprintf("INSERT INTO %s ([portal password redacted]);\n",
                                              $configValues['CONFIG_DB_TBL_DALOUSERINFO']);

--- a/app/operators/include/management/userinfo.php
+++ b/app/operators/include/management/userinfo.php
@@ -92,11 +92,10 @@ $_input_descriptors2 = array();
 $_input_descriptors2[] = array(
                                     'id' => 'portalLoginPassword',
                                     'caption' => t('ContactInfo','PortalLoginPassword'),
-                                    'type' => 'text',
+                                    'type' => 'password',
                                     'name' => 'portalLoginPassword',
-                                    'value' => ((isset($ui_PortalLoginPassword)) ? $ui_PortalLoginPassword : ''),
-                                    'tooltipText' => sprintf('If this field is empty then fields "%s" and "%s" are forced to "no"',
-                                                              t('ContactInfo','EnableUserUpdate'), t('ContactInfo','EnablePortalLogin')),
+                                    'value' => '',
+                                    'tooltipText' => 'For an existing user, leave this field empty to keep the current portal password.',
                               );
 
 $_input_descriptors2[] = array(

--- a/app/operators/include/management/userinfo.php
+++ b/app/operators/include/management/userinfo.php
@@ -95,6 +95,8 @@ $_input_descriptors2[] = array(
                                     'type' => 'password',
                                     'name' => 'portalLoginPassword',
                                     'value' => '',
+                                    'minlength' => 1,
+                                    'maxlength' => null,
                                     'tooltipText' => 'For an existing user, leave this field empty to keep the current portal password.',
                               );
 

--- a/app/operators/mng-batch-add.php
+++ b/app/operators/mng-batch-add.php
@@ -163,13 +163,16 @@
                 $notes = (array_key_exists('notes', $_POST) && isset($_POST['notes'])) ? $_POST['notes'] : "";
 
                 // first we check user portal login password
-                $ui_PortalLoginPassword = (isset($_POST['portalLoginPassword']) && !empty(trim($_POST['portalLoginPassword'])))
+                $ui_PortalLoginPassword = (isset($_POST['portalLoginPassword']) &&
+                                           dalo_portal_password_is_acceptable($_POST['portalLoginPassword']))
                                         ? trim($_POST['portalLoginPassword']) : "";
 
+                $portal_access_valid = dalo_portal_access_is_valid($_POST);
+
                 // these are forced to 0 (disabled) if user portal login password is empty
-                $ui_changeuserinfo = (!empty($ui_PortalLoginPassword) && isset($_POST['changeUserInfo']) && $_POST['changeUserInfo'] === '1')
+                $ui_changeuserinfo = (dalo_portal_password_is_present($ui_PortalLoginPassword) && isset($_POST['changeUserInfo']) && $_POST['changeUserInfo'] === '1')
                                    ? '1' : '0';
-                $ui_enableUserPortalLogin = (!empty($ui_PortalLoginPassword) && isset($_POST['enableUserPortalLogin']) && $_POST['enableUserPortalLogin'] === '1')
+                $ui_enableUserPortalLogin = (dalo_portal_password_is_present($ui_PortalLoginPassword) && isset($_POST['enableUserPortalLogin']) && $_POST['enableUserPortalLogin'] === '1')
                                           ? '1' : '0';
 
                 /* variables for userbillinfo */
@@ -204,7 +207,7 @@
                 $bi_emailinvoice = (array_key_exists('bi_emailinvoice', $_POST) && isset($_POST['bi_emailinvoice'])) ? $_POST['bi_emailinvoice'] : "";
 
                 // this is forced to 0 (disabled) if user portal login password is empty
-                $bi_changeuserbillinfo = (!empty($ui_PortalLoginPassword) && isset($_POST['bi_changeuserbillinfo']) && $_POST['bi_changeuserbillinfo'] === '1')
+                $bi_changeuserbillinfo = (dalo_portal_password_is_present($ui_PortalLoginPassword) && isset($_POST['bi_changeuserbillinfo']) && $_POST['bi_changeuserbillinfo'] === '1')
                                        ? '1' : '0';
 
 
@@ -242,14 +245,22 @@
 
                 // before looping through all generated batch users we create the batch_history entry
                 // to associate the created users with a batch_history entry
-                $sql_batch_id = addUserBatchHistory($dbSocket);
+                if (!$portal_access_valid) {
+                    $failureMsg = "A portal password is required before portal access can be enabled";
+                    $logAction .= "Failure creating batch because portal access requires a password on page: ";
+                    $sql_batch_id = 0;
+                } else {
+                    $sql_batch_id = addUserBatchHistory($dbSocket);
+                }
 
                 if ($sql_batch_id == 0) {
                     // 0 may be returned in the case of failure in adding the batch_history record due
                     // to SQL related issues or in case where there is a duplicate record of the batch_history,
                     // meaning, the same batch_name is used to identify the batch entry
-                    $failureMsg = "Failure creating batch users due to an error or possible duplicate entry: <b> $batch_name </b>";
-                    $logAction .= "Failure creating a batch_history entry on page: ";
+                    if ($portal_access_valid) {
+                        $failureMsg = "Failure creating batch users due to an error or possible duplicate entry: <b> $batch_name </b>";
+                        $logAction .= "Failure creating a batch_history entry on page: ";
+                    }
                 } else {
 
                     $actionMsgBadUsernames = "";

--- a/app/operators/mng-edit.php
+++ b/app/operators/mng-edit.php
@@ -138,11 +138,14 @@
             $notes = (array_key_exists('notes', $_POST) && isset($_POST['notes'])) ? $_POST['notes'] : "";
 
             // first we check user portal login password
-            $ui_PortalLoginPassword = (isset($_POST['portalLoginPassword']) && !empty(trim($_POST['portalLoginPassword'])))
+            $ui_PortalLoginPassword = (isset($_POST['portalLoginPassword']) &&
+                                       dalo_portal_password_is_acceptable($_POST['portalLoginPassword']))
                                     ? trim($_POST['portalLoginPassword']) : "";
 
             $ui_hasPortalLoginPassword = user_portal_password_is_set($dbSocket, $username);
-            $portal_password_available = $ui_hasPortalLoginPassword || !empty($ui_PortalLoginPassword);
+            $portal_password_available = $ui_hasPortalLoginPassword
+                                      || dalo_portal_password_is_present($ui_PortalLoginPassword);
+            $portal_access_valid = dalo_portal_access_is_valid($_POST, $ui_hasPortalLoginPassword);
 
             // Portal permissions require either an existing password or a newly supplied one.
             $ui_changeuserinfo = ($portal_password_available && isset($_POST['changeUserInfo']) && $_POST['changeUserInfo'] === '1')
@@ -150,8 +153,9 @@
             $ui_enableUserPortalLogin = ($portal_password_available && isset($_POST['enableUserPortalLogin']) && $_POST['enableUserPortalLogin'] === '1')
                                       ? '1' : '0';
 
-            if (!$portal_password_available && isset($_POST['enableUserPortalLogin']) && $_POST['enableUserPortalLogin'] === '1') {
-                $failureMsg = 'A portal password is required before portal login can be enabled.';
+            if (!$portal_access_valid) {
+                $failureMsg = 'A portal password is required before portal access can be enabled.';
+                $logAction .= "Failed updating user because portal access requires a password on page: ";
             }
 
             $bi_contactperson = (array_key_exists('bi_contactperson', $_POST) && isset($_POST['bi_contactperson'])) ? $_POST['bi_contactperson'] : "";
@@ -192,7 +196,7 @@
 
 
 
-            if (!empty($username)) {
+            if (!empty($username) && $portal_access_valid) {
 
                 // dealing with attributes
                 include("library/attributes.php");
@@ -311,7 +315,7 @@
                 $successMsg = sprintf("Successfully updated user <strong>%s</strong>", $username_enc);
                 $logAction .= sprintf("Successfully updated user %s on page: ", $username);
 
-            } else { // if username != ""
+            } else if (empty($username)) { // if username != ""
                 $failureMsg = "You have specified an empty or invalid username";
                 $logAction .= "empty or invalid username on page: ";
             }

--- a/app/operators/mng-edit.php
+++ b/app/operators/mng-edit.php
@@ -141,11 +141,18 @@
             $ui_PortalLoginPassword = (isset($_POST['portalLoginPassword']) && !empty(trim($_POST['portalLoginPassword'])))
                                     ? trim($_POST['portalLoginPassword']) : "";
 
-            // these are forced to 0 (disabled) if user portal login password is empty
-            $ui_changeuserinfo = (!empty($ui_PortalLoginPassword) && isset($_POST['changeUserInfo']) && $_POST['changeUserInfo'] === '1')
+            $ui_hasPortalLoginPassword = user_portal_password_is_set($dbSocket, $username);
+            $portal_password_available = $ui_hasPortalLoginPassword || !empty($ui_PortalLoginPassword);
+
+            // Portal permissions require either an existing password or a newly supplied one.
+            $ui_changeuserinfo = ($portal_password_available && isset($_POST['changeUserInfo']) && $_POST['changeUserInfo'] === '1')
                                ? '1' : '0';
-            $ui_enableUserPortalLogin = (!empty($ui_PortalLoginPassword) &&  isset($_POST['enableUserPortalLogin']) && $_POST['enableUserPortalLogin'] === '1')
+            $ui_enableUserPortalLogin = ($portal_password_available && isset($_POST['enableUserPortalLogin']) && $_POST['enableUserPortalLogin'] === '1')
                                       ? '1' : '0';
+
+            if (!$portal_password_available && isset($_POST['enableUserPortalLogin']) && $_POST['enableUserPortalLogin'] === '1') {
+                $failureMsg = 'A portal password is required before portal login can be enabled.';
+            }
 
             $bi_contactperson = (array_key_exists('bi_contactperson', $_POST) && isset($_POST['bi_contactperson'])) ? $_POST['bi_contactperson'] : "";
             $bi_company = (array_key_exists('bi_company', $_POST) && isset($_POST['bi_company'])) ? $_POST['bi_company'] : "";
@@ -177,8 +184,7 @@
             $bi_faxinvoice = (array_key_exists('bi_faxinvoice', $_POST) && isset($_POST['bi_faxinvoice'])) ? $_POST['bi_faxinvoice'] : "";
             $bi_emailinvoice = (array_key_exists('bi_emailinvoice', $_POST) && isset($_POST['bi_emailinvoice'])) ? $_POST['bi_emailinvoice'] : "";
 
-            // this is forced to 0 (disabled) if user portal login password is empty
-            $bi_changeuserbillinfo = (!empty($ui_PortalLoginPassword) && isset($_POST['bi_changeuserbillinfo']) && $_POST['bi_changeuserbillinfo'] === '1')
+            $bi_changeuserbillinfo = ($portal_password_available && isset($_POST['bi_changeuserbillinfo']) && $_POST['bi_changeuserbillinfo'] === '1')
                                    ? '1' : '0';
 
             $planName = (array_key_exists('planName', $_POST) && isset($_POST['planName'])) ? trim($_POST['planName']) : "";
@@ -333,7 +339,9 @@
 
         /* fill-in all the user info details */
         $sql = sprintf("SELECT firstname, lastname, email, department, company, workphone, homephone, mobilephone, address, city,
-                               state, country, zip, notes, changeuserinfo, portalloginpassword, enableportallogin, creationdate,
+                               state, country, zip, notes, changeuserinfo,
+                               (portalloginpassword IS NOT NULL AND portalloginpassword<>'') AS has_portal_password,
+                               enableportallogin, creationdate,
                                creationby, updatedate, updateby
                           FROM %s WHERE username='%s'", $configValues['CONFIG_DB_TBL_DALOUSERINFO'],
                                                         $dbSocket->escapeSimple($username));
@@ -343,7 +351,7 @@
         list(
               $ui_firstname, $ui_lastname, $ui_email, $ui_department, $ui_company, $ui_workphone, $ui_homephone,
               $ui_mobilephone, $ui_address, $ui_city, $ui_state, $ui_country, $ui_zip, $ui_notes, $ui_changeuserinfo,
-              $ui_PortalLoginPassword, $ui_enableUserPortalLogin, $ui_creationdate, $ui_creationby, $ui_updatedate,
+              $ui_hasPortalLoginPassword, $ui_enableUserPortalLogin, $ui_creationdate, $ui_creationby, $ui_updatedate,
               $ui_updateby
             ) = $res->fetchRow();
 

--- a/app/operators/mng-import-users.php
+++ b/app/operators/mng-import-users.php
@@ -48,7 +48,6 @@
     $valid_groups = get_groups();
     $valid_planNames = get_plans();
 
-    $cleartextPasswordAllowed = dalo_cleartext_password_allowed();
     $valid_passwordTypes = dalo_filter_password_types($valid_passwordTypes);
 
     $generatepassword = 'no';
@@ -501,17 +500,15 @@
                                                          'The system will take care of correctly hashing it.',
                                     );
 
-        if ($cleartextPasswordAllowed) {
-            $input_descriptors1[] = array(
-                                            "type" =>"select",
-                                            "name" => "enableportallogin",
-                                            "caption" => "Enable Portal Login",
-                                            "options" => [ "yes", "no" ],
-                                            "selected_value" => ((isset($failureMsg)) ? $enableportallogin : "no"),
-                                            "tooltipText" => "If set to 'yes', " .
-                                                             "allows the use of username and password for logging into the user portal.",
-                                        );
-        }
+        $input_descriptors1[] = array(
+                                        "type" =>"select",
+                                        "name" => "enableportallogin",
+                                        "caption" => "Enable Portal Login",
+                                        "options" => [ "yes", "no" ],
+                                        "selected_value" => ((isset($failureMsg)) ? $enableportallogin : "no"),
+                                        "tooltipText" => "If set to 'yes', " .
+                                                         "stores a secure, separate hash for user portal login.",
+                                    );
 
         $input_descriptors1[] = array(
                                         "type" => "select",

--- a/app/operators/mng-new-quick.php
+++ b/app/operators/mng-new-quick.php
@@ -89,13 +89,16 @@
             $notes = (array_key_exists('notes', $_POST) && isset($_POST['notes'])) ? $_POST['notes'] : "";
 
             // first we check user portal login password
-            $ui_PortalLoginPassword = (isset($_POST['portalLoginPassword']) && !empty(trim($_POST['portalLoginPassword'])))
+            $ui_PortalLoginPassword = (isset($_POST['portalLoginPassword']) &&
+                                       dalo_portal_password_is_acceptable($_POST['portalLoginPassword']))
                                     ? trim($_POST['portalLoginPassword']) : "";
 
+            $portal_access_valid = dalo_portal_access_is_valid($_POST);
+
             // these are forced to 0 (disabled) if user portal login password is empty
-            $ui_changeuserinfo = (!empty($ui_PortalLoginPassword) && isset($_POST['changeUserInfo']) && $_POST['changeUserInfo'] === '1')
+            $ui_changeuserinfo = (dalo_portal_password_is_present($ui_PortalLoginPassword) && isset($_POST['changeUserInfo']) && $_POST['changeUserInfo'] === '1')
                                ? '1' : '0';
-            $ui_enableUserPortalLogin = (!empty($ui_PortalLoginPassword) && isset($_POST['enableUserPortalLogin']) && $_POST['enableUserPortalLogin'] === '1')
+            $ui_enableUserPortalLogin = (dalo_portal_password_is_present($ui_PortalLoginPassword) && isset($_POST['enableUserPortalLogin']) && $_POST['enableUserPortalLogin'] === '1')
                                       ? '1' : '0';
 
             // billing info variables
@@ -118,7 +121,7 @@
             $bi_notes = (array_key_exists('bi_notes', $_POST) && isset($_POST['bi_notes'])) ? $_POST['bi_notes'] : "";
 
             // this is forced to 0 (disabled) if user portal login password is empty
-            $bi_changeuserbillinfo = (!empty($ui_PortalLoginPassword) && isset($_POST['bi_changeuserbillinfo']) && $_POST['bi_changeuserbillinfo'] === '1')
+            $bi_changeuserbillinfo = (dalo_portal_password_is_present($ui_PortalLoginPassword) && isset($_POST['bi_changeuserbillinfo']) && $_POST['bi_changeuserbillinfo'] === '1')
                                    ? '1' : '0';
 
             include implode(DIRECTORY_SEPARATOR, [ $configValues['COMMON_INCLUDES'], 'db_open.php' ]);
@@ -134,7 +137,10 @@
                 // username, password and password type are required. an empty password type
                 // means the posted one is unknown or no longer permitted (e.g. a cleartext
                 // type submitted while CONFIG_DB_PASSWORD_ENCRYPTION is set to 'no')
-                if (empty($username) || empty($password) || empty($passwordType)) {
+                if (!$portal_access_valid) {
+                    $failureMsg = "A portal password is required before portal access can be enabled";
+                    $logAction .= "Failed adding user because portal access requires a password on page: ";
+                } else if (empty($username) || empty($password) || empty($passwordType)) {
                     $failureMsg = "username, password and/or password type are empty or invalid";
                     $logAction .= "Failed adding (possible empty user/pass or invalid password type) new user [$username] on page: ";
                 } else {

--- a/app/operators/mng-new.php
+++ b/app/operators/mng-new.php
@@ -84,13 +84,16 @@
             $notes = (isset($_POST['notes']) && !empty(trim($_POST['notes']))) ? trim($_POST['notes']) : "";
 
             // first we check user portal login password
-            $ui_PortalLoginPassword = (isset($_POST['portalLoginPassword']) && !empty(trim($_POST['portalLoginPassword'])))
+            $ui_PortalLoginPassword = (isset($_POST['portalLoginPassword']) &&
+                                       dalo_portal_password_is_acceptable($_POST['portalLoginPassword']))
                                     ? trim($_POST['portalLoginPassword']) : "";
 
+            $portal_access_valid = dalo_portal_access_is_valid($_POST);
+
             // these are forced to 0 (disabled) if user portal login password is empty
-            $ui_changeuserinfo = (!empty($ui_PortalLoginPassword) && isset($_POST['changeUserInfo']) && $_POST['changeUserInfo'] === '1')
+            $ui_changeuserinfo = (dalo_portal_password_is_present($ui_PortalLoginPassword) && isset($_POST['changeUserInfo']) && $_POST['changeUserInfo'] === '1')
                                ? '1' : '0';
-            $ui_enableUserPortalLogin = (!empty($ui_PortalLoginPassword) && isset($_POST['enableUserPortalLogin']) && $_POST['enableUserPortalLogin'] === '1')
+            $ui_enableUserPortalLogin = (dalo_portal_password_is_present($ui_PortalLoginPassword) && isset($_POST['enableUserPortalLogin']) && $_POST['enableUserPortalLogin'] === '1')
                                       ? '1' : '0';
 
             isset($_POST['dictAttributes']) ? $dictAttributes = $_POST['dictAttributes'] : $dictAttributes = "";
@@ -124,7 +127,7 @@
             $bi_notes = (array_key_exists('bi_notes', $_POST) && isset($_POST['bi_notes'])) ? $_POST['bi_notes'] : "";
 
             // this is forced to 0 (disabled) if user portal login password is empty
-            $bi_changeuserbillinfo = (!empty($ui_PortalLoginPassword) && isset($_POST['bi_changeuserbillinfo']) && $_POST['bi_changeuserbillinfo'] === '1')
+            $bi_changeuserbillinfo = (dalo_portal_password_is_present($ui_PortalLoginPassword) && isset($_POST['bi_changeuserbillinfo']) && $_POST['bi_changeuserbillinfo'] === '1')
                                    ? '1' : '0';
 
             $bi_nextinvoicedue = (array_key_exists('bi_nextinvoicedue', $_POST) && isset($_POST['bi_nextinvoicedue'])) ? $_POST['bi_nextinvoicedue'] : "";
@@ -161,6 +164,11 @@
             } else {
                 // authentication method is invalid
                 $failureMsg = "Unknown authentication method";
+            }
+
+            if (!$portal_access_valid) {
+                $failureMsg = "A portal password is required before portal access can be enabled";
+                $username_to_check = "";
             }
 
             if (empty($username_to_check)) {

--- a/app/users/dologin.php
+++ b/app/users/dologin.php
@@ -37,7 +37,7 @@ $authenticated = false;
 // we interact with the db, ONLY IF user provided both operator_user and operator_pass params
 if (array_key_exists('csrf_token', $_POST) && isset($_POST['csrf_token']) && dalo_check_csrf_token($_POST['csrf_token']) &&
     array_key_exists('login_user', $_POST) && !empty($_POST['login_user']) &&
-    array_key_exists('login_pass', $_POST) && !empty($_POST['login_pass']) &&
+    array_key_exists('login_pass', $_POST) && is_string($_POST['login_pass']) && $_POST['login_pass'] !== '' &&
     array_key_exists('language', $_POST) && !empty(trim($_POST['language']))) {
 
     $language = strtolower(trim($_POST['language']));
@@ -83,9 +83,16 @@ if (array_key_exists('csrf_token', $_POST) && isset($_POST['csrf_token']) && dal
                         "UPDATE %s SET portalloginpassword=? WHERE id=? AND portalloginpassword=?",
                         $configValues['CONFIG_DB_TBL_DALOUSERINFO']
                     );
-                    $stmt = $dbSocket->prepare($sql);
-                    $dbSocket->execute($stmt, array($new_hash, intval($row['id']), $stored_password));
-                    $dbSocket->freePrepared($stmt);
+                    dalo_portal_db_sensitive_call(
+                        $dbSocket,
+                        function() use ($dbSocket, $sql, $new_hash, $row, $stored_password) {
+                            $stmt = $dbSocket->prepare($sql);
+                            $res = $dbSocket->execute($stmt, array($new_hash, intval($row['id']), $stored_password));
+                            $dbSocket->freePrepared($stmt);
+                            return $res;
+                        },
+                        $error_handler
+                    );
                 }
             }
         }

--- a/app/users/dologin.php
+++ b/app/users/dologin.php
@@ -26,11 +26,13 @@
 
 include('library/sessions.php');
 include_once('../common/includes/config_read.php');
+include_once('../common/includes/portal_password.php');
 include_once('lang/main.php');
 
 dalo_session_start();
 
 $errorMessage = '';
+$authenticated = false;
 
 // we interact with the db, ONLY IF user provided both operator_user and operator_pass params
 if (array_key_exists('csrf_token', $_POST) && isset($_POST['csrf_token']) && dalo_check_csrf_token($_POST['csrf_token']) &&
@@ -53,24 +55,40 @@ if (array_key_exists('csrf_token', $_POST) && isset($_POST['csrf_token']) && dal
 
     include('../common/includes/db_open.php');
 
-    $sql_WHERE = array();
-    $sql_WHERE[] = "enableportallogin=1";
-    $sql_WHERE[] = "portalloginpassword<>''";
-    $sql_WHERE[] = "portalloginpassword IS NOT NULL";
-    $sql_WHERE[] = sprintf("portalloginpassword='%s'", $dbSocket->escapeSimple($login_pass));
-    $sql_WHERE[] = sprintf("username='%s'", $dbSocket->escapeSimple($login_user));
+    $sql = sprintf(
+        "SELECT id, portalloginpassword FROM %s WHERE username=? AND enableportallogin=1 AND portalloginpassword IS NOT NULL AND portalloginpassword<>''",
+        $configValues['CONFIG_DB_TBL_DALOUSERINFO']
+    );
+    $stmt = $dbSocket->prepare($sql);
+    $res = $dbSocket->execute($stmt, array($login_user));
+    $dbSocket->freePrepared($stmt);
 
-    $sql = sprintf("SELECT COUNT(id) FROM %s WHERE ", $configValues['CONFIG_DB_TBL_DALOUSERINFO'])
-         . implode(" AND ", $sql_WHERE);
+    // We only accept one and only one user information record.
+    if (!DB::isError($res) && $res->numRows() === 1) {
+        $row = $res->fetchRow(DB_FETCHMODE_ASSOC);
+        $res->free();
+        $stored_password = $row['portalloginpassword'];
+        $verification = dalo_portal_password_verify($login_pass, $stored_password);
 
-    $res = $dbSocket->query($sql);
-    $numrows = intval($res->fetchrow()[0]);
+        if ($verification['verified']) {
+            $authenticated = true;
+            session_regenerate_id(true);
+            $_SESSION['logged_in'] = true;
+            $_SESSION['login_user'] = $login_user;
 
-    // we only accept ONE AND ONLY ONE RECORD as result
-    if ($numrows === 1) {
-        session_regenerate_id(true);
-        $_SESSION['logged_in'] = true;
-        $_SESSION['login_user'] = $login_user;
+            if ($verification['needs_rehash']) {
+                $new_hash = dalo_portal_password_hash($login_pass);
+                if ($new_hash !== false) {
+                    $sql = sprintf(
+                        "UPDATE %s SET portalloginpassword=? WHERE id=? AND portalloginpassword=?",
+                        $configValues['CONFIG_DB_TBL_DALOUSERINFO']
+                    );
+                    $stmt = $dbSocket->prepare($sql);
+                    $dbSocket->execute($stmt, array($new_hash, intval($row['id']), $stored_password));
+                    $dbSocket->freePrepared($stmt);
+                }
+            }
+        }
     }
 
     include('../common/includes/db_close.php');
@@ -81,8 +99,10 @@ if (array_key_exists('csrf_token', $_POST) && isset($_POST['csrf_token']) && dal
 // so we can check it for deciding where and how redirect user browser
 $header_location = "index.php";
 
-if (isset($_SESSION['logged_in']) && $_SESSION['logged_in'] !== true) {
+if (!$authenticated) {
     $header_location = "login.php";
+    $_SESSION['logged_in'] = false;
+    unset($_SESSION['login_user']);
     $_SESSION['login_error'] = true;
 }
 

--- a/app/users/pref-portal-password-edit.php
+++ b/app/users/pref-portal-password-edit.php
@@ -40,9 +40,11 @@
         if (array_key_exists('csrf_token', $_POST) && isset($_POST['csrf_token']) && dalo_check_csrf_token($_POST['csrf_token'])) {
             include('../common/includes/db_open.php');
 
-            $current_password = (isset($_POST['current_password']) && !empty(trim($_POST['current_password']))) ? trim($_POST['current_password']) : "";
+            $current_password = (isset($_POST['current_password']) &&
+                                 dalo_portal_password_is_acceptable($_POST['current_password']))
+                              ? trim($_POST['current_password']) : "";
 
-            if (empty($current_password)) {
+            if ($current_password === '') {
                 $numrows = 0;
             } else {
                 // Fetch by username, then verify the stored hash in PHP.
@@ -60,14 +62,18 @@
 
             if ($numrows === 1 && $verification['verified']) {
 
-                $new_password1 = (isset($_POST['new_password1']) && !empty(trim($_POST['new_password1']))) ? trim($_POST['new_password1']) : "";
-                $new_password2 = (isset($_POST['new_password2']) && !empty(trim($_POST['new_password2']))) ? trim($_POST['new_password2']) : "";
+                $new_password1 = (isset($_POST['new_password1']) &&
+                                  dalo_portal_password_is_acceptable($_POST['new_password1']))
+                               ? trim($_POST['new_password1']) : "";
+                $new_password2 = (isset($_POST['new_password2']) &&
+                                  dalo_portal_password_is_acceptable($_POST['new_password2']))
+                               ? trim($_POST['new_password2']) : "";
 
                 $error = false;
-                if (empty($new_password1)) {
+                if ($new_password1 === '') {
                     $error = true;
                     $failureMsg = "The new password you provided is empty or invalid";
-                } else if (empty($new_password2)) {
+                } else if ($new_password2 === '') {
                     $error = true;
                     $failureMsg = "The new password (confirmation) you provided is empty or invalid";
                 } else if ($new_password1 !== $new_password2) {
@@ -79,11 +85,21 @@
                     $new_hash = dalo_portal_password_hash($new_password1);
                     $sql = sprintf("UPDATE %s SET portalloginpassword=? WHERE id=? AND portalloginpassword=?",
                                    $configValues['CONFIG_DB_TBL_DALOUSERINFO']);
-                    $stmt = $dbSocket->prepare($sql);
                     $res = ($new_hash !== false)
-                         ? $dbSocket->execute($stmt, array($new_hash, intval($row['id']), $row['portalloginpassword']))
+                         ? dalo_portal_db_sensitive_call(
+                               $dbSocket,
+                               function() use ($dbSocket, $sql, $new_hash, $row) {
+                                   $stmt = $dbSocket->prepare($sql);
+                                   $res = $dbSocket->execute(
+                                       $stmt,
+                                       array($new_hash, intval($row['id']), $row['portalloginpassword'])
+                                   );
+                                   $dbSocket->freePrepared($stmt);
+                                   return $res;
+                               },
+                               $error_handler
+                           )
                          : DB::raiseError('Unable to hash portal password');
-                    $dbSocket->freePrepared($stmt);
 
                     if (!DB::isError($res) && $dbSocket->affectedRows() === 1) {
                         // success

--- a/app/users/pref-portal-password-edit.php
+++ b/app/users/pref-portal-password-edit.php
@@ -25,6 +25,7 @@
     $login_user = $_SESSION['login_user'];
 
     include_once('../common/includes/config_read.php');
+    include_once('../common/includes/portal_password.php');
 
     include_once("lang/main.php");
     include_once("../common/includes/validation.php");
@@ -44,17 +45,20 @@
             if (empty($current_password)) {
                 $numrows = 0;
             } else {
-                // check if current password is valid
-                $sql = sprintf("SELECT COUNT(id) FROM %s WHERE username='%s' AND portalloginpassword='%s'",
-                               $configValues['CONFIG_DB_TBL_DALOUSERINFO'], $dbSocket->escapeSimple($login_user),
-                               $dbSocket->escapeSimple($current_password));
-
-                $res = $dbSocket->query($sql);
-                $logDebugSQL .= "$sql;\n";
-                $numrows = intval($res->fetchRow()[0]);
+                // Fetch by username, then verify the stored hash in PHP.
+                $sql = sprintf("SELECT id, portalloginpassword FROM %s WHERE username=?",
+                               $configValues['CONFIG_DB_TBL_DALOUSERINFO']);
+                $stmt = $dbSocket->prepare($sql);
+                $res = $dbSocket->execute($stmt, array($login_user));
+                $dbSocket->freePrepared($stmt);
+                $numrows = (!DB::isError($res)) ? $res->numRows() : 0;
+                $row = ($numrows === 1) ? $res->fetchRow(DB_FETCHMODE_ASSOC) : null;
+                $verification = is_array($row)
+                              ? dalo_portal_password_verify($current_password, $row['portalloginpassword'])
+                              : array('verified' => false);
             }
 
-            if ($numrows === 1) {
+            if ($numrows === 1 && $verification['verified']) {
 
                 $new_password1 = (isset($_POST['new_password1']) && !empty(trim($_POST['new_password1']))) ? trim($_POST['new_password1']) : "";
                 $new_password2 = (isset($_POST['new_password2']) && !empty(trim($_POST['new_password2']))) ? trim($_POST['new_password2']) : "";
@@ -72,13 +76,16 @@
                 }
 
                 if (!$error) {
-                    $sql = sprintf("UPDATE %s SET portalloginpassword='%s' WHERE username='%s'",
-                                   $configValues['CONFIG_DB_TBL_DALOUSERINFO'], $dbSocket->escapeSimple($new_password1),
-                                   $dbSocket->escapeSimple($login_user));
-                    $res = $dbSocket->query($sql);
-                    $logDebugSQL .= "$sql;\n";
+                    $new_hash = dalo_portal_password_hash($new_password1);
+                    $sql = sprintf("UPDATE %s SET portalloginpassword=? WHERE id=? AND portalloginpassword=?",
+                                   $configValues['CONFIG_DB_TBL_DALOUSERINFO']);
+                    $stmt = $dbSocket->prepare($sql);
+                    $res = ($new_hash !== false)
+                         ? $dbSocket->execute($stmt, array($new_hash, intval($row['id']), $row['portalloginpassword']))
+                         : DB::raiseError('Unable to hash portal password');
+                    $dbSocket->freePrepared($stmt);
 
-                    if (!DB::isError($res)) {
+                    if (!DB::isError($res) && $dbSocket->affectedRows() === 1) {
                         // success
                         $successMsg = "The password for logging into the user portal has been changed";
                         $logAction = "User $login_user has changed their password for logging into the user portal";

--- a/contrib/db/mariadb-daloradius.sql
+++ b/contrib/db/mariadb-daloradius.sql
@@ -888,7 +888,7 @@ CREATE TABLE `userinfo` (
   `zip` VARCHAR(200) DEFAULT NULL,
   `notes` VARCHAR(200) DEFAULT NULL,
   `changeuserinfo` VARCHAR(128) DEFAULT NULL,
-  `portalloginpassword` VARCHAR(128) DEFAULT '',
+  `portalloginpassword` VARCHAR(255) DEFAULT '',
   `enableportallogin` INT(32) DEFAULT '0',
   `creationdate` DATETIME DEFAULT '0000-00-00 00:00:00',
   `creationby` VARCHAR(128) DEFAULT NULL,

--- a/contrib/db/migrations/2026-09-user-portal-password-hashing.sql
+++ b/contrib/db/migrations/2026-09-user-portal-password-hashing.sql
@@ -1,0 +1,13 @@
+--
+-- daloRADIUS user portal password hashing migration
+--
+-- Fresh installations already use this column size in
+-- contrib/db/mariadb-daloradius.sql.
+--
+-- This migration only widens the column. Use the application login path or
+-- contrib/scripts/maintenance/hash-user-portal-passwords.php to replace
+-- existing plaintext values with password_hash() digests.
+--
+
+ALTER TABLE userinfo
+  MODIFY COLUMN IF EXISTS portalloginpassword VARCHAR(255) DEFAULT '';

--- a/contrib/db/migrations/2026-09-user-portal-password-hashing.sql
+++ b/contrib/db/migrations/2026-09-user-portal-password-hashing.sql
@@ -6,7 +6,7 @@
 --
 -- This migration only widens the column. Use the application login path or
 -- contrib/scripts/maintenance/hash-user-portal-passwords.php to replace
--- existing plaintext values with password_hash() digests.
+-- existing plaintext values with version-marked password_hash() digests.
 --
 
 ALTER TABLE userinfo

--- a/contrib/scripts/maintenance/hash-user-portal-passwords.php
+++ b/contrib/scripts/maintenance/hash-user-portal-passwords.php
@@ -30,6 +30,10 @@ include_once $root . '/app/common/includes/config_read.php';
 include_once $root . '/app/common/includes/portal_password.php';
 include $root . '/app/common/includes/db_open.php';
 
+// PEAR DB interpolates prepared parameters in error debug information. Never
+// invoke the application's verbose callback while credentials are in a query.
+$dbSocket->setErrorHandling(PEAR_ERROR_RETURN);
+
 $table = $configValues['CONFIG_DB_TBL_DALOUSERINFO'];
 $last_id = 0;
 $counts = array(

--- a/contrib/scripts/maintenance/hash-user-portal-passwords.php
+++ b/contrib/scripts/maintenance/hash-user-portal-passwords.php
@@ -1,0 +1,131 @@
+<?php
+/*
+ * Hash legacy plaintext user portal passwords.
+ *
+ * Usage:
+ *   php hash-user-portal-passwords.php --dry-run
+ *   php hash-user-portal-passwords.php
+ */
+
+if (PHP_SAPI !== 'cli') {
+    http_response_code(404);
+    exit(1);
+}
+
+$options = getopt('', array('dry-run', 'batch-size::', 'help'));
+if (isset($options['help'])) {
+    fwrite(STDOUT, "Usage: php hash-user-portal-passwords.php [--dry-run] [--batch-size=N]\n");
+    exit(0);
+}
+
+$dry_run = isset($options['dry-run']);
+$batch_size = isset($options['batch-size']) ? intval($options['batch-size']) : 100;
+if ($batch_size < 1 || $batch_size > 1000) {
+    fwrite(STDERR, "batch-size must be between 1 and 1000\n");
+    exit(2);
+}
+
+$root = dirname(__DIR__, 3);
+include_once $root . '/app/common/includes/config_read.php';
+include_once $root . '/app/common/includes/portal_password.php';
+include $root . '/app/common/includes/db_open.php';
+
+$table = $configValues['CONFIG_DB_TBL_DALOUSERINFO'];
+$last_id = 0;
+$counts = array(
+    'scanned' => 0,
+    'empty' => 0,
+    'already_hashed' => 0,
+    'migrated' => 0,
+    'conflicted' => 0,
+    'failed' => 0,
+);
+
+while (true) {
+    $sql = sprintf(
+        "SELECT id, portalloginpassword FROM %s WHERE id > ? ORDER BY id ASC LIMIT %d",
+        $table,
+        $batch_size
+    );
+    $stmt = $dbSocket->prepare($sql);
+    $res = $dbSocket->execute($stmt, array($last_id));
+    $dbSocket->freePrepared($stmt);
+
+    if (DB::isError($res)) {
+        $counts['failed']++;
+        break;
+    }
+
+    $rows = array();
+    while ($row = $res->fetchRow(DB_FETCHMODE_ASSOC)) {
+        $rows[] = $row;
+    }
+    $res->free();
+
+    if (count($rows) === 0) {
+        break;
+    }
+
+    foreach ($rows as $row) {
+        $id = intval($row['id']);
+        $stored_password = (string) $row['portalloginpassword'];
+        $last_id = $id;
+        $counts['scanned']++;
+
+        if ($stored_password === '') {
+            $counts['empty']++;
+            continue;
+        }
+
+        if (dalo_portal_password_is_hash($stored_password)) {
+            $counts['already_hashed']++;
+            continue;
+        }
+
+        if ($dry_run) {
+            $counts['migrated']++;
+            continue;
+        }
+
+        $hash = dalo_portal_password_hash($stored_password);
+        if ($hash === false) {
+            $counts['failed']++;
+            continue;
+        }
+
+        $sql = sprintf(
+            "UPDATE %s SET portalloginpassword=? WHERE id=? AND portalloginpassword=?",
+            $table
+        );
+        $stmt = $dbSocket->prepare($sql);
+        $update = $dbSocket->execute($stmt, array($hash, $id, $stored_password));
+        $dbSocket->freePrepared($stmt);
+
+        if (DB::isError($update)) {
+            $counts['failed']++;
+            continue;
+        }
+
+        if ($dbSocket->affectedRows() === 1) {
+            $counts['migrated']++;
+        } else {
+            $counts['conflicted']++;
+        }
+    }
+}
+
+include $root . '/app/common/includes/db_close.php';
+
+fwrite(STDOUT, sprintf(
+    "%s: scanned=%d empty=%d already_hashed=%d %s=%d conflicted=%d failed=%d\n",
+    $dry_run ? 'DRY RUN' : 'COMPLETE',
+    $counts['scanned'],
+    $counts['empty'],
+    $counts['already_hashed'],
+    $dry_run ? 'would_migrate' : 'migrated',
+    $counts['migrated'],
+    $counts['conflicted'],
+    $counts['failed']
+));
+
+exit($counts['failed'] === 0 ? 0 : 1);

--- a/doc/setup/user-portal-passwords.md
+++ b/doc/setup/user-portal-passwords.md
@@ -2,7 +2,9 @@
 
 User portal credentials are independent from FreeRADIUS authentication credentials. The **Allow cleartext password attributes in db** setting only controls whether cleartext RADIUS attributes such as `Cleartext-Password` may be stored in `radcheck`; it does not control the user portal password.
 
-The user portal password is always stored as a one-way hash produced by PHP's `password_hash()` with `PASSWORD_DEFAULT` and is verified with `password_verify()`. Operators can replace a portal password, but the stored value is never displayed or pre-filled.
+The user portal password is always stored as a one-way hash produced by PHP's `password_hash()` with `PASSWORD_DEFAULT` and is verified with `password_verify()`. Stored values carry the application marker `$dalo$portal$v1$`, which distinguishes them from legacy plaintext and identifies the verification format independently of PHP's algorithm marker. Operators can replace a portal password, but the stored value is never displayed or pre-filled.
+
+The `$dalo$portal$v1$` namespace is reserved for daloRADIUS-generated values. Before enabling this feature on an existing database, administrators should check for legacy plaintext values that already begin with this marker; a marker followed by a syntactically valid PHP password hash is treated as a stored hash.
 
 ## Upgrading an existing installation
 
@@ -35,7 +37,7 @@ Then convert them:
 php contrib/scripts/maintenance/hash-user-portal-passwords.php
 ```
 
-The command processes records in bounded batches, skips empty and already-hashed values, and does not print usernames, passwords, or hashes. It is safe to run again. Use `--batch-size=N` to select a batch size between 1 and 1000.
+The command processes records in bounded batches, skips empty and already-marked values, and does not print usernames, passwords, hashes, or database debug queries containing them. It is safe to run again. Unmarked values, including strings that happen to look like PHP password hashes, are treated as legacy plaintext. Use `--batch-size=N` to select a batch size between 1 and 1000.
 
 Legacy plaintext values also migrate automatically after the next successful portal login. New or changed portal passwords are always hashed.
 

--- a/doc/setup/user-portal-passwords.md
+++ b/doc/setup/user-portal-passwords.md
@@ -1,0 +1,53 @@
+# User portal password storage and upgrade
+
+User portal credentials are independent from FreeRADIUS authentication credentials. The **Allow cleartext password attributes in db** setting only controls whether cleartext RADIUS attributes such as `Cleartext-Password` may be stored in `radcheck`; it does not control the user portal password.
+
+The user portal password is always stored as a one-way hash produced by PHP's `password_hash()` with `PASSWORD_DEFAULT` and is verified with `password_verify()`. Operators can replace a portal password, but the stored value is never displayed or pre-filled.
+
+## Upgrading an existing installation
+
+Back up the database before upgrading. Apply the schema migration before deploying the updated application:
+
+```sh
+mariadb -u raduser -p raddb \
+  < contrib/db/migrations/2026-09-user-portal-password-hashing.sql
+```
+
+For Docker Compose, run from the directory containing `docker-compose.yml`:
+
+```sh
+docker compose exec -T radius-mysql sh -lc \
+  'mariadb -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE"' \
+  < contrib/db/migrations/2026-09-user-portal-password-hashing.sql
+```
+
+The migration widens `userinfo.portalloginpassword` to `VARCHAR(255)`. It is idempotent and does not transform existing values.
+
+After deploying the updated application, inspect how many legacy values remain:
+
+```sh
+php contrib/scripts/maintenance/hash-user-portal-passwords.php --dry-run
+```
+
+Then convert them:
+
+```sh
+php contrib/scripts/maintenance/hash-user-portal-passwords.php
+```
+
+The command processes records in bounded batches, skips empty and already-hashed values, and does not print usernames, passwords, or hashes. It is safe to run again. Use `--batch-size=N` to select a batch size between 1 and 1000.
+
+Legacy plaintext values also migrate automatically after the next successful portal login. New or changed portal passwords are always hashed.
+
+## Operator behavior
+
+On an existing user's edit page, the portal password field is intentionally empty:
+
+- leave it empty to preserve the current credential;
+- enter a value to replace the credential with a new hash;
+- disabling portal login does not reveal or delete the existing hash;
+- portal login cannot be enabled until a credential exists.
+
+## Rollback
+
+The schema widening is backward compatible, but older daloRADIUS versions compare portal passwords directly in SQL and cannot authenticate records that have already been hashed. After converting values, rolling back the application requires restoring the pre-upgrade database backup or resetting affected portal passwords.

--- a/tests/portal-password-storage.test.php
+++ b/tests/portal-password-storage.test.php
@@ -20,6 +20,7 @@ function check($label, $condition) {
 $login = file_get_contents($root . '/app/users/dologin.php');
 $change = file_get_contents($root . '/app/users/pref-portal-password-edit.php');
 $form = file_get_contents($root . '/app/operators/include/management/userinfo.php');
+$layout = file_get_contents($root . '/app/common/includes/layout.php');
 $functions = file_get_contents($root . '/app/operators/include/management/functions.php');
 $import = file_get_contents($root . '/app/operators/mng-import-users.php');
 $config = file_get_contents($root . '/app/operators/config-user.php');
@@ -53,6 +54,11 @@ check('operator form uses an empty password input',
       strpos($form, "'type' => 'password'") !== false
       && strpos($form, "'value' => ''") !== false
       && strpos($form, '$ui_PortalLoginPassword') === false);
+check('portal password has separate browser length constraints',
+      strpos($form, "'minlength' => 1") !== false
+      && strpos($form, "'maxlength' => null") !== false
+      && substr_count($layout, "array_key_exists('minlength', \$input_descriptor)") >= 2
+      && substr_count($layout, "array_key_exists('maxlength', \$input_descriptor)") >= 2);
 check('common create and update paths hash portal passwords',
       substr_count($functions, 'dalo_portal_password_hash') >= 2);
 check('common create and update paths redact password logs',
@@ -80,6 +86,38 @@ check('self-service validates NUL before trimming password fields',
       substr_count($change, 'dalo_portal_password_is_acceptable') >= 3);
 check('fresh schema reserves 255 characters for password hashes',
       strpos($schema, '`portalloginpassword` VARCHAR(255)') !== false);
+
+$_SERVER['PHP_SELF'] = '/cli/tests';
+require_once $root . '/app/common/includes/layout.php';
+$configValues['CONFIG_DB_PASSWORD_MIN_LENGTH'] = 8;
+$configValues['CONFIG_DB_PASSWORD_MAX_LENGTH'] = 14;
+
+ob_start();
+print_input_field(array('name' => 'radiusPassword', 'type' => 'password'));
+$default_password_html = ob_get_clean();
+check('ordinary password fields retain the configured database bounds',
+      strpos($default_password_html, ' minlength="8"') !== false
+      && strpos($default_password_html, ' maxlength="14"') !== false);
+
+$portal_descriptor = array(
+    'name' => 'portalLoginPassword',
+    'type' => 'password',
+    'minlength' => 1,
+    'maxlength' => null,
+);
+ob_start();
+print_input_field($portal_descriptor);
+$portal_password_html = ob_get_clean();
+check('portal password renderer accepts zero and omits the RADIUS maximum',
+      strpos($portal_password_html, ' minlength="1"') !== false
+      && strpos($portal_password_html, ' maxlength=') === false);
+
+ob_start();
+menu_print_input_field($portal_descriptor);
+$menu_portal_password_html = ob_get_clean();
+check('menu password renderer applies the same portal override',
+      strpos($menu_portal_password_html, ' minlength="1"') !== false
+      && strpos($menu_portal_password_html, ' maxlength=') === false);
 
 printf("\n%s\n", $failures === 0 ? 'ALL PASSED' : sprintf('%d FAILURE(S)', $failures));
 exit($failures === 0 ? 0 : 1);

--- a/tests/portal-password-storage.test.php
+++ b/tests/portal-password-storage.test.php
@@ -23,7 +23,16 @@ $form = file_get_contents($root . '/app/operators/include/management/userinfo.ph
 $functions = file_get_contents($root . '/app/operators/include/management/functions.php');
 $import = file_get_contents($root . '/app/operators/mng-import-users.php');
 $config = file_get_contents($root . '/app/operators/config-user.php');
+$migration = file_get_contents($root . '/contrib/scripts/maintenance/hash-user-portal-passwords.php');
 $schema = file_get_contents($root . '/contrib/db/mariadb-daloradius.sql');
+$operator_flows = array(
+    'mng-new' => file_get_contents($root . '/app/operators/mng-new.php'),
+    'mng-new-quick' => file_get_contents($root . '/app/operators/mng-new-quick.php'),
+    'mng-batch-add' => file_get_contents($root . '/app/operators/mng-batch-add.php'),
+    'bill-pos-new' => file_get_contents($root . '/app/operators/bill-pos-new.php'),
+    'mng-edit' => file_get_contents($root . '/app/operators/mng-edit.php'),
+    'bill-pos-edit' => file_get_contents($root . '/app/operators/bill-pos-edit.php'),
+);
 
 check('login verifies outside SQL',
       strpos($login, 'dalo_portal_password_verify') !== false
@@ -34,6 +43,9 @@ check('failed login cannot reuse an authenticated session',
       strpos($login, '$authenticated = false') !== false
       && strpos($login, 'if (!$authenticated)') !== false
       && strpos($login, "unset(\$_SESSION['login_user'])") !== false);
+check('password zero is not rejected by login empty semantics',
+      strpos($login, "\$_POST['login_pass'] !== ''") !== false
+      && strpos($login, "!empty(\$_POST['login_pass'])") === false);
 check('password change hashes before storage',
       strpos($change, 'dalo_portal_password_hash') !== false
       && strpos($change, "SET portalloginpassword='%s'") === false);
@@ -45,6 +57,11 @@ check('common create and update paths hash portal passwords',
       substr_count($functions, 'dalo_portal_password_hash') >= 2);
 check('common create and update paths redact password logs',
       substr_count($functions, '[portal password redacted]') >= 2);
+check('all sensitive password writes disable verbose PEAR DB errors',
+      strpos($login, 'dalo_portal_db_sensitive_call') !== false
+      && strpos($change, 'dalo_portal_db_sensitive_call') !== false
+      && substr_count($functions, 'dalo_portal_db_sensitive_call') >= 2
+      && strpos($migration, 'setErrorHandling(PEAR_ERROR_RETURN)') !== false);
 check('empty edit preserves the existing portal credential',
       strpos($functions, 'unset($params[\'portalloginpassword\'])') !== false);
 check('CSV portal login is independent from cleartext RADIUS setting',
@@ -52,6 +69,15 @@ check('CSV portal login is independent from cleartext RADIUS setting',
       && strpos($import, 'stores a secure, separate hash') !== false);
 check('RADIUS cleartext setting explains the portal-password boundary',
       strpos($config, 'only controls RADIUS password attributes in radcheck') !== false);
+
+foreach ($operator_flows as $name => $flow) {
+    check("$name rejects missing credentials before writes",
+          strpos($flow, 'dalo_portal_access_is_valid') !== false
+          && strpos($flow, '!$portal_access_valid') !== false
+          && strpos($flow, 'dalo_portal_password_is_acceptable') !== false);
+}
+check('self-service validates NUL before trimming password fields',
+      substr_count($change, 'dalo_portal_password_is_acceptable') >= 3);
 check('fresh schema reserves 255 characters for password hashes',
       strpos($schema, '`portalloginpassword` VARCHAR(255)') !== false);
 

--- a/tests/portal-password-storage.test.php
+++ b/tests/portal-password-storage.test.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ * Static regression checks for portal password storage call sites.
+ *
+ * Run with: php tests/portal-password-storage.test.php
+ */
+
+$root = dirname(__DIR__);
+$failures = 0;
+function check($label, $condition) {
+    global $failures;
+    if ($condition) {
+        printf("ok   - %s\n", $label);
+    } else {
+        printf("FAIL - %s\n", $label);
+        $failures++;
+    }
+}
+
+$login = file_get_contents($root . '/app/users/dologin.php');
+$change = file_get_contents($root . '/app/users/pref-portal-password-edit.php');
+$form = file_get_contents($root . '/app/operators/include/management/userinfo.php');
+$functions = file_get_contents($root . '/app/operators/include/management/functions.php');
+$import = file_get_contents($root . '/app/operators/mng-import-users.php');
+$config = file_get_contents($root . '/app/operators/config-user.php');
+$schema = file_get_contents($root . '/contrib/db/mariadb-daloradius.sql');
+
+check('login verifies outside SQL',
+      strpos($login, 'dalo_portal_password_verify') !== false
+      && strpos($login, "portalloginpassword='%s'") === false);
+check('login performs conditional lazy migration',
+      strpos($login, 'WHERE id=? AND portalloginpassword=?') !== false);
+check('failed login cannot reuse an authenticated session',
+      strpos($login, '$authenticated = false') !== false
+      && strpos($login, 'if (!$authenticated)') !== false
+      && strpos($login, "unset(\$_SESSION['login_user'])") !== false);
+check('password change hashes before storage',
+      strpos($change, 'dalo_portal_password_hash') !== false
+      && strpos($change, "SET portalloginpassword='%s'") === false);
+check('operator form uses an empty password input',
+      strpos($form, "'type' => 'password'") !== false
+      && strpos($form, "'value' => ''") !== false
+      && strpos($form, '$ui_PortalLoginPassword') === false);
+check('common create and update paths hash portal passwords',
+      substr_count($functions, 'dalo_portal_password_hash') >= 2);
+check('common create and update paths redact password logs',
+      substr_count($functions, '[portal password redacted]') >= 2);
+check('empty edit preserves the existing portal credential',
+      strpos($functions, 'unset($params[\'portalloginpassword\'])') !== false);
+check('CSV portal login is independent from cleartext RADIUS setting',
+      strpos($import, 'if ($cleartextPasswordAllowed)') === false
+      && strpos($import, 'stores a secure, separate hash') !== false);
+check('RADIUS cleartext setting explains the portal-password boundary',
+      strpos($config, 'only controls RADIUS password attributes in radcheck') !== false);
+check('fresh schema reserves 255 characters for password hashes',
+      strpos($schema, '`portalloginpassword` VARCHAR(255)') !== false);
+
+printf("\n%s\n", $failures === 0 ? 'ALL PASSED' : sprintf('%d FAILURE(S)', $failures));
+exit($failures === 0 ? 0 : 1);

--- a/tests/portal-password.test.php
+++ b/tests/portal-password.test.php
@@ -24,9 +24,10 @@ $password = 'portal-secret-753';
 $hash1 = dalo_portal_password_hash($password);
 $hash2 = dalo_portal_password_hash($password);
 
-check('hash returns a string', is_string($hash1) && $hash1 !== '');
+check('hash returns a versioned string',
+      is_string($hash1) && substr($hash1, 0, strlen(dalo_portal_password_prefix())) === dalo_portal_password_prefix());
 check('random salts produce different hashes', is_string($hash2) && $hash1 !== $hash2);
-check('hash is recognized', dalo_portal_password_is_hash($hash1));
+check('versioned hash is recognized', dalo_portal_password_is_hash($hash1));
 check('plaintext is not recognized as a hash', !dalo_portal_password_is_hash($password));
 
 $verified = dalo_portal_password_verify($password, $hash1);
@@ -36,7 +37,8 @@ check('current hash does not need rehashing', $verified['needs_rehash'] === fals
 check('wrong hashed password is rejected',
       dalo_portal_password_verify('wrong', $hash1)['verified'] === false);
 
-$old_parameters_hash = password_hash($password, PASSWORD_BCRYPT, array('cost' => 4));
+$old_parameters_hash = dalo_portal_password_prefix()
+                     . password_hash($password, PASSWORD_BCRYPT, array('cost' => 4));
 check('old hash parameters are detected',
       dalo_portal_password_verify($password, $old_parameters_hash)['needs_rehash'] === true);
 
@@ -46,9 +48,95 @@ check('legacy plaintext is marked for migration',
       $legacy['legacy'] === true && $legacy['needs_rehash'] === true);
 check('wrong legacy plaintext is rejected',
       dalo_portal_password_verify('wrong', $password)['verified'] === false);
+
+$hash_shaped_legacy = password_hash('unrelated-value', PASSWORD_BCRYPT);
+$hash_shaped_result = dalo_portal_password_verify($hash_shaped_legacy, $hash_shaped_legacy);
+check('unmarked hash-shaped plaintext remains a legacy credential',
+      $hash_shaped_result['verified'] === true
+      && $hash_shaped_result['legacy'] === true
+      && !dalo_portal_password_is_hash($hash_shaped_legacy));
+
+$zero_hash = dalo_portal_password_hash('0');
+check('password zero is accepted and verifies',
+      is_string($zero_hash) && dalo_portal_password_verify('0', $zero_hash)['verified'] === true);
+check('NUL password is rejected without an exception', dalo_portal_password_hash("a\0b") === false);
+check('leading and trailing NUL passwords are rejected before trimming',
+      dalo_portal_password_hash("\0ab") === false
+      && dalo_portal_password_hash("ab\0") === false
+      && !dalo_portal_password_is_acceptable("\0ab")
+      && !dalo_portal_password_is_acceptable("ab\0"));
+check('NUL password does not authenticate against a versioned hash',
+      dalo_portal_password_verify("a\0b", $hash1)['verified'] === false);
+check('NUL password does not authenticate as a legacy credential',
+      dalo_portal_password_verify("ab\0", "ab\0")['verified'] === false);
 check('empty values cannot authenticate',
       dalo_portal_password_verify('', '')['verified'] === false);
 check('empty passwords are not hashed', dalo_portal_password_hash('') === false);
+
+check('portal access without a credential is rejected',
+      dalo_portal_access_is_valid(array('enableUserPortalLogin' => '1')) === false);
+check('an existing credential allows portal access to be retained',
+      dalo_portal_access_is_valid(array('changeUserInfo' => '1'), true) === true);
+check('password zero satisfies portal access validation',
+      dalo_portal_access_is_valid(array(
+          'enableUserPortalLogin' => '1',
+          'portalLoginPassword' => '0',
+      )) === true);
+check('a NUL password fails before portal writes',
+      dalo_portal_access_is_valid(array(
+          'enableUserPortalLogin' => '1',
+          'portalLoginPassword' => "a\0b",
+      )) === false);
+check('edge NUL passwords fail before portal writes',
+      dalo_portal_access_is_valid(array(
+          'enableUserPortalLogin' => '1',
+          'portalLoginPassword' => "\0ab",
+      )) === false
+      && dalo_portal_access_is_valid(array(
+          'enableUserPortalLogin' => '1',
+          'portalLoginPassword' => "ab\0",
+      )) === false);
+
+if (!defined('PEAR_ERROR_RETURN')) {
+    define('PEAR_ERROR_RETURN', 1);
+}
+if (!defined('PEAR_ERROR_CALLBACK')) {
+    define('PEAR_ERROR_CALLBACK', 16);
+}
+
+class PortalPasswordFakeDb {
+    public $mode = PEAR_ERROR_CALLBACK;
+    public $option = null;
+
+    public function setErrorHandling($mode, $option = null) {
+        $this->mode = $mode;
+        $this->option = $option;
+    }
+
+    public function failWithDebugInfo($secret) {
+        if ($this->mode === PEAR_ERROR_CALLBACK) {
+            print "debug SQL contains $secret";
+        }
+        return false;
+    }
+}
+
+$fake_db = new PortalPasswordFakeDb();
+$restored_handler = function() {};
+$secret = 'portal-db-error-secret';
+ob_start();
+$result = dalo_portal_db_sensitive_call(
+    $fake_db,
+    function() use ($fake_db, $secret) {
+        return $fake_db->failWithDebugInfo($secret);
+    },
+    $restored_handler
+);
+$output = ob_get_clean();
+check('sensitive DB errors cannot emit interpolated credentials',
+      $result === false && strpos($output, $secret) === false);
+check('sensitive DB calls restore the application error callback',
+      $fake_db->mode === PEAR_ERROR_CALLBACK && $fake_db->option === $restored_handler);
 
 printf("\n%s\n", $failures === 0 ? 'ALL PASSED' : sprintf('%d FAILURE(S)', $failures));
 exit($failures === 0 ? 0 : 1);

--- a/tests/portal-password.test.php
+++ b/tests/portal-password.test.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ * Standalone tests for user portal password helpers.
+ *
+ * Run with: php tests/portal-password.test.php
+ */
+
+$root = dirname(__DIR__);
+$_SERVER['PHP_SELF'] = '/cli/tests';
+require $root . '/app/common/includes/portal_password.php';
+
+$failures = 0;
+function check($label, $condition) {
+    global $failures;
+    if ($condition) {
+        printf("ok   - %s\n", $label);
+    } else {
+        printf("FAIL - %s\n", $label);
+        $failures++;
+    }
+}
+
+$password = 'portal-secret-753';
+$hash1 = dalo_portal_password_hash($password);
+$hash2 = dalo_portal_password_hash($password);
+
+check('hash returns a string', is_string($hash1) && $hash1 !== '');
+check('random salts produce different hashes', is_string($hash2) && $hash1 !== $hash2);
+check('hash is recognized', dalo_portal_password_is_hash($hash1));
+check('plaintext is not recognized as a hash', !dalo_portal_password_is_hash($password));
+
+$verified = dalo_portal_password_verify($password, $hash1);
+check('hashed password verifies', $verified['verified'] === true);
+check('hashed password is not legacy', $verified['legacy'] === false);
+check('current hash does not need rehashing', $verified['needs_rehash'] === false);
+check('wrong hashed password is rejected',
+      dalo_portal_password_verify('wrong', $hash1)['verified'] === false);
+
+$old_parameters_hash = password_hash($password, PASSWORD_BCRYPT, array('cost' => 4));
+check('old hash parameters are detected',
+      dalo_portal_password_verify($password, $old_parameters_hash)['needs_rehash'] === true);
+
+$legacy = dalo_portal_password_verify($password, $password);
+check('legacy plaintext verifies exactly', $legacy['verified'] === true);
+check('legacy plaintext is marked for migration',
+      $legacy['legacy'] === true && $legacy['needs_rehash'] === true);
+check('wrong legacy plaintext is rejected',
+      dalo_portal_password_verify('wrong', $password)['verified'] === false);
+check('empty values cannot authenticate',
+      dalo_portal_password_verify('', '')['verified'] === false);
+check('empty passwords are not hashed', dalo_portal_password_hash('') === false);
+
+printf("\n%s\n", $failures === 0 ? 'ALL PASSED' : sprintf('%d FAILURE(S)', $failures));
+exit($failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

This PR replaces plaintext storage of user portal passwords in `userinfo.portalloginpassword` with versioned hashes generated by PHP's `password_hash()`.

User portal credentials remain independent from the RADIUS password attributes stored in `radcheck`.

Stored credentials now use the following application-level format:

```text
$dalo$portal$v1$<PHP password hash>
```

The application marker distinguishes hashes generated by daloRADIUS from legacy plaintext values that may happen to resemble a PHP password hash.

## Changes

- Hash new and replaced user portal passwords with `PASSWORD_DEFAULT`.
- Verify stored hashes with `password_verify()`.
- Preserve compatibility with existing plaintext portal passwords.
- Opportunistically migrate a legacy plaintext password after successful authentication.
- Rehash successfully verified credentials when `password_needs_rehash()` requires it.
- Use a conditional update during lazy migration to avoid overwriting concurrent password changes.
- Never pre-fill or display an existing portal password or hash.
- Treat an empty password field during operator edits as “keep the existing credential.”
- Accept `"0"` as a valid password.
- Reject passwords containing NUL bytes without triggering a PHP exception.
- Abort operator mutations when portal access is requested without a valid existing or replacement credential.
- Prevent PEAR DB error callbacks from exposing interpolated plaintext passwords or hashes.
- Increase `userinfo.portalloginpassword` from `VARCHAR(128)` to `VARCHAR(255)`.
- Add an idempotent SQL migration for existing installations.
- Add a bounded and idempotent CLI migration command with dry-run support.
- Clarify that the “Allow cleartext password attributes in db” setting only applies to RADIUS attributes in `radcheck`.

## Backward compatibility

Unmarked stored values are treated as legacy plaintext credentials.

After a successful login, the credential is replaced with a versioned hash. This allows existing users to continue authenticating without requiring an immediate password reset.

Legacy plaintext values that resemble bcrypt or another PHP password-hash format are still handled as plaintext because only values carrying the daloRADIUS marker are interpreted as hashes.

The `$dalo$portal$v1$` namespace is reserved for daloRADIUS-generated credentials. The upgrade documentation describes the corresponding check for existing databases.

## Upgrade instructions

Apply the schema migration before deploying the updated application:

```sh
mariadb -u root -p radius \
  < contrib/db/migrations/2026-09-user-portal-password-hashing.sql
```

Existing credentials may then be inspected without exposing their values:

```sh
php contrib/scripts/maintenance/hash-user-portal-passwords.php --dry-run
```

Convert the remaining legacy credentials with:

```sh
php contrib/scripts/maintenance/hash-user-portal-passwords.php
```

Legacy credentials are also migrated opportunistically after successful portal authentication.

## Testing

The following checks were completed successfully:

- PHP syntax checks for all modified PHP files
- all standalone repository tests
- portal-password helper regression tests
- operator storage-path regression checks
- Docker image build
- fresh MariaDB schema initialization
- repeatable schema migration to `VARCHAR(255)`
- CLI dry-run, migration, batching, and idempotence
- HTTP authentication with a legacy plaintext credential
- opportunistic migration to the versioned format
- authentication with a legacy plaintext value resembling a bcrypt hash
- authentication and migration of password `"0"`
- rejection of incorrect passwords
- rejection of disabled and duplicate portal accounts
- NUL-byte rejection, including leading and trailing NUL bytes
- forced SQL failure during lazy migration
- verification that forced SQL errors expose neither plaintext nor hash input
- verification that a failed lazy migration preserves the existing credential
- verification that the isolated web logs contain no PHP warning or fatal error
- `git diff --check`

## Security considerations

- Passwords and hashes are not written to application logs.
- Sensitive PEAR DB operations use `PEAR_ERROR_RETURN` rather than the verbose callback, which can include interpolated query parameters.
- Lazy migration only occurs after successful authentication.
- The migration update compares the previously read value to avoid overwriting a concurrent password change.
- The textual value of an unmarked hash is never accepted as a fallback for a marked credential, avoiding pass-the-hash behavior.

## Related issues

Fixes: #753

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes user portal credentials from plaintext in `userinfo.portalloginpassword` to versioned `password_hash()` digests. Existing plaintext credentials remain usable and migrate after successful login, while RADIUS password attributes remain unchanged. Fixes #753.

**Migration**

- Apply `contrib/db/migrations/2026-09-user-portal-password-hashing.sql` before deploying; it widens the column to `VARCHAR(255)` and is idempotent.
- Run `contrib/scripts/maintenance/hash-user-portal-passwords.php --dry-run`, then without `--dry-run`, to migrate remaining credentials in bounded batches; connection failures exit the script and startup session errors are silenced.
- Older daloRADIUS versions cannot authenticate hashed credentials, so rollback after migration requires restoring a pre-upgrade database backup.

**Behavior changes**

- Only `$dalo$portal$v1$`-marked values are treated as hashes; unmarked values, including hash-looking strings, remain legacy plaintext.
- Operator forms never display or pre-fill credentials; an empty password preserves the existing one, and portal access cannot be enabled without a valid credential.
- Password `0` is valid, NUL-containing passwords are rejected, and sensitive database errors and SQL logs redact credentials.

<sup>Written for commit 0f9fb08e0b3560cead98ddf9a02932d14ac044d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/daloradius/pull/775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

